### PR TITLE
feat: support url/base64 content prediction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go build -a -o /model-backen
 RUN --mount=type=cache,target=/root/.cache/go-build go build -a -o /model-backend-migrate ./migrate
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 AS runtime
-# FROM gcr.io/distroless/base AS runtime
+FROM gcr.io/distroless/base AS runtime
 
 ENV GIN_MODE=release
 WORKDIR /model-backend

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Table of Contents:
 - [sample models](https://artifacts.instill.tech/visual-data-preparation/sample-models/yolov4-onnx-cpu.zip) example CPU models running in Triton server
 To download those dependencies, you could run quick-download.sh
 ```bash
-$ ./examples-go/quick-download.sh
+$ ./scripts/quick-download.sh
 ```
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Table of Contents:
 
 
 ## Prerequisite
-- [conda-pack](https://artifacts.instill.tech/visual-data-preparation/conda-pack) this is a Conda environment for Python Backend running in Triton server 
 - [sample models](https://artifacts.instill.tech/visual-data-preparation/sample-models/yolov4-onnx-cpu.zip) example CPU models running in Triton server
-To download those dependencies, you could run quick-download.sh
+To download the sample model, you could run quick-download.sh
 ```bash
 $ ./scripts/quick-download.sh
 ```
@@ -24,7 +23,7 @@ $ ./scripts/quick-download.sh
 
 ```bash
 $ docker-compose up -d
-$ go run ./examples-go/grpc_client.go upload --file sample-models/yolov4-onnx-cpu.zip --name yolov4 --cvtask 2  # upload a YOLOv4 model for object detection; note --cvtask 0: undefined 1: image classification task and 2: object detection task 
+$ go run ./examples-go/grpc_client.go upload --file sample-models/yolov4-onnx-cpu.zip --name yolov4 --cvtask DETECTION  # upload a YOLOv4 model for object detection; note --cvtask is optional and could be specified as DETECTION, CLASSIFICATION, without specifying cvtask will default UNDEFINED
 $ go run ./examples-go/grpc_client.go load -n yolov4 --version 1  # deploy the ensemble model
 $ go run ./examples-go/grpc_client.go predict -n yolov4 --version 1 -f sample-models/dog.jpg # make inference
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -162,7 +162,7 @@ func main() {
 	)
 
 	// Register custom route for  GET /hello/{name}
-	if err := gwS.HandlePath("POST", "/models/{name}/upload/outputs", appendCustomHeaderMiddleware(rpc.HandlePredictModelByUpload)); err != nil {
+	if err := gwS.HandlePath("POST", "/models/{name}/versions/{version}/upload/outputs", appendCustomHeaderMiddleware(rpc.HandlePredictModelByUpload)); err != nil {
 		panic(err)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,6 +89,7 @@ func grpcHandlerFunc(grpcServer *grpc.Server, gwHandler http.Handler) http.Handl
 
 func main() {
 	logger, _ := logger.GetZapLogger()
+	grpc_zap.ReplaceGrpcLoggerV2(logger)
 
 	if err := configs.Init(); err != nil {
 		logger.Fatal(err.Error())

--- a/conda-pack/README.md
+++ b/conda-pack/README.md
@@ -1,2 +1,0 @@
-This file python-3-8.tar.gz include numpy and scikit-learn package for Python Backend running on Triton Inference Server.
-In case you need other dependencies such as opencv, etc please create an other Conda environment by refer [here](https://github.com/triton-inference-server/python_backend#2-packaging-the-conda-environment).

--- a/conda-pack/python-3-8.tar.gz
+++ b/conda-pack/python-3-8.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2af3c8396f1d069abfe0e4f0f4a976989792ee18a31fe0241fb4e0e612ab6fdf
-size 504793915

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -22,7 +22,7 @@ database:
   version: 3
   pool:
     idleconnections: 5
-    maxconnections: 10
+    maxconnections: 30
     connlifetime: 30 # In minutes
 tritonserver:
   grpcuri: 0.0.0.0:8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
         container_name: triton-server
         volumes:
             - models:/models
-            - ./conda-pack:/conda-pack
+            - conda_pack:/conda-pack
         ports:
             - 8001:8001
         healthcheck:
@@ -60,7 +60,14 @@ services:
         ulimits:
             memlock: -1
             stack: 67108864
+
+    triton_conda_env:
+        container_name: triton-conda-env
+        image: instill/triton-conda-env:v0.1.0-alpha-cpu
+        volumes:
+        - conda_pack:/conda-pack            
 volumes:
     dbdata:
     models:
+    conda_pack:
     

--- a/examples-go/grpc_client.go
+++ b/examples-go/grpc_client.go
@@ -23,8 +23,8 @@ func upload(c *cli.Context) error {
 		log.Fatalf("File model do not exist, you could download sample-models by examples-go/quick-download.sh")
 	}
 
-	// Create connection to server with timeout 300 secs to ensure file streamed successfully
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
+	// Create connection to server with timeout 1000 secs to ensure file streamed successfully
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1000)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, "localhost:8080", grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -89,7 +89,7 @@ func upload(c *cli.Context) error {
 }
 
 func load(c *cli.Context) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1000)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, "localhost:8080", grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -126,7 +126,7 @@ func predict(c *cli.Context) error {
 	}
 
 	// Set up a connection to the server.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1000)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, "localhost:8080", grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/examples-go/grpc_client.go
+++ b/examples-go/grpc_client.go
@@ -18,7 +18,7 @@ import (
 func upload(c *cli.Context) error {
 	filePath := c.String("file")
 	modelName := c.String("name")
-	cvtask := c.Int("cvtask")
+	cvtask := c.String("cvtask")
 	if _, err := os.Stat(filePath); err != nil {
 		log.Fatalf("File model do not exist, you could download sample-models by examples-go/quick-download.sh")
 	}
@@ -60,10 +60,16 @@ func upload(c *cli.Context) error {
 			log.Fatalf("Could not read the file %v", filePath)
 		}
 		if firstChunk {
+			cvt := model.CVTask_UNDEFINED
+			if cvtask == model.CVTask_DETECTION.String() {
+				cvt = model.CVTask_DETECTION
+			} else if cvtask == model.CVTask_CLASSIFICATION.String() {
+				cvt = model.CVTask_CLASSIFICATION
+			}
 			err = streamUploader.Send(&model.CreateModelRequest{
 				Name:        modelName,
 				Description: "YoloV4 for object detection",
-				CvTask:      model.CVTask(cvtask),
+				CvTask:      cvt,
 				Content:     buf[:n],
 			})
 			firstChunk = false
@@ -100,10 +106,10 @@ func load(c *cli.Context) error {
 	client := model.NewModelClient(conn)
 
 	res, err := client.UpdateModel(ctx, &model.UpdateModelRequest{
+		Name:    c.String("name"),
+		Version: int32(c.Int("version")),
 		Model: &model.UpdateModelInfo{
-			Name:    c.String("name"),
-			Version: int32(c.Int("version")),
-			Status:  model.ModelStatus_ONLINE,
+			Status: model.ModelStatus_ONLINE,
 		},
 		UpdateMask: &fieldmaskpb.FieldMask{
 			Paths: []string{"name", "status"},
@@ -211,12 +217,11 @@ func main() {
 						Usage:    "model `NAME`",
 						Required: false,
 					},
-					&cli.IntFlag{
-						Name:        "cvtask",
-						Aliases:     []string{"cv"},
-						Usage:       "model `TASK`",
-						DefaultText: "0",
-						Required:    false,
+					&cli.StringFlag{
+						Name:     "cvtask",
+						Aliases:  []string{"cv"},
+						Usage:    "model `TASK`",
+						Required: false,
 					},
 				},
 				Action: func(c *cli.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea // indirect
+	github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220224084556-83b082053f0f // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220224084556-83b082053f0f // indirect
+	github.com/instill-ai/protogen-go v0.1.1-alpha // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/instill-ai/protogen-go v0.0.0-20220219062322-6a4b524722dc // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -573,6 +573,8 @@ github.com/instill-ai/protogen-go v0.0.0-20220219062322-6a4b524722dc h1:FB/LZrD1
 github.com/instill-ai/protogen-go v0.0.0-20220219062322-6a4b524722dc/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea h1:llNYw4hTDc6ihZhlDVsLke1FJ0zJ/S5q3WSYh7uk+A4=
 github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220224084556-83b082053f0f h1:tmYDLfv1pdOY31wNP2DIG9QzDb54oljxfuDSXMd8Vx8=
+github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220224084556-83b082053f0f/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/go.sum
+++ b/go.sum
@@ -571,6 +571,8 @@ github.com/instill-ai/protogen-go v0.0.0-20220218052108-74a473c326b7 h1:G0gFscf9
 github.com/instill-ai/protogen-go v0.0.0-20220218052108-74a473c326b7/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/protogen-go v0.0.0-20220219062322-6a4b524722dc h1:FB/LZrD1T12txnLqmg4Dta2GzC399O27/Nkiyd22nRA=
 github.com/instill-ai/protogen-go v0.0.0-20220219062322-6a4b524722dc/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea h1:llNYw4hTDc6ihZhlDVsLke1FJ0zJ/S5q3WSYh7uk+A4=
+github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/go.sum
+++ b/go.sum
@@ -575,6 +575,8 @@ github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea h1:
 github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220223091118-ed559967d7ea/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220224084556-83b082053f0f h1:tmYDLfv1pdOY31wNP2DIG9QzDb54oljxfuDSXMd8Vx8=
 github.com/instill-ai/protogen-go v0.1.0-alpha.0.20220224084556-83b082053f0f/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.1.1-alpha h1:rZ/mGWOi8sbSfub840WBDB/AmaClgkRjGT/8sDvCveo=
+github.com/instill-ai/protogen-go v0.1.1-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -4,3 +4,15 @@ var CVTasks = map[string]int{
 	"cls": 1,
 	"det": 2,
 }
+
+const MaxBatchSize int = 32
+
+const (
+	_  = iota
+	KB = 1 << (10 * iota)
+	MB
+	GB
+	TB
+)
+
+const MaxImageSizeBytes int = 4 * MB

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,8 +1,8 @@
 package utils
 
 var CVTasks = map[string]int{
-	"cls": 1,
-	"det": 2,
+	"CLASSIFICATION": 1,
+	"DETECTION":      2,
 }
 
 const MaxBatchSize int = 32

--- a/pkg/repository/model.go
+++ b/pkg/repository/model.go
@@ -15,7 +15,7 @@ type ModelRepository interface {
 	GetModelByName(namespace string, modelName string) (models.Model, error)
 	ListModels(query models.ListModelQuery) ([]models.Model, error)
 	CreateVersion(version models.Version) error
-	UpdateModelVersions(modelId int32, version models.Version) error
+	UpdateModelVersion(modelId int32, modelVersion int32, versionInfo models.Version) error
 	GetModelVersion(modelId int32, version int32) (models.Version, error)
 	GetModelVersions(modelId int32) ([]models.Version, error)
 	UpdateModelMetaData(modelId int32, updatedModel models.Model) error
@@ -81,9 +81,9 @@ func (r *modelRepository) CreateVersion(version models.Version) error {
 	return nil
 }
 
-func (r *modelRepository) UpdateModelVersions(modelId int32, version models.Version) error {
+func (r *modelRepository) UpdateModelVersion(modelId int32, modelVersion int32, versionInfo models.Version) error {
 
-	if result := r.DB.Model(&models.Version{}).Omit(`"version"."model_name"`).Where("model_id", modelId).Updates(&version); result.Error != nil {
+	if result := r.DB.Model(&models.Version{}).Omit(`"version"."model_name"`).Where(map[string]interface{}{"model_id": modelId, "version": modelVersion}).Updates(&versionInfo); result.Error != nil {
 		return status.Errorf(codes.Internal, "Error %v", result.Error)
 	}
 

--- a/pkg/services/model.go
+++ b/pkg/services/model.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,16 +18,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-func makeError(statusCode codes.Code, title string, detail string) error {
-	err := &models.Error{
-		Status: int32(statusCode),
-		Title:  title,
-		Detail: detail,
-	}
-	data, _ := json.Marshal(err)
-	return status.Error(statusCode, string(data))
-}
 
 func createModelResponse(modelInDB models.Model, versions []models.Version, tritonModels []models.TModel) *models.ModelResponse {
 	var vers []models.VersionResponse
@@ -89,7 +78,7 @@ type ModelService interface {
 	UpdateModelMetaData(namespace string, updatedModel models.Model) (*model.ModelInfo, error)
 	GetModelVersion(modelId int32, version int32) (models.Version, error)
 	GetModelVersions(modelId int32) ([]models.Version, error)
-	PredictModelByUpload(namespace string, modelName string, version int32, filePath string, cvTask model.CVTask) (interface{}, error)
+	PredictModelByUpload(namespace string, modelName string, version int32, imgsBytes [][]byte, cvTask model.CVTask) (interface{}, error)
 	CreateModelByUpload(namespace string, createdModel *models.Model) (*model.ModelInfo, error)
 	HandleCreateModelByUpload(namespace string, createdModel *models.Model) (*models.ModelResponse, error)
 	ListModels(namespace string) ([]*model.ModelInfo, error)
@@ -166,46 +155,42 @@ func (s *modelService) GetTModels(modelId int32) ([]models.TModel, error) {
 	return s.modelRepository.GetTModels(modelId)
 }
 
-func (s *modelService) PredictModelByUpload(namespace string, modelName string, version int32, filePath string, cvTask model.CVTask) (interface{}, error) {
+func (s *modelService) PredictModelByUpload(namespace string, modelName string, version int32, imgsBytes [][]byte, cvTask model.CVTask) (interface{}, error) {
 	// Triton model name is change into
 	modelInDB, err := s.GetModelByName(namespace, modelName)
 	if err != nil {
-		return nil, makeError(404, "PredictModel", "Model not found")
+		return nil, fmt.Errorf("Model not found")
 	}
 
 	ensembleModel, err := s.modelRepository.GetTEnsembleModel(modelInDB.Id, version)
 	if err != nil {
-		return nil, makeError(404, "PredictModel", "Triton model not found")
+		return nil, fmt.Errorf("Triton model not found")
 	}
 
 	ensembleModelName := ensembleModel.Name
 	ensembleModelVersion := ensembleModel.Version
 	modelMetadataResponse := triton.ModelMetadataRequest(triton.TritonClient, ensembleModelName, fmt.Sprint(ensembleModelVersion))
 	if modelMetadataResponse == nil {
-		return nil, makeError(422, "PredictModel", "Model is offline")
+		return nil, fmt.Errorf("Model is offline")
 	}
 	modelConfigResponse := triton.ModelConfigRequest(triton.TritonClient, ensembleModelName, fmt.Sprint(ensembleModelVersion))
 	if modelMetadataResponse == nil {
-		return nil, makeError(404, "PredictModel", "Model config not found")
-	}
-	input, err := triton.PreProcess(filePath, modelMetadataResponse, modelConfigResponse, cvTask)
-	if err != nil {
-		return nil, makeError(422, "PredictModel", err.Error())
+		return nil, err
 	}
 	// /* We use a simple model that takes 2 input tensors of 16 integers
 	// each and returns 2 output tensors of 16 integers each. One
 	// output tensor is the element-wise sum of the inputs and one
 	// output is the element-wise difference. */
-	inferResponse, err := triton.ModelInferRequest(triton.TritonClient, cvTask, input, ensembleModelName, fmt.Sprint(ensembleModelVersion), modelMetadataResponse, modelConfigResponse)
+	inferResponse, err := triton.ModelInferRequest(triton.TritonClient, cvTask, imgsBytes, ensembleModelName, fmt.Sprint(ensembleModelVersion), modelMetadataResponse, modelConfigResponse)
 	if err != nil {
-		return nil, makeError(422, "PredictModel InferRequest", err.Error())
+		return nil, err
 	}
 	// /* We expect there to be 2 results (each with batch-size 1). Walk
 	// over all 16 result elements and print the sum and difference
 	// calculated by the model. */
 	postprocessResponse, err := triton.PostProcess(inferResponse, modelMetadataResponse, cvTask)
 	if err != nil {
-		return nil, makeError(422, "PredictModel PostProcess", err.Error())
+		return nil, err
 	}
 	switch cvTask {
 	case model.CVTask_CLASSIFICATION:
@@ -214,11 +199,11 @@ func (s *modelService) PredictModelByUpload(namespace string, modelName string, 
 		for _, clsRes := range clsResponses {
 			clsResSplit := strings.Split(clsRes, ":")
 			if len(clsResSplit) != 3 {
-				return nil, makeError(422, "PredictModel", "Unable to decode inference output")
+				return nil, fmt.Errorf("Unable to decode inference output")
 			}
 			score, err := strconv.ParseFloat(clsResSplit[0], 32)
 			if err != nil {
-				return nil, makeError(422, "PredictModel", "Unable to decode inference output")
+				return nil, fmt.Errorf("Unable to decode inference output")
 			}
 			clsOutput := model.ClassificationOutput{
 				Category: clsResSplit[2],
@@ -274,7 +259,7 @@ func createModel(s *modelService, namespace string, uploadedModel *models.Model)
 	if err != nil {
 		createdModel, err := s.CreateModel(uploadedModel)
 		if err != nil {
-			return models.Model{}, []models.Version{}, []models.TModel{}, makeError(500, "CreateModel", "Could not create model in DB")
+			return models.Model{}, []models.Version{}, []models.TModel{}, fmt.Errorf("Could not create model in DB")
 		}
 		modelInDB = *createdModel
 	}
@@ -288,7 +273,7 @@ func createModel(s *modelService, namespace string, uploadedModel *models.Model)
 	uploadedModel.Versions[0].ModelId = modelInDB.Id
 	versionInDB, err := s.CreateVersion(uploadedModel.Versions[0])
 	if err != nil {
-		return models.Model{}, []models.Version{}, []models.TModel{}, makeError(500, "CreateModel", "Could not create model version in DB")
+		return models.Model{}, []models.Version{}, []models.TModel{}, fmt.Errorf("Could not create model version in DB")
 	}
 	for i := 0; i < len(uploadedModel.TritonModels); i++ {
 		tmodel := uploadedModel.TritonModels[i]
@@ -296,12 +281,12 @@ func createModel(s *modelService, namespace string, uploadedModel *models.Model)
 		tmodel.ModelVersion = versionInDB.Version
 		err = s.modelRepository.CreateTModel(tmodel)
 		if err != nil {
-			return models.Model{}, []models.Version{}, []models.TModel{}, makeError(500, "CreateModel", "Could not create triton model in DB")
+			return models.Model{}, []models.Version{}, []models.TModel{}, fmt.Errorf("Could not create triton model in DB")
 		}
 	}
 	versions, err := s.GetModelVersions(modelInDB.Id)
 	if err != nil {
-		return models.Model{}, []models.Version{}, []models.TModel{}, makeError(500, "CreateModel", "Could not get model versions in DB")
+		return models.Model{}, []models.Version{}, []models.TModel{}, fmt.Errorf("Could not get model versions in DB")
 	}
 
 	return modelInDB, versions, uploadedModel.TritonModels, nil
@@ -319,12 +304,12 @@ func (s *modelService) HandleCreateModelByUpload(namespace string, uploadedModel
 
 func (s *modelService) ListModels(namespace string) ([]*model.ModelInfo, error) {
 	if !triton.IsTritonServerReady() {
-		return []*model.ModelInfo{}, makeError(503, "ListModels", "Triton Server not ready yet")
+		return []*model.ModelInfo{}, fmt.Errorf("Triton Server not ready yet")
 	}
 
 	models, err := s.modelRepository.ListModels(models.ListModelQuery{Namespace: namespace})
 	if err != nil {
-		return []*model.ModelInfo{}, makeError(500, "ListModels", err.Error())
+		return []*model.ModelInfo{}, err
 	}
 
 	var resModels []*model.ModelInfo
@@ -332,11 +317,11 @@ func (s *modelService) ListModels(namespace string) ([]*model.ModelInfo, error) 
 		md := models[i]
 		versions, err := s.GetModelVersions(md.Id)
 		if err != nil {
-			return []*model.ModelInfo{}, makeError(500, "ListModels", "Could not get model versions in DB")
+			return []*model.ModelInfo{}, err
 		}
 		tritonModels, err := s.GetTModels(md.Id)
 		if err != nil {
-			return []*model.ModelInfo{}, makeError(500, "ListModels", "Could not get triton model in DB")
+			return []*model.ModelInfo{}, err
 
 		}
 		resModels = append(resModels, createModelInfo(md, versions, tritonModels))
@@ -348,17 +333,17 @@ func (s *modelService) ListModels(namespace string) ([]*model.ModelInfo, error) 
 func (s *modelService) UpdateModelMetaData(namespace string, updatedModel models.Model) (*model.ModelInfo, error) {
 	md, err := s.GetModelByName(namespace, updatedModel.Name)
 	if err != nil {
-		return &model.ModelInfo{}, makeError(404, "UpdateModelMetaData Error", "The model not found in server")
+		return &model.ModelInfo{}, err
 	}
 
 	err = s.modelRepository.UpdateModelMetaData(md.Id, updatedModel)
 	if err != nil {
-		return &model.ModelInfo{}, makeError(500, "UpdateModelMetaData Error", err.Error())
+		return &model.ModelInfo{}, err
 	}
 
 	modelInfo, err := s.GetModelMetaData(namespace, md.Name)
 	if err != nil {
-		return &model.ModelInfo{}, makeError(500, "UpdateModelMetaData Error", err.Error())
+		return &model.ModelInfo{}, err
 	}
 
 	return modelInfo, nil
@@ -367,7 +352,7 @@ func (s *modelService) UpdateModelMetaData(namespace string, updatedModel models
 func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelRequest) (*model.ModelInfo, error) {
 	modelInDB, err := s.GetModelByName(namespace, in.Model.Name)
 	if err != nil {
-		return &model.ModelInfo{}, makeError(404, "UpdateModel Error", "The model not found in server")
+		return &model.ModelInfo{}, err
 	}
 
 	if in.UpdateMask != nil && len(in.UpdateMask.Paths) > 0 {
@@ -376,7 +361,7 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 			case "status":
 				ensembleModel, err := s.modelRepository.GetTEnsembleModel(modelInDB.Id, in.Model.Version)
 				if err != nil {
-					return &model.ModelInfo{}, makeError(404, "UpdateModel Error", "The model not found in server")
+					return &model.ModelInfo{}, err
 				}
 				switch in.Model.Status {
 				case model.ModelStatus_ONLINE:
@@ -387,16 +372,16 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 							Status:    model.ModelStatus_ERROR.String(),
 						})
 						if err != nil {
-							return &model.ModelInfo{}, makeError(500, "UpdateModel Error", "Could not update model status")
+							return &model.ModelInfo{}, err
 						}
-						return &model.ModelInfo{}, makeError(500, "Load Model Error", err.Error())
+						return &model.ModelInfo{}, err
 					} else {
 						err := s.UpdateModelVersions(modelInDB.Id, models.Version{
 							UpdatedAt: time.Now(),
 							Status:    model.ModelStatus_ONLINE.String(),
 						})
 						if err != nil {
-							return &model.ModelInfo{}, makeError(500, "UpdateModel Error", "Could not update model version status")
+							return &model.ModelInfo{}, err
 						}
 					}
 				case model.ModelStatus_OFFLINE:
@@ -407,20 +392,20 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 							Status:    model.ModelStatus_ERROR.String(),
 						})
 						if err != nil {
-							return &model.ModelInfo{}, makeError(500, "UpdateModel Error", "Could not update model status")
+							return &model.ModelInfo{}, err
 						}
-						return &model.ModelInfo{}, makeError(500, "Unload Model Error", err.Error())
+						return &model.ModelInfo{}, err
 					} else {
 						err = s.UpdateModelVersions(modelInDB.Id, models.Version{
 							UpdatedAt: time.Now(),
 							Status:    model.ModelStatus_OFFLINE.String(),
 						})
 						if err != nil {
-							return &model.ModelInfo{}, makeError(500, "UpdateModel Error", "Could not update model status")
+							return &model.ModelInfo{}, err
 						}
 					}
 				default:
-					return &model.ModelInfo{}, makeError(400, "UpdateModel Error", "Wrong status value. Status should be online or offline")
+					return &model.ModelInfo{}, fmt.Errorf("Wrong status value. Status should be online or offline")
 				}
 			}
 		}
@@ -432,17 +417,17 @@ func (s *modelService) GetModelMetaData(namespace string, modelName string) (*mo
 	// TODO: improve by using join
 	resModelInDB, err := s.GetModelByName(namespace, modelName)
 	if err != nil {
-		return &model.ModelInfo{}, makeError(404, "GetModel", fmt.Sprintf("Model %v not found in namespace %v", modelName, namespace))
+		return &model.ModelInfo{}, err
 	}
 
 	versions, err := s.GetModelVersions(resModelInDB.Id)
 	if err != nil {
-		return &model.ModelInfo{}, makeError(404, "GetModel", "There is no versions for this model")
+		return &model.ModelInfo{}, err
 	}
 
 	tritonModels, err := s.GetTModels(resModelInDB.Id)
 	if err != nil {
-		return &model.ModelInfo{}, makeError(404, "GetModel", "There is no triton model for this model")
+		return &model.ModelInfo{}, err
 	}
 
 	return createModelInfo(resModelInDB, versions, tritonModels), nil
@@ -451,7 +436,7 @@ func (s *modelService) GetModelMetaData(namespace string, modelName string) (*mo
 func (s *modelService) DeleteModel(namespace string, modelName string) error {
 	modelInDB, err := s.GetModelByName(namespace, modelName)
 	if err != nil {
-		return makeError(404, "DeleteModel", fmt.Sprintf("Model %v not found in namespace %v", modelName, namespace))
+		return err
 	}
 
 	modelVersionsInDB, err := s.GetModelVersions(modelInDB.Id)
@@ -477,11 +462,11 @@ func (s *modelService) DeleteModel(namespace string, modelName string) error {
 func (s *modelService) DeleteModelVersion(namespace string, modelName string, version int32) error {
 	modelInDB, err := s.GetModelByName(namespace, modelName)
 	if err != nil {
-		return makeError(404, "DeleteModelVersion", fmt.Sprintf("Model %v not found in namespace %v", modelName, namespace))
+		return err
 	}
 	modelVersionInDB, err := s.GetModelVersion(modelInDB.Id, int32(version))
 	if err != nil {
-		return makeError(404, "DeleteModelVersion", fmt.Sprintf("Model %v with version %v not found in namespace %v", modelName, version, namespace))
+		return err
 	}
 
 	ensembleModel, err := s.modelRepository.GetTEnsembleModel(modelInDB.Id, modelVersionInDB.Version)
@@ -499,7 +484,7 @@ func (s *modelService) DeleteModelVersion(namespace string, modelName string, ve
 
 	modelVersionsInDB, err := s.GetModelVersions(modelInDB.Id)
 	if err != nil {
-		return makeError(404, "DeleteModelVersion", fmt.Sprintf("There is no version of model %v", modelName))
+		return err
 	}
 
 	if len(modelVersionsInDB) > 1 {

--- a/pkg/services/model.go
+++ b/pkg/services/model.go
@@ -350,7 +350,7 @@ func (s *modelService) UpdateModelMetaData(namespace string, updatedModel models
 }
 
 func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelRequest) (*model.ModelInfo, error) {
-	modelInDB, err := s.GetModelByName(namespace, in.Model.Name)
+	modelInDB, err := s.GetModelByName(namespace, in.Name)
 	if err != nil {
 		return &model.ModelInfo{}, err
 	}
@@ -359,7 +359,7 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 		for _, field := range in.UpdateMask.Paths {
 			switch field {
 			case "status":
-				ensembleModel, err := s.modelRepository.GetTEnsembleModel(modelInDB.Id, in.Model.Version)
+				ensembleModel, err := s.modelRepository.GetTEnsembleModel(modelInDB.Id, in.Version)
 				if err != nil {
 					return &model.ModelInfo{}, err
 				}
@@ -407,10 +407,18 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 				default:
 					return &model.ModelInfo{}, fmt.Errorf("Wrong status value. Status should be online or offline")
 				}
+			case "description":
+				err = s.UpdateModelVersion(modelInDB.Id, in.Version, models.Version{
+					UpdatedAt:   time.Now(),
+					Description: in.Model.Description,
+				})
+				if err != nil {
+					return &model.ModelInfo{}, err
+				}
 			}
 		}
 	}
-	return s.GetModelMetaData(namespace, in.Model.Name)
+	return s.GetModelMetaData(namespace, in.Name)
 }
 
 func (s *modelService) GetModelMetaData(namespace string, modelName string) (*model.ModelInfo, error) {

--- a/pkg/services/model.go
+++ b/pkg/services/model.go
@@ -74,7 +74,7 @@ type ModelService interface {
 	GetModelByName(namespace string, modelName string) (models.Model, error)
 	GetModelMetaData(namespace string, modelName string) (*model.ModelInfo, error)
 	CreateVersion(version models.Version) (models.Version, error)
-	UpdateModelVersions(modelId int32, version models.Version) error
+	UpdateModelVersion(modelId int32, modelVersion int32, versionInfo models.Version) error
 	UpdateModelMetaData(namespace string, updatedModel models.Model) (*model.ModelInfo, error)
 	GetModelVersion(modelId int32, version int32) (models.Version, error)
 	GetModelVersions(modelId int32) ([]models.Version, error)
@@ -139,8 +139,8 @@ func (s *modelService) CreateVersion(version models.Version) (models.Version, er
 	}
 }
 
-func (s *modelService) UpdateModelVersions(modelId int32, version models.Version) error {
-	return s.modelRepository.UpdateModelVersions(modelId, version)
+func (s *modelService) UpdateModelVersion(modelId int32, modelVersion int32, versionInfo models.Version) error {
+	return s.modelRepository.UpdateModelVersion(modelId, modelVersion, versionInfo)
 }
 
 func (s *modelService) GetModelVersion(modelId int32, version int32) (models.Version, error) {
@@ -367,7 +367,7 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 				case model.ModelStatus_ONLINE:
 					_, err = triton.LoadModelRequest(triton.TritonClient, ensembleModel.Name)
 					if err != nil {
-						err = s.UpdateModelVersions(modelInDB.Id, models.Version{
+						err = s.UpdateModelVersion(modelInDB.Id, ensembleModel.ModelVersion, models.Version{
 							UpdatedAt: time.Now(),
 							Status:    model.ModelStatus_ERROR.String(),
 						})
@@ -376,7 +376,7 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 						}
 						return &model.ModelInfo{}, err
 					} else {
-						err := s.UpdateModelVersions(modelInDB.Id, models.Version{
+						err := s.UpdateModelVersion(modelInDB.Id, ensembleModel.ModelVersion, models.Version{
 							UpdatedAt: time.Now(),
 							Status:    model.ModelStatus_ONLINE.String(),
 						})
@@ -387,7 +387,7 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 				case model.ModelStatus_OFFLINE:
 					_, err = triton.UnloadModelRequest(triton.TritonClient, ensembleModel.Name)
 					if err != nil {
-						err = s.UpdateModelVersions(modelInDB.Id, models.Version{
+						err = s.UpdateModelVersion(modelInDB.Id, ensembleModel.ModelVersion, models.Version{
 							UpdatedAt: time.Now(),
 							Status:    model.ModelStatus_ERROR.String(),
 						})
@@ -396,7 +396,7 @@ func (s *modelService) UpdateModel(namespace string, in *model.UpdateModelReques
 						}
 						return &model.ModelInfo{}, err
 					} else {
-						err = s.UpdateModelVersions(modelInDB.Id, models.Version{
+						err = s.UpdateModelVersion(modelInDB.Id, ensembleModel.ModelVersion, models.Version{
 							UpdatedAt: time.Now(),
 							Status:    model.ModelStatus_OFFLINE.String(),
 						})

--- a/rpc/model.go
+++ b/rpc/model.go
@@ -243,13 +243,11 @@ func saveFile(stream model.Model_CreateModelByUploadServer) (outFile string, mod
 	return tmpFile, &uploadedModel, nil
 }
 
-func savePredictInput(stream model.Model_PredictModelByUploadServer) (imageFile string, modelId string, version int32, err error) {
-	firstChunk := true
-	var fp *os.File
-
+func savePredictInput(stream model.Model_PredictModelByUploadServer) (imageByte []byte, modelId string, version int32, err error) {
+	var firstChunk = true
 	var fileData *model.PredictModelRequest
 
-	var tmpFile string
+	var fileContent []byte
 
 	for {
 		fileData, err = stream.Recv() //ignoring the data  TO-Do save files received
@@ -259,29 +257,19 @@ func savePredictInput(stream model.Model_PredictModelByUploadServer) (imageFile 
 			}
 
 			err = errors.Wrapf(err,
-				"failed unexpectadely while reading chunks from stream")
-			return "", "", -1, err
+				"failed while reading chunks from stream")
+			return []byte{}, "", -1, err
 		}
 
 		if firstChunk { //first chunk contains file name
 			modelId = fileData.Name
 			version = fileData.Version
 
-			tmpFile = path.Join("/tmp/", uuid.New().String())
-			fp, err = os.Create(tmpFile)
-			if err != nil {
-				return "", "", -1, err
-			}
-			defer fp.Close()
-
 			firstChunk = false
 		}
-		err = writeToFp(fp, fileData.Content)
-		if err != nil {
-			return "", "", -1, err
-		}
+		fileContent = append(fileContent, fileData.Content...)
 	}
-	return tmpFile, modelId, version, nil
+	return fileContent, modelId, version, nil
 }
 
 func makeError(statusCode codes.Code, title string, detail string) error {
@@ -293,8 +281,7 @@ func makeError(statusCode codes.Code, title string, detail string) error {
 	return status.Error(statusCode, string(data))
 }
 
-func makeResponse(w http.ResponseWriter, status int, title string, detail string) {
-	fmt.Println(" makeResponse ", status, title, detail, w)
+func makeJsonResponse(w http.ResponseWriter, status int, title string, detail string) {
 	w.Header().Add("Content-Type", "application/json+problem")
 	w.WriteHeader(status)
 	obj, _ := json.Marshal(models.Error{
@@ -338,22 +325,22 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 	if strings.Contains(contentType, "multipart/form-data") {
 		username := r.Header.Get("Username")
 		if username == "" {
-			makeResponse(w, 422, "Required parameter missing", "Required parameter Jwt-Sub not found in your header")
+			makeJsonResponse(w, 422, "Required parameter missing", "Required parameter Jwt-Sub not found in your header")
 			return
 		}
 
 		if strings.Contains(username, "..") || strings.Contains(username, "/") { //TODO add github username validator
-			makeResponse(w, 422, "Username error", "The user name should not contain special characters")
+			makeJsonResponse(w, 422, "Username error", "The user name should not contain special characters")
 			return
 		}
 
 		modelName := r.FormValue("name")
 		if modelName == "" {
-			makeResponse(w, 400, "Missing parameter", "Model name need to be specified")
+			makeJsonResponse(w, 400, "Missing parameter", "Model name need to be specified")
 			return
 		}
 		if match, _ := regexp.MatchString("^[A-Za-z0-9][a-zA-Z0-9_.-]*$", modelName); !match {
-			makeResponse(w, 400, "Invalid parameter", "Model name is invalid")
+			makeJsonResponse(w, 400, "Invalid parameter", "Model name is invalid")
 			return
 		}
 
@@ -363,19 +350,19 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 			cvTask = val
 		} else {
 			if sCVTask != "" {
-				makeResponse(w, 400, "Parameter Error", "Wrong CV Task value")
+				makeJsonResponse(w, 400, "Parameter Error", "Wrong CV Task value")
 				return
 			}
 		}
 
 		err := r.ParseMultipartForm(4 << 20)
 		if err != nil {
-			makeResponse(w, 500, "Internal Error", "Error while reading file from request")
+			makeJsonResponse(w, 500, "Internal Error", "Error while reading file from request")
 			return
 		}
 		file, _, err := r.FormFile("content")
 		if err != nil {
-			makeResponse(w, 500, "Internal Error", "Error while reading file from request")
+			makeJsonResponse(w, 500, "Internal Error", "Error while reading file from request")
 			return
 		}
 		defer file.Close()
@@ -391,18 +378,18 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 			buf.Write(part[:count])
 		}
 		if err != io.EOF {
-			makeResponse(w, 400, "File Error", "Error reading input file")
+			makeJsonResponse(w, 400, "File Error", "Error reading input file")
 			return
 		}
 		tmpFile := path.Join("/tmp", uuid.New().String())
 		fp, err := os.Create(tmpFile)
 		if err != nil {
-			makeResponse(w, 400, "File Error", "Error reading input file")
+			makeJsonResponse(w, 400, "File Error", "Error reading input file")
 			return
 		}
 		err = writeToFp(fp, buf.Bytes())
 		if err != nil {
-			makeResponse(w, 400, "File Error", "Error reading input file")
+			makeJsonResponse(w, 400, "File Error", "Error reading input file")
 			return
 		}
 
@@ -431,13 +418,13 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 		}
 		isOk := unzip(tmpFile, configs.Config.TritonServer.ModelStore, username, &uploadedModel)
 		if !isOk {
-			makeResponse(w, 400, "Add Model Error", "Could not extract zip file")
+			makeJsonResponse(w, 400, "Add Model Error", "Could not extract zip file")
 			return
 		}
 
 		resModel, err := modelService.HandleCreateModelByUpload(username, &uploadedModel)
 		if err != nil {
-			makeResponse(w, 500, "Add Model Error", err.Error())
+			makeJsonResponse(w, 500, "Add Model Error", err.Error())
 			return
 		}
 
@@ -449,6 +436,7 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(405)
 	}
+	return
 }
 
 func (s *serviceHandlers) CreateModel(ctx context.Context, in *model.CreateModelRequest) (*model.ModelInfo, error) {
@@ -515,9 +503,57 @@ func (s *serviceHandlers) ListModels(ctx context.Context, in *model.ListModelReq
 	return &model.ListModelResponse{Models: resModels}, err
 }
 
-func (s *serviceHandlers) PredictModel(ctx context.Context, in *model.PredictModelRequest) (*structpb.Struct, error) {
-	fmt.Println("PredictModel", in)
-	return &structpb.Struct{}, nil
+func (s *serviceHandlers) PredictModel(ctx context.Context, in *model.PredictModelImageRequest) (*structpb.Struct, error) {
+	username, err := getUsername(ctx)
+	if err != nil {
+		return &structpb.Struct{}, err
+	}
+
+	modelInDB, err := s.modelService.GetModelByName(username, in.Name)
+	if err != nil {
+		return &structpb.Struct{}, makeError(404, "PredictModel", fmt.Sprintf("The model named %v not found in server", in.Name))
+	}
+
+	_, err = s.modelService.GetModelVersion(modelInDB.Id, in.Version)
+	if err != nil {
+		return &structpb.Struct{}, makeError(404, "PredictModel", fmt.Sprintf("The model %v  with version %v not found in server", in.Name, in.Version))
+	}
+
+	imgsBytes, _, err := ParseImageRequestInputsToBytes(in)
+	if err != nil {
+		return &structpb.Struct{}, makeError(400, "PredictModel", err.Error())
+	}
+
+	cvTask := model.CVTask(modelInDB.CVTask)
+	response, err := s.modelService.PredictModelByUpload(username, in.Name, int32(in.Version), imgsBytes, cvTask)
+	if err != nil {
+		return &structpb.Struct{}, makeError(400, "PredictModel", err.Error())
+	}
+
+	var data = &structpb.Struct{}
+	var b []byte
+	switch cvTask {
+	case model.CVTask_CLASSIFICATION:
+		b, err = json.Marshal(response.(*model.ClassificationOutputs))
+		if err != nil {
+			return &structpb.Struct{}, makeError(500, "PredictModel", err.Error())
+		}
+	case model.CVTask_DETECTION:
+		b, err = json.Marshal(response.(*model.DetectionOutputs))
+		if err != nil {
+			return &structpb.Struct{}, makeError(500, "PredictModel", err.Error())
+		}
+	default:
+		b, err = json.Marshal(response.(*inferenceserver.ModelInferResponse))
+		if err != nil {
+			return &structpb.Struct{}, makeError(500, "PredictModel", err.Error())
+		}
+	}
+	err = protojson.Unmarshal(b, data)
+	if err != nil {
+		return &structpb.Struct{}, makeError(500, "PredictModel", err.Error())
+	}
+	return data, nil
 }
 
 func (s *serviceHandlers) PredictModelByUpload(stream model.Model_PredictModelByUploadServer) error {
@@ -530,7 +566,7 @@ func (s *serviceHandlers) PredictModelByUpload(stream model.Model_PredictModelBy
 		return err
 	}
 
-	imageFile, modelName, version, err := savePredictInput(stream)
+	imageByte, modelName, version, err := savePredictInput(stream)
 	if err != nil {
 		return makeError(500, "PredictModel", "Could not save the file")
 	}
@@ -541,7 +577,7 @@ func (s *serviceHandlers) PredictModelByUpload(stream model.Model_PredictModelBy
 	}
 	cvTask := model.CVTask(modelInDB.CVTask)
 
-	response, err := s.modelService.PredictModelByUpload(username, modelName, version, imageFile, cvTask)
+	response, err := s.modelService.PredictModelByUpload(username, modelName, version, [][]byte{imageByte}, cvTask)
 
 	if err != nil {
 		return err
@@ -581,16 +617,19 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 		modelName := pathParams["name"]
 
 		if username == "" {
-			makeResponse(w, 422, "Required parameter missing", "Required parameter Jwt-Sub not found in your header")
+			makeJsonResponse(w, 422, "Required parameter missing", "Required parameter Jwt-Sub not found in your header")
+			return
 		}
 		if modelName == "" {
-			makeResponse(w, 422, "Required parameter missing", "Required parameter mode name not found")
+			makeJsonResponse(w, 422, "Required parameter missing", "Required parameter mode name not found")
+			return
 		}
 
 		modelVersion, err := strconv.ParseInt(r.FormValue("version"), 10, 32)
 
 		if err != nil {
-			makeResponse(w, 400, "Wrong parameter type", "Version should be a number greater than 0")
+			makeJsonResponse(w, 400, "Wrong parameter type", "Version should be a number greater than 0")
+			return
 		}
 
 		db := database.GetConnection()
@@ -599,48 +638,27 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 
 		modelInDB, err := modelService.GetModelByName(username, modelName)
 		if err != nil {
-			makeResponse(w, 404, "Model not found", "The model not found in server")
+			makeJsonResponse(w, 404, "Model not found", "The model not found in server")
+			return
 		}
 
 		err = r.ParseMultipartForm(4 << 20)
 		if err != nil {
-			makeResponse(w, 500, "Internal Error", "Error while reading file from request")
+			makeJsonResponse(w, 500, "Internal Error", "Error while reading file from request")
+			return
 		}
 
-		file, _, err := r.FormFile("content")
+		imgsBytes, _, err := parseImageFormDataInputsToBytes(r)
 		if err != nil {
-			makeResponse(w, 500, "Internal Error", "Error while reading file from request")
-		}
-		defer file.Close()
-		reader := bufio.NewReader(file)
-		buf := bytes.NewBuffer(make([]byte, 0))
-		part := make([]byte, 1024)
-		count := 0
-		for {
-			if count, err = reader.Read(part); err != nil {
-				break
-			}
-			buf.Write(part[:count])
-		}
-		if err != io.EOF {
-			makeResponse(w, 400, "Internal Error", "Error reading input file")
-		}
-
-		tmpFile := path.Join("/tmp", uuid.New().String()+".jpg")
-		fp, err := os.Create(tmpFile)
-		if err != nil {
-			makeResponse(w, 400, "Internal Error", "Error reading input file")
-		}
-
-		err = writeToFp(fp, buf.Bytes())
-		if err != nil {
-			makeResponse(w, 400, "Internal Error", "Error reading input file")
+			makeJsonResponse(w, 400, "File Input Error", err.Error())
+			return
 		}
 
 		cvTask := model.CVTask(modelInDB.CVTask)
-		response, err := modelService.PredictModelByUpload(username, modelName, int32(modelVersion), tmpFile, cvTask)
+		response, err := modelService.PredictModelByUpload(username, modelName, int32(modelVersion), imgsBytes, cvTask)
 		if err != nil {
-			makeResponse(w, 500, "Error Predict Model", err.Error())
+			makeJsonResponse(w, 500, "Error Predict Model", err.Error())
+			return
 		}
 
 		w.Header().Add("Content-Type", "application/json+problem")
@@ -651,6 +669,7 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(405)
 	}
+	return
 }
 
 func (s *serviceHandlers) GetModel(ctx context.Context, in *model.GetModelRequest) (*model.ModelInfo, error) {

--- a/rpc/model.go
+++ b/rpc/model.go
@@ -419,18 +419,14 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 		isOk := unzip(tmpFile, configs.Config.TritonServer.ModelStore, username, &uploadedModel)
 		if !isOk {
 			makeJsonResponse(w, 400, "Add Model Error", "Could not extract zip file")
-			database.Close(db)
 			return
 		}
 
 		resModel, err := modelService.HandleCreateModelByUpload(username, &uploadedModel)
 		if err != nil {
 			makeJsonResponse(w, 500, "Add Model Error", err.Error())
-			database.Close(db)
 			return
 		}
-
-		database.Close(db)
 
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(200)
@@ -642,21 +638,18 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 		modelInDB, err := modelService.GetModelByName(username, modelName)
 		if err != nil {
 			makeJsonResponse(w, 404, "Model not found", "The model not found in server")
-			database.Close(db)
 			return
 		}
 
 		err = r.ParseMultipartForm(4 << 20)
 		if err != nil {
 			makeJsonResponse(w, 500, "Internal Error", "Error while reading file from request")
-			database.Close(db)
 			return
 		}
 
 		imgsBytes, _, err := parseImageFormDataInputsToBytes(r)
 		if err != nil {
 			makeJsonResponse(w, 400, "File Input Error", err.Error())
-			database.Close(db)
 			return
 		}
 
@@ -664,11 +657,8 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 		response, err := modelService.PredictModelByUpload(username, modelName, int32(modelVersion), imgsBytes, cvTask)
 		if err != nil {
 			makeJsonResponse(w, 500, "Error Predict Model", err.Error())
-			database.Close(db)
 			return
 		}
-
-		database.Close(db)
 
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(200)

--- a/rpc/model.go
+++ b/rpc/model.go
@@ -625,7 +625,7 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 			return
 		}
 
-		modelVersion, err := strconv.ParseInt(r.FormValue("version"), 10, 32)
+		modelVersion, err := strconv.ParseInt(pathParams["version"], 10, 32)
 
 		if err != nil {
 			makeJsonResponse(w, 400, "Wrong parameter type", "Version should be a number greater than 0")

--- a/rpc/model.go
+++ b/rpc/model.go
@@ -436,7 +436,6 @@ func HandleCreateModelByUpload(w http.ResponseWriter, r *http.Request, pathParam
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(405)
 	}
-	return
 }
 
 func (s *serviceHandlers) CreateModel(ctx context.Context, in *model.CreateModelRequest) (*model.ModelInfo, error) {
@@ -669,7 +668,6 @@ func HandlePredictModelByUpload(w http.ResponseWriter, r *http.Request, pathPara
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(405)
 	}
-	return
 }
 
 func (s *serviceHandlers) GetModel(ctx context.Context, in *model.GetModelRequest) (*model.ModelInfo, error) {

--- a/rpc/payload.go
+++ b/rpc/payload.go
@@ -141,15 +141,15 @@ func parseImageFormDataInputsToBytes(r *http.Request) (imgsBytes [][]byte, imgsM
 	for _, content := range inputs {
 		file, err := content.Open()
 		if err != nil {
-			log.Printf("Unable to open file for image %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
-			return nil, nil, fmt.Errorf("Unable to open file for image %v", content.Filename)
+			log.Printf("Unable to open file for image %v", err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to open file for image")
 		}
 
 		buff := new(bytes.Buffer) // pointer
 		numBytes, err := buff.ReadFrom(file)
 		if err != nil {
-			log.Printf("Unable to read content body from image %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
-			return nil, nil, fmt.Errorf("Unable to read content body from image %v", content.Filename)
+			log.Printf("Unable to read content body from image %v", err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to read content body from image")
 		}
 
 		if numBytes > int64(consts.MaxImageSizeBytes) {
@@ -163,8 +163,8 @@ func parseImageFormDataInputsToBytes(r *http.Request) (imgsBytes [][]byte, imgsM
 
 		img, format, err := image.Decode(buff)
 		if err != nil {
-			log.Printf("Unable to decode image: %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
-			return nil, nil, fmt.Errorf("Unable to decode image %v", content.Filename)
+			log.Printf("Unable to decode image: %v", err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to decode image")
 		}
 
 		// Encode into jpeg to remove alpha channel (hack)
@@ -172,8 +172,8 @@ func parseImageFormDataInputsToBytes(r *http.Request) (imgsBytes [][]byte, imgsM
 		buff = new(bytes.Buffer)
 		err = jpeg.Encode(buff, img, &jpeg.Options{Quality: 100})
 		if err != nil {
-			log.Printf("Unable to process image: %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
-			return nil, nil, fmt.Errorf("Unable to process image %v", content.Filename)
+			log.Printf("Unable to process image: %v", err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to process image")
 		}
 
 		imgsBytes = append(imgsBytes, buff.Bytes())

--- a/rpc/payload.go
+++ b/rpc/payload.go
@@ -68,7 +68,6 @@ func parseImageFromURL(url string) (*image.Image, *imageMetadata, error) {
 
 func parseImageFromBase64(encoded string) (*image.Image, *imageMetadata, error) {
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
-	fmt.Println("???decoded ", decoded)
 	if err != nil {
 		log.Printf("Unable to decode base64 image. %v", err) // The internal error err only appears in the logs, because it's only useful to us
 		return nil, nil, fmt.Errorf("Unable to decode base64 image")
@@ -112,7 +111,6 @@ func ParseImageRequestInputsToBytes(inputs *model.PredictModelImageRequest) (img
 				return nil, nil, fmt.Errorf("Unable to parse image %v from url", idx)
 			}
 		} else if len(content.Base64) > 0 {
-			fmt.Println(">>>>>>>> ", content.Base64)
 			img, metadata, err = parseImageFromBase64(content.Base64)
 			if err != nil {
 				log.Printf("Unable to parse base64 image %v. %v", idx, err) // The internal error err only appears in the logs, because it's only useful to us

--- a/rpc/payload.go
+++ b/rpc/payload.go
@@ -7,7 +7,6 @@ import (
 	"image"
 	"image/jpeg"
 	"log"
-	"mime/multipart"
 	"net/http"
 	"path"
 
@@ -21,10 +20,6 @@ type imageMetadata struct {
 	format   string
 	width    int
 	height   int
-}
-
-type imageFormDataInputs struct {
-	Contents []*multipart.FileHeader `form:"contents"`
 }
 
 func parseImageFromURL(url string) (*image.Image, *imageMetadata, error) {

--- a/rpc/payload.go
+++ b/rpc/payload.go
@@ -1,0 +1,189 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"path"
+
+	consts "github.com/instill-ai/model-backend/internal"
+	"github.com/instill-ai/protogen-go/model"
+)
+
+// Internally used image metadata
+type imageMetadata struct {
+	filename string
+	format   string
+	width    int
+	height   int
+}
+
+type imageFormDataInputs struct {
+	Contents []*multipart.FileHeader `form:"contents"`
+}
+
+func parseImageFromURL(url string) (*image.Image, *imageMetadata, error) {
+	response, err := http.Get(url)
+	if err != nil {
+		log.Printf("Unable to download image at %v. %v", url, err) // The internal error err only appears in the logs, because it's only useful to us
+		return nil, nil, fmt.Errorf("Unable to download image at %v", url)
+	}
+	defer response.Body.Close()
+
+	buff := new(bytes.Buffer) // pointer
+	numBytes, err := buff.ReadFrom(response.Body)
+	if err != nil {
+		log.Printf("Unable to read content body from image at %v. %v", url, err) // The internal error err only appears in the logs, because it's only useful to us
+		return nil, nil, fmt.Errorf("Unable to read content body from image at %v", url)
+	}
+
+	if numBytes > int64(consts.MaxImageSizeBytes) {
+		return nil, nil, fmt.Errorf(
+			"Image size must be smaller than %vMB. Got %vMB",
+			float32(consts.MaxImageSizeBytes)/float32(consts.MB),
+			float32(numBytes)/float32(consts.MB),
+		)
+	}
+
+	img, format, err := image.Decode(buff)
+	if err != nil {
+		log.Printf("Unable to decode image at %v. %v", url, err) // The internal error err only appears in the logs, because it's only useful to us
+		return nil, nil, fmt.Errorf("Unable to decode image at %v", url)
+	}
+
+	metadata := imageMetadata{
+		filename: path.Base(url),
+		format:   format,
+		width:    img.Bounds().Dx(),
+		height:   img.Bounds().Dy(),
+	}
+
+	return &img, &metadata, nil
+}
+
+func parseImageFromBase64(encoded string) (*image.Image, *imageMetadata, error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		log.Printf("Unable to decode base64 image. %v", err) // The internal error err only appears in the logs, because it's only useful to us
+		return nil, nil, fmt.Errorf("Unable to decode base64 image")
+	}
+	numBytes := len(decoded)
+	if numBytes > consts.MaxImageSizeBytes {
+		return nil, nil, fmt.Errorf(
+			"Image size must be smaller than %vMB. Got %vMB",
+			float32(consts.MaxImageSizeBytes)/float32(consts.MB),
+			float32(numBytes)/float32(consts.MB),
+		)
+	}
+	img, format, err := image.Decode(bytes.NewReader(decoded))
+	if err != nil {
+		log.Printf("Unable to decode base64 image. %v", err) // The internal error err only appears in the logs, because it's only useful to us
+		return nil, nil, fmt.Errorf("Unable to decode base64 image")
+	}
+
+	metadata := imageMetadata{
+		filename: "",
+		format:   format,
+		width:    img.Bounds().Dx(),
+		height:   img.Bounds().Dy(),
+	}
+
+	return &img, &metadata, nil
+}
+
+func ParseImageRequestInputsToBytes(inputs *model.PredictModelImageRequest) (imgsBytes [][]byte, imgsMetadata []*imageMetadata, err error) {
+	for idx, content := range inputs.Contents {
+		var (
+			img      *image.Image
+			metadata *imageMetadata
+			err      error
+		)
+
+		if len(content.Url) > 0 {
+			img, metadata, err = parseImageFromURL(content.Url)
+			if err != nil {
+				log.Printf("Unable to parse image %v from url. %v", idx, err) // The internal error err only appears in the logs, because it's only useful to us
+				return nil, nil, fmt.Errorf("Unable to parse image %v from url", idx)
+			}
+		} else if len(content.Base64) > 0 {
+			img, metadata, err = parseImageFromBase64(content.Base64)
+			if err != nil {
+				log.Printf("Unable to parse base64 image %v. %v", idx, err) // The internal error err only appears in the logs, because it's only useful to us
+				return nil, nil, fmt.Errorf("Unable to parse base64 image %v", idx)
+			}
+		} else {
+			return nil, nil, fmt.Errorf(`Image %v must define either a "url" or "base64" field. None of them were defined`, idx)
+		}
+
+		// Encode into jpeg to remove alpha channel (hack)
+		// This may slightly degrade the image quality
+		buff := new(bytes.Buffer)
+		err = jpeg.Encode(buff, *img, &jpeg.Options{Quality: 100})
+		if err != nil {
+			log.Printf("Unable to process image %v. %v", idx, err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to process image %v", idx)
+		}
+
+		imgsBytes = append(imgsBytes, buff.Bytes())
+		imgsMetadata = append(imgsMetadata, metadata)
+	}
+
+	return imgsBytes, imgsMetadata, nil
+}
+
+func parseImageFormDataInputsToBytes(r *http.Request) (imgsBytes [][]byte, imgsMetadata []*imageMetadata, err error) {
+	inputs := r.MultipartForm.File["contents"]
+	for _, content := range inputs {
+		file, err := content.Open()
+		if err != nil {
+			log.Printf("Unable to open file for image %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to open file for image %v", content.Filename)
+		}
+
+		buff := new(bytes.Buffer) // pointer
+		numBytes, err := buff.ReadFrom(file)
+		if err != nil {
+			log.Printf("Unable to read content body from image %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to read content body from image %v", content.Filename)
+		}
+
+		if numBytes > int64(consts.MaxImageSizeBytes) {
+			return nil, nil, fmt.Errorf(
+				"Image size must be smaller than %vMB. Got %vMB from image %v",
+				float32(consts.MaxImageSizeBytes)/float32(consts.MB),
+				float32(numBytes)/float32(consts.MB),
+				content.Filename,
+			)
+		}
+
+		img, format, err := image.Decode(buff)
+		if err != nil {
+			log.Printf("Unable to decode image: %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to decode image %v", content.Filename)
+		}
+
+		// Encode into jpeg to remove alpha channel (hack)
+		// This may slightly degrade the image quality
+		buff = new(bytes.Buffer)
+		err = jpeg.Encode(buff, img, &jpeg.Options{Quality: 100})
+		if err != nil {
+			log.Printf("Unable to process image: %v. %v", content.Filename, err) // The internal error err only appears in the logs, because it's only useful to us
+			return nil, nil, fmt.Errorf("Unable to process image %v", content.Filename)
+		}
+
+		imgsBytes = append(imgsBytes, buff.Bytes())
+		imgsMetadata = append(imgsMetadata, &imageMetadata{
+			filename: content.Filename,
+			format:   format,
+			width:    img.Bounds().Dx(),
+			height:   img.Bounds().Dy(),
+		})
+	}
+
+	return imgsBytes, imgsMetadata, nil
+}

--- a/rpc/payload.go
+++ b/rpc/payload.go
@@ -68,6 +68,7 @@ func parseImageFromURL(url string) (*image.Image, *imageMetadata, error) {
 
 func parseImageFromBase64(encoded string) (*image.Image, *imageMetadata, error) {
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	fmt.Println("???decoded ", decoded)
 	if err != nil {
 		log.Printf("Unable to decode base64 image. %v", err) // The internal error err only appears in the logs, because it's only useful to us
 		return nil, nil, fmt.Errorf("Unable to decode base64 image")
@@ -111,6 +112,7 @@ func ParseImageRequestInputsToBytes(inputs *model.PredictModelImageRequest) (img
 				return nil, nil, fmt.Errorf("Unable to parse image %v from url", idx)
 			}
 		} else if len(content.Base64) > 0 {
+			fmt.Println(">>>>>>>> ", content.Base64)
 			img, metadata, err = parseImageFromBase64(content.Base64)
 			if err != nil {
 				log.Printf("Unable to parse base64 image %v. %v", idx, err) // The internal error err only appears in the logs, because it's only useful to us

--- a/scripts/quick-download.sh
+++ b/scripts/quick-download.sh
@@ -1,10 +1,6 @@
 
 #!/bin/sh
 
-echo "Downloading conda-pack"
-mkdir conda-pack > /dev/null 2>&1
-wget https://artifacts.instill.tech/vdp/conda-pack/python-3-8.tar.gz -P ./conda-pack/
-
 echo "Downloading sample-models"
 mkdir sample-models > /dev/null 2>&1
 wget https://artifacts.instill.tech/vdp/sample-models/yolov4-onnx-cpu.zip -P ./sample-models/


### PR DESCRIPTION
Because

- besides making predictions via form-data (for REST API) and stream (for gRPC), the model-backend should support inference through URL/base64 image

This commit

- add predict method for input URL/base64
- closes #26 
- closes #27 
- closes #36 