### PR TITLE
ci: add build/push images workflow

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,24 @@
+name: Build and Push Images
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker-hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: dropletbot
+          password: ${{ secrets.botDockerHubPassword }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: instill/model-backend:latest,instill/model-backend:${{ github.ref_name }}
+          cache-from: type=registry,ref=instill/model-backend:buildcache
+          cache-to: type=registry,ref=instill/model-backend:buildcache,mode=max


### PR DESCRIPTION
Because

- we need to build and push images to the Docker Hub at the release

This commit

- set up the GitHub Action workflow accordingly.
