### PR TITLE
fix: update docker compose file for building dev image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
             timeout: 20s
             retries: 10
     model-backend-migrate:
-        image: instill/model-backend:latest
+        build:
+            context: .
+        image: instill/model-backend:dev 
         container_name: model-backend-migrate
         depends_on:
             database:
@@ -24,7 +26,9 @@ services:
         entrypoint: ./model-backend-migrate
 
     model-backend:
-        image: instill/model-backend:latest
+        build:
+            context: .
+        image: instill/model-backend:dev 
         container_name: model-backend
         depends_on:
             triton-server:


### PR DESCRIPTION
Because

- building docker dev image is an easy way for user who want to run model-backend from source code

This commit

- update docker-compose to build dev docker image
- close #28 