### PR TITLE
fix: remove readme file when error

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -135,6 +135,8 @@ func RemoveModelRepository(modelRepositoryRoot string, namespace string, modelNa
 			panic(err)
 		}
 	}
+	readmeFilePath := fmt.Sprintf("%v/%v#%v#README.md#%v", modelRepositoryRoot, namespace, modelName, instanceName)
+	_ = os.Remove(readmeFilePath)
 }
 
 // ConvertAllJSONKeySnakeCase traverses a JSON object to replace all keys to snake_case.

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -776,6 +776,7 @@ func (h *handler) CreateModel(ctx context.Context, req *modelPB.CreateModelReque
 		modelSrcDir := fmt.Sprintf("/tmp/%v", rdid.String())
 		err = util.GitHubClone(modelSrcDir, instanceConfig)
 		if err != nil {
+			util.RemoveModelRepository(configs.Config.TritonServer.ModelStore, owner, githubModel.ID, tag.Name)
 			return &modelPB.CreateModelResponse{}, makeError(codes.InvalidArgument, "Add Model Error", err.Error())
 		}
 		bInstanceConfig, _ := json.Marshal(instanceConfig)


### PR DESCRIPTION
Because

- Readme file exists if creating a model failed

This commit

- Remove Readme file if creating a model failed
