### PR TITLE
chore: support dvc in GitHub model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,14 @@ RUN make build
 FROM alpine:3.16.0 AS runtime
 RUN apk update
 RUN apk add git git-lfs
+# Install python/pip
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3-dev && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+RUN apk add --no-cache libffi-dev build-base py3-pip python3-dev
+RUN apk add --no-cache libgit2-dev py3-pygit2
+RUN pip3 install dvc[gs]
 
 WORKDIR /model-backend
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -75,7 +75,8 @@ func GitHubClone(dir string, instanceConfig datamodel.GitHubModelInstanceConfigu
 	dvcPath := findDVCPath(dir)
 	if dvcPath != "" {
 		cmd = exec.Command("/bin/sh", "-c", fmt.Sprintf("cd %s; dvc pull", dvcPath))
-		return cmd.Run()
+		err = cmd.Run()
+		return err
 	}
 	return nil
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -47,6 +47,17 @@ func GetModelMetaFromReadme(readmeFilePath string) (*ModelMeta, error) {
 	return &modelMeta, err
 }
 
+func findDVCPath(dir string) string {
+	dvcPath := ""
+	_ = filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+		if f.Name() == ".dvc" {
+			dvcPath = path
+		}
+		return nil
+	})
+	return dvcPath
+}
+
 func GitHubClone(dir string, instanceConfig datamodel.GitHubModelInstanceConfiguration) error {
 	urlRepo := instanceConfig.Repository
 	if !strings.HasPrefix(urlRepo, "https://github.com") {
@@ -57,7 +68,16 @@ func GitHubClone(dir string, instanceConfig datamodel.GitHubModelInstanceConfigu
 	}
 
 	cmd := exec.Command("git", "clone", "-b", instanceConfig.Tag, urlRepo, dir)
-	return cmd.Run()
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+	dvcPath := findDVCPath(dir)
+	if dvcPath != "" {
+		cmd = exec.Command("/bin/sh", "-c", fmt.Sprintf("cd %s; dvc pull", dvcPath))
+		return cmd.Run()
+	}
+	return nil
 }
 
 type Tag struct {


### PR DESCRIPTION
Because

- GitHub LFS have limited quotation then support DVC tool to make a bridge between GitHub and Cloud Storage for model large files

This commit

- Add DVC tool to pull models from cloud storage
