### PR TITLE
refactor: move cvtask from PredictModel method to CreateModel method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ $ ./examples-go/quick-download.sh
 
 ```bash
 $ docker-compose up -d
-$ go run ./examples-go/grpc_client.go upload -f sample-models/yolov4-onnx-cpu.zip  # upload a YOLOv4 model for object detection
+$ go run ./examples-go/grpc_client.go upload --file sample-models/yolov4-onnx-cpu.zip --cvtask 2  # upload a YOLOv4 model for object detection; note --cvtask 0: undefined 1: image classification task and 2: object detection task 
 $ go run ./examples-go/grpc_client.go load -n yolov4  # deploy the ensemble model
-$ go run ./examples-go/grpc_client.go predict -n yolov4 -t 1 -f sample-models/dog.jpg # -t 0: image classification task and 1: object detection task
+$ go run ./examples-go/grpc_client.go predict -n yolov4 -f sample-models/dog.jpg # make inference
 ```
 
 ### Create a your own model to run in Triton server

--- a/examples-go/grpc_client.go
+++ b/examples-go/grpc_client.go
@@ -17,6 +17,7 @@ import (
 
 func upload(c *cli.Context) error {
 	filePath := c.String("file")
+	cvtask := c.Int("cvtask")
 	if _, err := os.Stat(filePath); err != nil {
 		log.Fatalf("File model do not exist, you could download sample-models by examples-go/quick-download.sh")
 	}
@@ -65,6 +66,7 @@ func upload(c *cli.Context) error {
 				Framework:   "pytorch",
 				Optimized:   false,
 				Visibility:  "public",
+				CvTask:      model.CVTask(cvtask),
 				Content:     buf[:n],
 			})
 			firstChunk = false
@@ -163,7 +165,6 @@ func predict(c *cli.Context) error {
 			err = streamUploader.Send(&model.PredictModelRequest{
 				Name:    "yolov4",
 				Version: 1,
-				Type:    model.PredictModelRequest_CVTask(c.Int("type")),
 				Content: buf[:n],
 			})
 			if err != nil {
@@ -203,6 +204,19 @@ func main() {
 						FilePath: "./sample-models/yolov4-onnx-cpu.zip",
 						Required: true,
 					},
+					&cli.StringFlag{
+						Name:     "name",
+						Aliases:  []string{"n"},
+						Usage:    "model `NAME`",
+						Required: false,
+					},
+					&cli.IntFlag{
+						Name:        "cvtask",
+						Aliases:     []string{"cv"},
+						Usage:       "model `TASK`",
+						DefaultText: "0",
+						Required:    false,
+					},
 				},
 				Action: func(c *cli.Context) error {
 					return upload(c)
@@ -233,12 +247,6 @@ func main() {
 						Name:     "name",
 						Aliases:  []string{"n"},
 						Usage:    "Model `NAME`",
-						Required: true,
-					},
-					&cli.IntFlag{
-						Name:     "type",
-						Aliases:  []string{"t"},
-						Usage:    "Model `TYPE`",
 						Required: true,
 					},
 					&cli.StringFlag{

--- a/examples-go/grpc_client.go
+++ b/examples-go/grpc_client.go
@@ -122,6 +122,7 @@ func load(c *cli.Context) error {
 
 func predict(c *cli.Context) error {
 	filePath := c.String("file")
+	modelName := c.String("name")
 	if _, err := os.Stat(filePath); err != nil {
 		log.Fatalf("File image do not exist")
 	}
@@ -163,7 +164,7 @@ func predict(c *cli.Context) error {
 		}
 		if firstChunk {
 			err = streamUploader.Send(&model.PredictModelRequest{
-				Name:    "yolov4",
+				Name:    modelName,
 				Version: 1,
 				Content: buf[:n],
 			})

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	gorm.io/gorm v1.22.5
 )
 
+require github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b
+
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
@@ -36,7 +38,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b // indirect
+	github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,6 @@ require (
 	gorm.io/gorm v1.22.5
 )
 
-require github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b
-
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
@@ -38,6 +36,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,14 +20,12 @@ require (
 	go.uber.org/zap v1.20.0
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
-	google.golang.org/genproto v0.0.0-20220211171837-173942840c17 // indirect
+	google.golang.org/genproto v0.0.0-20220215190005-e57b466719ef // indirect
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/gorm v1.22.5
 )
-
-require github.com/instill-ai/protogen-go v0.0.0-20220214084110-9a2713d704b2
 
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
@@ -38,6 +36,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,6 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.0.0-20220216034626-ca8bdc92ddca h1:+oa4c6C/fMnMqjwjlYfk0WlHBYo2TVBUd7I9IZ+Zn30=
-github.com/instill-ai/protogen-go v0.0.0-20220216034626-ca8bdc92ddca/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b h1:47xsn68li0+CuT38qQR/f2hEeLxxoipkDCnAtJKXLUc=
 github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=

--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,10 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.0.0-20220214084110-9a2713d704b2 h1:IIkKYAdgeQrj6Gm6zHCMJMOsfzpLqYQPfNokrUzuEZs=
-github.com/instill-ai/protogen-go v0.0.0-20220214084110-9a2713d704b2/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.0.0-20220216034626-ca8bdc92ddca h1:+oa4c6C/fMnMqjwjlYfk0WlHBYo2TVBUd7I9IZ+Zn30=
+github.com/instill-ai/protogen-go v0.0.0-20220216034626-ca8bdc92ddca/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b h1:47xsn68li0+CuT38qQR/f2hEeLxxoipkDCnAtJKXLUc=
+github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -1455,8 +1457,8 @@ google.golang.org/genproto v0.0.0-20211013025323-ce878158c4d4/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220211171837-173942840c17 h1:2X+CNIheCutWRyKRte8szGxrE5ggtV4U+NKAbh/oLhg=
-google.golang.org/genproto v0.0.0-20220211171837-173942840c17/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
+google.golang.org/genproto v0.0.0-20220215190005-e57b466719ef h1:LgGaJzny+/at3jTXZUNh/l8VBWyAiskCHrwq6iEYE7I=
+google.golang.org/genproto v0.0.0-20220215190005-e57b466719ef/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/internal/db/migrations/000001_init.down.sql
+++ b/internal/db/migrations/000001_init.down.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-DROP TABLE IF EXISTS `model_versions`;
+DROP TABLE IF EXISTS `versions`;
 DROP TABLE IF EXISTS `models`;
 
 COMMIT;

--- a/internal/triton/consts.go
+++ b/internal/triton/consts.go
@@ -14,13 +14,6 @@ const maxImageSizeBytes int = 4 * MB
 
 const classificationTopK int64 = 5
 
-type CVTask int
-
-const (
-	Classification CVTask = iota
-	Detection
-)
-
 type DetectionOutput struct {
 	Boxes  [][][]float32
 	Labels [][]string

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -55,9 +55,17 @@ type Model struct {
 	Author string `json:"author,omitempty"`
 
 	// workspace name where model belong to
-	Namespace string
+	Namespace string `json:"namespace,omitempty"`
+
+	CVTask int `json:"cv_task,omitempty"`
+
+	// Model task version
+	CVVersion int `json:"cv_version,omitempty"`
 
 	FullName string
+
+	// // List of versions used when processing data not store in DB
+	Versions []VersionResponse
 }
 
 type Version struct {
@@ -81,9 +89,6 @@ type Version struct {
 
 	// Model version metadata
 	Metadata JSONB `gorm:"type:jsonb"`
-
-	// Model name not store in DB, only to check when upload model without known about model ID
-	ModelName string
 }
 
 type JSONB map[string]interface{}

--- a/rpc/model.go
+++ b/rpc/model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/instill-ai/model-backend/configs"
 	database "github.com/instill-ai/model-backend/internal/db"
 	metadataUtil "github.com/instill-ai/model-backend/internal/grpc/metadata"
+	"github.com/instill-ai/model-backend/internal/inferenceserver"
 	"github.com/instill-ai/model-backend/internal/triton"
 	"github.com/instill-ai/model-backend/pkg/models"
 	"github.com/instill-ai/model-backend/pkg/repository"
@@ -62,17 +63,17 @@ func writeToFp(fp *os.File, data []byte) error {
 	}
 }
 
-func unzip(filePath string, dstDir string) ([]*models.Model, []*models.Version, bool) {
+func unzip(filePath string, dstDir string, uploadedModelInfo *models.Model) ([]*models.Model, bool) {
 	archive, err := zip.OpenReader(filePath)
 	if err != nil {
 		fmt.Println("Error when open zip file ", err)
-		return []*models.Model{}, []*models.Version{}, false
+		return []*models.Model{}, false
 	}
 	defer archive.Close()
 
 	var createdModels []*models.Model
-	var createdVersions []*models.Version
 	var currentModelName string
+	var currentModel *models.Model
 	for _, f := range archive.File {
 		if strings.Contains(f.Name, "__MACOSX") { // ignore temp directory in macos
 			continue
@@ -82,7 +83,7 @@ func unzip(filePath string, dstDir string) ([]*models.Model, []*models.Version, 
 
 		if !strings.HasPrefix(filePath, filepath.Clean(dstDir)+string(os.PathSeparator)) {
 			fmt.Println("invalid file path")
-			return []*models.Model{}, []*models.Version{}, false
+			return []*models.Model{}, false
 		}
 		if f.FileInfo().IsDir() {
 			dirName := f.Name
@@ -91,17 +92,20 @@ func unzip(filePath string, dstDir string) ([]*models.Model, []*models.Version, 
 			}
 			if !strings.Contains(dirName, "/") { // top directory model
 				currentModelName = dirName
-				newModel := &models.Model{
-					Name:       dirName,
-					CreatedAt:  time.Now(),
-					UpdatedAt:  time.Now(),
-					Type:       "tensorrt",
-					Framework:  "pytorch",
-					Optimized:  false,
-					Icon:       "",
-					Visibility: "public",
+				currentModel = &models.Model{
+					Name:        dirName,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+					Type:        uploadedModelInfo.Type,
+					Framework:   uploadedModelInfo.Framework,
+					Optimized:   false,
+					Icon:        "",
+					Visibility:  "public",
+					Description: uploadedModelInfo.Description,
+					Versions:    []models.VersionResponse{},
+					CVTask:      uploadedModelInfo.CVTask,
 				}
-				createdModels = append(createdModels, newModel)
+				createdModels = append(createdModels, currentModel)
 			} else { // version folder
 				patternVersionFolder := fmt.Sprintf("^%v/[0-9]+$", currentModelName)
 				match, _ := regexp.MatchString(patternVersionFolder, dirName)
@@ -110,17 +114,13 @@ func unzip(filePath string, dstDir string) ([]*models.Model, []*models.Version, 
 					sVersion := elems[len(elems)-1]
 					iVersion, err := strconv.Atoi(sVersion)
 					if err == nil {
-						newVersion := &models.Version{
+						currentModel.Versions = append(currentModel.Versions, models.VersionResponse{
 							Version:   int32(iVersion),
 							CreatedAt: time.Now(),
-							ModelName: currentModelName,
 							UpdatedAt: time.Now(),
-							Status:    "offline",
-							Metadata:  models.JSONB{},
-						}
-						createdVersions = append(createdVersions, newVersion)
+							Status:    model.ModelStatus_OFFLINE.String(),
+						})
 					}
-
 				}
 			}
 
@@ -128,32 +128,29 @@ func unzip(filePath string, dstDir string) ([]*models.Model, []*models.Version, 
 			_ = os.MkdirAll(filePath, os.ModePerm)
 			continue
 		}
-
 		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
-			return []*models.Model{}, []*models.Version{}, false
+			return []*models.Model{}, false
 		}
 
 		dstFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 		if err != nil {
-			return []*models.Model{}, []*models.Version{}, false
+			return []*models.Model{}, false
 		}
-
 		fileInArchive, err := f.Open()
 		if err != nil {
-			return []*models.Model{}, []*models.Version{}, false
+			return []*models.Model{}, false
 		}
 
 		if _, err := io.Copy(dstFile, fileInArchive); err != nil {
-			return []*models.Model{}, []*models.Version{}, false
+			return []*models.Model{}, false
 		}
-
 		dstFile.Close()
 		fileInArchive.Close()
 	}
-	return createdModels, createdVersions, true
+	return createdModels, true
 }
 
-func saveFile(stream model.Model_CreateModelByUploadServer) (outFile string, err error) {
+func saveFile(stream model.Model_CreateModelByUploadServer) (outFile string, modelInfo *models.Model, err error) {
 	firstChunk := true
 	var fp *os.File
 
@@ -161,6 +158,7 @@ func saveFile(stream model.Model_CreateModelByUploadServer) (outFile string, err
 
 	var tmpFile string
 
+	var uploadedModeInfo models.Model
 	for {
 		fileData, err = stream.Recv() //ignoring the data  TO-Do save files received
 		if err != nil {
@@ -170,14 +168,23 @@ func saveFile(stream model.Model_CreateModelByUploadServer) (outFile string, err
 
 			err = errors.Wrapf(err,
 				"failed unexpectadely while reading chunks from stream")
-			return "", err
+			return "", &models.Model{}, err
 		}
 
 		if firstChunk { //first chunk contains file name
 			tmpFile = path.Join("/tmp", uuid.New().String()+".zip")
 			fp, err = os.Create(tmpFile)
+			uploadedModeInfo = models.Model{
+				Type:        fileData.Type,
+				Framework:   fileData.Framework,
+				Description: fileData.Description,
+				Optimized:   fileData.Optimized,
+				Visibility:  fileData.Visibility,
+				CVTask:      int(fileData.CvTask),
+				CVVersion:   int(fileData.Version),
+			}
 			if err != nil {
-				return "", err
+				return "", &models.Model{}, err
 			}
 			defer fp.Close()
 
@@ -185,13 +192,13 @@ func saveFile(stream model.Model_CreateModelByUploadServer) (outFile string, err
 		}
 		err = writeToFp(fp, fileData.Content)
 		if err != nil {
-			return "", err
+			return "", &models.Model{}, err
 		}
 	}
-	return tmpFile, nil
+	return tmpFile, &uploadedModeInfo, nil
 }
 
-func savePredictInput(stream model.Model_PredictModelByUploadServer) (imageFile string, modelId string, version int32, modelType triton.CVTask, err error) {
+func savePredictInput(stream model.Model_PredictModelByUploadServer) (imageFile string, modelId string, version int32, err error) {
 	firstChunk := true
 	var fp *os.File
 
@@ -208,18 +215,17 @@ func savePredictInput(stream model.Model_PredictModelByUploadServer) (imageFile 
 
 			err = errors.Wrapf(err,
 				"failed unexpectadely while reading chunks from stream")
-			return "", "", -1, 0, err
+			return "", "", -1, err
 		}
 
 		if firstChunk { //first chunk contains file name
 			modelId = fileData.Name
 			version = fileData.Version
-			modelType = triton.CVTask(fileData.Type)
 
 			tmpFile = path.Join("/tmp/", uuid.New().String())
 			fp, err = os.Create(tmpFile)
 			if err != nil {
-				return "", "", -1, 0, err
+				return "", "", -1, err
 			}
 			defer fp.Close()
 
@@ -227,10 +233,10 @@ func savePredictInput(stream model.Model_PredictModelByUploadServer) (imageFile 
 		}
 		err = writeToFp(fp, fileData.Content)
 		if err != nil {
-			return "", "", -1, 0, err
+			return "", "", -1, err
 		}
 	}
-	return tmpFile, modelId, version, modelType, nil
+	return tmpFile, modelId, version, nil
 }
 
 func makeError(statusCode codes.Code, title string, detail string) error {
@@ -328,12 +334,16 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 			makeResponse(w, 400, "Internal Error", "Error reading input file")
 		}
 
-		createdModels, createdVersions, isOk := unzip(tmpFile, configs.Config.TritonServer.ModelStore)
+		var uploadedModelInfo = models.Model{
+			Description: r.FormValue("description"),
+		}
+
+		createdModels, isOk := unzip(tmpFile, configs.Config.TritonServer.ModelStore, &uploadedModelInfo)
 		if !isOk || len(createdModels) == 0 {
 			makeResponse(w, 400, "Add Model Error", "Could not extract zip file")
 		}
 
-		respModels, err := modelService.HandleCreateModelByUpload(username, createdModels, createdVersions)
+		respModels, err := modelService.HandleCreateModelByUpload(username, createdModels)
 		if err != nil {
 			makeResponse(w, 500, "Add Model Error", err.Error())
 		}
@@ -359,23 +369,19 @@ func (s *serviceHandlers) CreateModelByUpload(stream model.Model_CreateModelByUp
 	if err != nil {
 		return err
 	}
-
-	tmpFile, err := saveFile(stream)
+	tmpFile, uploadedModelInfo, err := saveFile(stream)
 	if err != nil {
 		return makeError(400, "Save File Error", err.Error())
 	}
-
 	// extract zip file from tmp to models directory
-	createdModels, createdVersions, isOk := unzip(tmpFile, configs.Config.TritonServer.ModelStore)
+	createdModels, isOk := unzip(tmpFile, configs.Config.TritonServer.ModelStore, uploadedModelInfo)
 	if !isOk || len(createdModels) == 0 {
 		return makeError(400, "Save File Error", "Could not extract zip file")
 	}
-
-	respModels, err := s.modelService.CreateModelByUpload(username, createdModels, createdVersions)
+	respModels, err := s.modelService.CreateModelByUpload(username, createdModels)
 	if err != nil {
 		return makeError(500, "Add Model Error", err.Error())
 	}
-
 	var res model.CreateModelsResponse
 	res.Models = respModels
 	err = stream.SendAndClose(&res)
@@ -424,11 +430,16 @@ func (s *serviceHandlers) PredictModelByUpload(stream model.Model_PredictModelBy
 		return err
 	}
 
-	imageFile, modelName, version, cvTask, err := savePredictInput(stream)
-
+	imageFile, modelName, version, err := savePredictInput(stream)
 	if err != nil {
 		return makeError(500, "PredictModel", "Could not save the file")
 	}
+
+	modelInDB, err := s.modelService.GetModelByName(username, modelName)
+	if err != nil {
+		return makeError(404, "PredictModel", fmt.Sprintf("The model %v do not exist", modelName))
+	}
+	cvTask := model.CVTask(modelInDB.CVTask)
 
 	response, err := s.modelService.PredictModelByUpload(username, modelName, version, imageFile, cvTask)
 
@@ -439,14 +450,18 @@ func (s *serviceHandlers) PredictModelByUpload(stream model.Model_PredictModelBy
 	var data = &structpb.Struct{}
 	var b []byte
 	switch cvTask {
-	case triton.Classification:
+	case model.CVTask_CLASSIFICATION:
 		b, err = json.Marshal(response.(*model.ClassificationOutputs))
 		if err != nil {
 			return makeError(500, "PredictModel", err.Error())
 		}
-
-	case triton.Detection:
+	case model.CVTask_DETECTION:
 		b, err = json.Marshal(response.(*model.DetectionOutputs))
+		if err != nil {
+			return makeError(500, "PredictModel", err.Error())
+		}
+	default:
+		b, err = json.Marshal(response.(*inferenceserver.ModelInferResponse))
 		if err != nil {
 			return makeError(500, "PredictModel", err.Error())
 		}
@@ -476,17 +491,12 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 		if err != nil {
 			makeResponse(w, 400, "Wrong parameter type", "Version should be a number greater than 0")
 		}
-		modelType, err := strconv.Atoi(r.FormValue("type"))
-		if err != nil {
-			makeResponse(w, 400, "Wrong parameter type", "Type should be a number greater than or equal 0")
-		}
-		cvTask := triton.CVTask(modelType)
 
 		db := database.GetConnection()
 		modelRepository := repository.NewModelRepository(db)
 		modelService := services.NewModelService(modelRepository)
 
-		_, err = modelService.GetModelByName(username, modelName)
+		modelInDB, err := modelService.GetModelByName(username, modelName)
 		if err != nil {
 			makeResponse(w, 404, "Model not found", "The model not found in server")
 		}
@@ -526,6 +536,7 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 			makeResponse(w, 400, "Internal Error", "Error reading input file")
 		}
 
+		cvTask := model.CVTask(modelInDB.CVTask)
 		response, err := modelService.PredictModelByUpload(username, modelName, int32(modelVersion), tmpFile, cvTask)
 		if err != nil {
 			makeResponse(w, 500, "Error Predict Model", err.Error())

--- a/rpc/model.go
+++ b/rpc/model.go
@@ -112,7 +112,7 @@ func unzip(filePath string, dstDir string, uploadedModelInfo *models.Model) ([]*
 				if match {
 					elems := strings.Split(dirName, "/")
 					sVersion := elems[len(elems)-1]
-					iVersion, err := strconv.Atoi(sVersion)
+					iVersion, err := strconv.ParseInt(sVersion, 10, 32)
 					if err == nil {
 						currentModel.Versions = append(currentModel.Versions, models.VersionResponse{
 							Version:   int32(iVersion),

--- a/scripts/quick-download.sh
+++ b/scripts/quick-download.sh
@@ -3,11 +3,11 @@
 
 echo "Downloading conda-pack"
 mkdir conda-pack > /dev/null 2>&1
-wget https://artifacts.instill.tech/visual-data-preparation/conda-pack/python-3-8.tar.gz -P ./conda-pack/
+wget https://artifacts.instill.tech/vdp/conda-pack/python-3-8.tar.gz -P ./conda-pack/
 
 echo "Downloading sample-models"
 mkdir sample-models > /dev/null 2>&1
-wget https://artifacts.instill.tech/visual-data-preparation/sample-models/yolov4-onnx-cpu.zip -P ./sample-models/
+wget https://artifacts.instill.tech/vdp/sample-models/yolov4-onnx-cpu.zip -P ./sample-models/
 
 echo "Download sample images"
 wget https://artifacts.instill.tech/dog.jpg -P ./sample-models/


### PR DESCRIPTION
Because

- User know CV Task when creating a model, then it is convenient to add CV Task at that point

This commit

- Move CV Task from PredictModel method to CreateModel method
