### PR TITLE
chore: update output format of unspecified task

### DIFF
--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -1,7 +1,7 @@
 name: Add PR to Project
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - ready_for_review

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220709051344-5e035024ab8d
+	github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220715075327-c07b2a37216f
 	github.com/instill-ai/usage-client v0.1.1-alpha
 	github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523
 	github.com/knadh/koanf v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -706,6 +706,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220709051344-5e035024ab8d h1:FB8H4ujDHfFMO+wvIimtlUqWcYaIsPtLjkuL88d7Zro=
 github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220709051344-5e035024ab8d/go.mod h1:d9ebEdwMX2Las4OScym45qbQM+xcBQITqvq/8anTVas=
+github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220715075327-c07b2a37216f h1:lkbb8AuIU5Jmx12oj3F/GNhuDNZCPg+o+h3JSIRiNaQ=
+github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220715075327-c07b2a37216f/go.mod h1:d9ebEdwMX2Las4OScym45qbQM+xcBQITqvq/8anTVas=
 github.com/instill-ai/usage-client v0.1.1-alpha h1:TG1jH82GHjPqmjogQ4I1d8KFY5cBzrskBt9stoARWnU=
 github.com/instill-ai/usage-client v0.1.1-alpha/go.mod h1:Vi+RgL2YNT+hfztD33JzqFl/Y7/SsV+NpWGIjUgig3s=
 github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523 h1:HsZW2VWEnPhxitcyJEGbuQ9vi2LVsSEA8ezPIkp4VQs=

--- a/internal/triton/const.go
+++ b/internal/triton/const.go
@@ -9,3 +9,21 @@ type KeypointOutput struct {
 	Keypoints [][][]float32
 	Scores    []float32
 }
+
+type BatchUnspecifiedTaskOutputs struct {
+	Name              string
+	Shape             []int64
+	DataType          string
+	SerializedOutputs []interface{} // batching output
+}
+
+type SingleOutputUnspecifiedTaskOutput struct {
+	Name     string
+	Shape    []int64
+	DataType string
+	Data     interface{} // batching output
+}
+
+type UnspecifiedTaskOutput struct {
+	RawOutput []SingleOutputUnspecifiedTaskOutput
+}

--- a/internal/triton/util.go
+++ b/internal/triton/util.go
@@ -128,6 +128,34 @@ func Reshape1DArrayFloat32To3D(array []float32, shape []int64) ([][][]float32, e
 	return res, nil
 }
 
+func Reshape1DArrayFloat32To2D(array []float32, shape []int64) ([][]float32, error) {
+	if len(array) == 0 {
+		return [][]float32{}, nil
+	}
+
+	if len(shape) != 2 {
+		return nil, fmt.Errorf("Expected a 2D shape, got %vD shape %v", len(shape), shape)
+	}
+
+	var prod int64 = 1
+	for _, s := range shape {
+		prod *= s
+	}
+	if prod != int64(len(array)) {
+		return nil, fmt.Errorf("Cannot reshape array of length %v into shape %v", len(array), shape)
+	}
+
+	res := make([][]float32, shape[0])
+	for i := int64(0); i < shape[0]; i++ {
+		res[i] = make([]float32, shape[1])
+		start := i * shape[0]
+		end := start + shape[1]
+		res[i] = array[start:end]
+	}
+
+	return res, nil
+}
+
 func GetOutputFromInferResponse(name string, response *inferenceserver.ModelInferResponse) (*inferenceserver.ModelInferResponse_InferOutputTensor, []byte, error) {
 	for idx, output := range response.Outputs {
 		if output.Name == name {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -246,6 +246,7 @@ func RemoveModelRepository(modelRepositoryRoot string, namespace string, modelNa
 
 // ConvertAllJSONKeySnakeCase traverses a JSON object to replace all keys to snake_case.
 func ConvertAllJSONKeySnakeCase(i interface{}) {
+
 	switch v := i.(type) {
 	case map[string]interface{}:
 		for k, vv := range v {
@@ -258,6 +259,15 @@ func ConvertAllJSONKeySnakeCase(i interface{}) {
 		}
 	case []map[string]interface{}:
 		for _, vv := range v {
+			ConvertAllJSONKeySnakeCase(vv)
+		}
+	case map[string][]map[string]interface{}:
+		for k, vv := range v {
+			sc := strcase.ToSnake(k)
+			if sc != k {
+				v[sc] = v[k]
+				delete(v, k)
+			}
 			ConvertAllJSONKeySnakeCase(vv)
 		}
 	}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -2032,7 +2032,7 @@ func (h *handler) TriggerModelInstance(ctx context.Context, req *modelPB.Trigger
 			return &modelPB.TriggerModelInstanceResponse{}, status.Error(codes.Internal, err.Error())
 		}
 	default:
-		b, err = util.MarshalOptions.Marshal(response.(*inferenceserver.ModelInferResponse))
+		b, err = util.MarshalOptions.Marshal(response.(*modelPB.UnspecifiedTaskOutputs))
 		if err != nil {
 			return &modelPB.TriggerModelInstanceResponse{}, status.Error(codes.Internal, err.Error())
 		}
@@ -2115,7 +2115,7 @@ func (h *handler) TestModelInstance(ctx context.Context, req *modelPB.TestModelI
 			return &modelPB.TestModelInstanceResponse{}, status.Error(codes.Internal, err.Error())
 		}
 	default:
-		b, err = util.MarshalOptions.Marshal(response.(*inferenceserver.ModelInferResponse))
+		b, err = util.MarshalOptions.Marshal(response.(*modelPB.UnspecifiedTaskOutputs))
 		if err != nil {
 			return &modelPB.TestModelInstanceResponse{}, status.Error(codes.Internal, err.Error())
 		}


### PR DESCRIPTION
Because

- decode output triton and format as a standardized output for unspecified task

This commit

- format output of unspecified task
- close #138 
