### PR TITLE
chore: adopt lastest protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220809155503-10fac2901a67
+	github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220813140655-b09bed6bedb9
 	github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523
 	github.com/knadh/koanf v1.4.1
 	github.com/mitchellh/mapstructure v1.5.0
@@ -20,7 +20,6 @@ require (
 	github.com/rs/cors v1.8.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/stretchr/testify v1.7.2
-	github.com/urfave/cli/v2 v2.11.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/net v0.0.0-20220615171555-694bf12d69de
 	google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90
@@ -34,7 +33,6 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/containerd v1.6.6 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
@@ -60,8 +58,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
-github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -702,8 +700,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220809155503-10fac2901a67 h1:r1lvea2kLPoW5AoWHCQYH9XxUy5deZKJUK3qwTaQYa4=
-github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220809155503-10fac2901a67/go.mod h1:d9ebEdwMX2Las4OScym45qbQM+xcBQITqvq/8anTVas=
+github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220813140655-b09bed6bedb9 h1:kMgC62oYS18t87B0C8AzTxFtcXGllmePPedzkwqLyzE=
+github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220813140655-b09bed6bedb9/go.mod h1:d9ebEdwMX2Las4OScym45qbQM+xcBQITqvq/8anTVas=
 github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523 h1:HsZW2VWEnPhxitcyJEGbuQ9vi2LVsSEA8ezPIkp4VQs=
 github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523/go.mod h1:/UEx/zFyMo7so2ctBY0pzjmIoJB9Qz5Y4gvwU2FoU74=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
@@ -1088,8 +1086,6 @@ github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -1174,8 +1170,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.11.0 h1:c6bD90aLd2iEsokxhxkY5Er0zA2V9fId2aJfwmrF+do=
-github.com/urfave/cli/v2 v2.11.0/go.mod h1:f8iq5LtQ/bLxafbdBSLPPNsgaW0l/2fYYEHhAyPlwvo=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
@@ -1195,8 +1189,6 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -74,7 +74,7 @@ export default function (data) {
   queryModelInstance.ListModelInstance()
   queryModelInstance.LookupModelInstance()
 
-  // // Get model card
+  // Get model card
   getModelCard.GetModelCard()
 }
 

--- a/integration-test/rest_create_model.js
+++ b/integration-test/rest_create_model.js
@@ -267,14 +267,14 @@ export function CreateModelFromGitHub() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1,             
+          r.json().batch_outputs[0].classification.score === 1,
       });
 
       // Predict multiple images with url
@@ -289,20 +289,18 @@ export function CreateModelFromGitHub() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1,  
-        [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[1].task`]: (r) =>
-          r.json().batch_outputs[1].task === "CLASSIFICATION",
+          r.json().batch_outputs[0].classification.score === 1,
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[1].classification.category`]: (r) =>
           r.json().batch_outputs[1].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/v1.0:trigger url cls batch_outputs[1].classification.score`]: (r) =>
-          r.json().batch_outputs[1].classification.score === 1,            
+          r.json().batch_outputs[1].classification.score === 1,
       });
 
       check(http.request("POST", `${apiHost}/v1alpha/models`, JSON.stringify({

--- a/integration-test/rest_infer_model.js
+++ b/integration-test/rest_infer_model.js
@@ -95,14 +95,14 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1,          
+          r.json().batch_outputs[0].classification.score === 1,
       });
 
       // Predict multiple images with url
@@ -117,20 +117,18 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1, 
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images batch_outputs[1].task`]: (r) =>
-          r.json().batch_outputs[1].task === "CLASSIFICATION",
+          r.json().batch_outputs[0].classification.score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls multiple images batch_outputs[1].classification.category`]: (r) =>
           r.json().batch_outputs[1].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url cls response batch_outputs[1].classification.score`]: (r) =>
-          r.json().batch_outputs[1].classification.score === 1,           
+          r.json().batch_outputs[1].classification.score === 1,
       });
 
       // Predict with base64
@@ -142,14 +140,14 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls status`]: (r) =>
           r.status === 200,
+          [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1,  
+          r.json().batch_outputs[0].classification.score === 1,
       });
 
       // Predict multiple images with base64
@@ -164,52 +162,48 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1, 
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images batch_outputs[1].task`]: (r) =>
-          r.json().batch_outputs[1].task === "CLASSIFICATION",
+          r.json().batch_outputs[0].classification.score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls multiple images batch_outputs[1].classification.category`]: (r) =>
           r.json().batch_outputs[1].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 cls response batch_outputs[1].classification.score`]: (r) =>
-          r.json().batch_outputs[1].classification.score === 1,    
+          r.json().batch_outputs[1].classification.score === 1,
       });
 
       // Predict with multiple-part
       let fd = new FormData();
       fd.append("file", http.file(dog_img));
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:test-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1,  
+          r.json().batch_outputs[0].classification.score === 1,
       });
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1, 
+          r.json().batch_outputs[0].classification.score === 1,
       });
 
       // Predict multiple images with multiple-part
@@ -222,52 +216,44 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 3,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1, 
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs[1].task`]: (r) =>
-          r.json().batch_outputs[1].task === "CLASSIFICATION",
+          r.json().batch_outputs[0].classification.score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs[1].classification.category`]: (r) =>
           r.json().batch_outputs[1].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls response batch_outputs[1].classification.score`]: (r) =>
-          r.json().batch_outputs[1].classification.score === 1, 
-          [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs[2].task`]: (r) =>
-          r.json().batch_outputs[2].task === "CLASSIFICATION",
+          r.json().batch_outputs[1].classification.score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls multiple images batch_outputs[2].classification.category`]: (r) =>
           r.json().batch_outputs[2].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart cls response batch_outputs[2].classification.score`]: (r) =>
-          r.json().batch_outputs[2].classification.score === 1,             
+          r.json().batch_outputs[2].classification.score === 1,
       });
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images task`]: (r) =>
+          r.json().task === "TASK_CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 3,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "CLASSIFICATION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[0].classification.category`]: (r) =>
           r.json().batch_outputs[0].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[0].classification.score`]: (r) =>
-          r.json().batch_outputs[0].classification.score === 1, 
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[1].task`]: (r) =>
-          r.json().batch_outputs[1].task === "CLASSIFICATION",
+          r.json().batch_outputs[0].classification.score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[1].classification.category`]: (r) =>
           r.json().batch_outputs[1].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls response batch_outputs[1].classification.score`]: (r) =>
-          r.json().batch_outputs[1].classification.score === 1, 
-          [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[2].task`]: (r) =>
-          r.json().batch_outputs[2].task === "CLASSIFICATION",
+          r.json().batch_outputs[1].classification.score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls multiple images batch_outputs[2].classification.category`]: (r) =>
           r.json().batch_outputs[2].classification.category === "match",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart cls response batch_outputs[2].classification.score`]: (r) =>
-          r.json().batch_outputs[2].classification.score === 1,   
+          r.json().batch_outputs[2].classification.score === 1,
       });
 
       // clean up
@@ -352,24 +338,24 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict multiple images with url
@@ -384,22 +370,22 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[1].detection.bounding_boxes.length`]: (r) =>
@@ -407,15 +393,15 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[1].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,          
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict with base64
@@ -427,24 +413,24 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict multiple images with base64
@@ -459,22 +445,22 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[1].detection.bounding_boxes.length`]: (r) =>
@@ -482,67 +468,65 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[1].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,         
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict with multiple-part
       let fd = new FormData();
       fd.append("file", http.file(dog_img));
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:test-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict multiple images with multiple-part
@@ -555,22 +539,22 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 3,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[1].detection.bounding_boxes.length`]: (r) =>
@@ -578,51 +562,51 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,   
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[2].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[2].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[2].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[2].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.height === 0,             
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.height === 0,
       });
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 3,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[1].detection.bounding_boxes.length`]: (r) =>
@@ -630,29 +614,29 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,   
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[2].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[2].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[2].detection.bounding_boxes[0].category === "test",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].score === 1, 
+          r.json().batch_outputs[2].detection.bounding_boxes[0].score === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart multiple images det batch_outputs[2].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.height === 0,   
+          r.json().batch_outputs[2].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // clean up
@@ -737,20 +721,20 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,                                                  
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
       });
 
       // Predict multiple images with url
@@ -765,28 +749,28 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
           r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,          
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,
       });
 
       // Predict with base64
@@ -798,20 +782,20 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,  
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
       });
 
       // Predict multiple images with base64
@@ -826,71 +810,67 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
           r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 multiple images undefined batch_outputs[1].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,    
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,
       });
 
       // Predict with multiple-part
       fd = new FormData();
       fd.append("file", http.file(dog_img));
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:test-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined, 
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
       });
 
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
           r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
       });
@@ -900,78 +880,74 @@ export function InferModel() {
       fd.append("file", http.file(dog_img));
       fd.append("file", http.file(cat_img));
       fd.append("file", http.file(bear_img));
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:test-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 3,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined, 
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,       
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].shape !== undefined,           
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].shape !== undefined,
       });
 
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 3,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "UNSPECIFIED",
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined task`]: (r) =>
+          r.json().task === "TASK_UNSPECIFIED",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs.length`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,   
+          r.json().batch_outputs[0].unspecified.raw_outputs.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[0].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined, 
+          r.json().batch_outputs[0].unspecified.raw_outputs[0].shape !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[1].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,       
+          r.json().batch_outputs[1].unspecified.raw_outputs[0].shape !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].data`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].data !== undefined,   
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].data !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].data_type`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].data_type === "FP32",   
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].data_type === "FP32",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].name`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].name === "output",   
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].name === "output",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart undefined batch_outputs[2].unspecified.raw_outputs[0].shape`]: (r) =>
-          r.json().batch_outputs[2].unspecified.raw_outputs[0].shape !== undefined,  
+          r.json().batch_outputs[2].unspecified.raw_outputs[0].shape !== undefined,
       });
 
       // clean up
@@ -1056,16 +1032,16 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url keypoint status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url keypoint task`]: (r) =>
+          r.json().task === "TASK_KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url keypoint batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url keypoint batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url keypoint batch_outputs[0].keypoint.keypoint_groups.length`]: (r) =>
           r.json().batch_outputs[0].keypoint.keypoint_groups.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url keypoint batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,            
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url keypoint batch_outputs[0].keypoint.keypoint_groups[0].score`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1,          
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1,
       });
 
       // Predict multiple images with url
@@ -1091,16 +1067,16 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 keypoint status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 keypoint task`]: (r) =>
+          r.json().task === "TASK_KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 keypoint batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 keypoint batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 keypoint batch_outputs[0].keypoint.keypoint_groups.length`]: (r) =>
           r.json().batch_outputs[0].keypoint.keypoint_groups.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 keypoint batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,            
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 keypoint batch_outputs[0].keypoint.keypoint_groups[0].score`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1,   
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1,
       });
 
       // Predict multiple images with base64
@@ -1120,37 +1096,35 @@ export function InferModel() {
       // Predict with multiple-part
       let fd = new FormData();
       fd.append("file", http.file(dog_img));
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:test-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart keypoint status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart keypoint task`]: (r) =>
+          r.json().task === "TASK_KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart keypoint batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart keypoint batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart keypoint batch_outputs[0].keypoint.keypoint_groups.length`]: (r) =>
           r.json().batch_outputs[0].keypoint.keypoint_groups.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart keypoint batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,            
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart keypoint batch_outputs[0].keypoint.keypoint_groups[0].score`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1, 
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1,
       });
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart keypoint status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart keypoint task`]: (r) =>
+          r.json().task === "TASK_KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart keypoint batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart keypoint batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "KEYPOINT",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart keypoint batch_outputs[0].keypoint.keypoint_groups.length`]: (r) =>
           r.json().batch_outputs[0].keypoint.keypoint_groups.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart keypoint batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,            
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].keypoint_group.length > 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart keypoint batch_outputs[0].keypoint.keypoint_groups[0].score`]: (r) =>
-          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1, 
+          r.json().batch_outputs[0].keypoint.keypoint_groups[0].score === 1,
       });
 
       // Predict multiple images with multiple-part
@@ -1217,7 +1191,7 @@ export function InferModel() {
         "POST /v1alpha/models:multipart response model.update_time": (r) =>
           r.json().model.update_time !== undefined,
       });
-      
+
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:deploy`, {}, {
         headers: genHeader(`application/json`),
       }), {
@@ -1252,24 +1226,24 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,                   
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict multiple images with url
@@ -1286,34 +1260,34 @@ export function InferModel() {
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,           
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict with base64
@@ -1325,24 +1299,24 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,  
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict multiple images with base64
@@ -1357,88 +1331,86 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger base64 det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger url det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict with multiple-part
       let fd = new FormData();
       fd.append("file", http.file(dog_img));
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:test-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
       // Predict multiple images with multiple-part
@@ -1450,36 +1422,36 @@ export function InferModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:test-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,
       });
       check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/latest:trigger-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
@@ -1488,34 +1460,34 @@ export function InferModel() {
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 2,
-        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
+        [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[1].detection.bounding_boxes[0].category === "",
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].score === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.top === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.left === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,                    
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.width === 0,
         [`POST /v1alpha/models/${model_id}/instances/latest:trigger-multipart det multiple images batch_outputs[1].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0, 
+          r.json().batch_outputs[1].detection.bounding_boxes[0].bounding_box.height === 0,
       });
 
 
@@ -1598,29 +1570,27 @@ export function InferModel() {
       // Predict with multiple-part
       let fd = new FormData();
       fd.append("file", http.file(dog_rgba_img));
-      check(http.post(`${apiHost}/v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart`, fd.body(), {
-        headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
-      }), {
+      check(res, {
         [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det status`]: (r) =>
           r.status === 200,
+        [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det task`]: (r) =>
+          r.json().task === "TASK_DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det batch_outputs.length`]: (r) =>
           r.json().batch_outputs.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det .batch_outputs[0].task`]: (r) =>
-          r.json().batch_outputs[0].task === "DETECTION",
         [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det batch_outputs[0].detection.bounding_boxes.length`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes.length === 1,
-        [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipartl det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
+        [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det batch_outputs[0].detection.bounding_boxes[0].category`]: (r) =>
           r.json().batch_outputs[0].detection.bounding_boxes[0].category === "dog",
         [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det batch_outputs[0].detection.bounding_boxes[0].score`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].score !== undefined, 
+          r.json().batch_outputs[0].detection.bounding_boxes[0].score !== undefined,
         [`POST /v1alpha/models/${model_id}/instances/lv1.0-cpu:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.top`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top !== 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.top !== 0,
         [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.left`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left !== 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.left !== 0,
         [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.width`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width !== 0,                    
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.width !== 0,
         [`POST /v1alpha/models/${model_id}/instances/v1.0-cpu:test-multipart det batch_outputs[0].detection.bounding_boxes[0].bounding_box.height`]: (r) =>
-          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height !== 0,             
+          r.json().batch_outputs[0].detection.bounding_boxes[0].bounding_box.height !== 0,
       });
 
       // clean up

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1854,7 +1854,10 @@ func (h *handler) TestModelInstanceBinaryFileUpload(stream modelPB.ModelService_
 		return err
 	}
 
-	err = stream.SendAndClose(&modelPB.TestModelInstanceBinaryFileUploadResponse{BatchOutputs: response})
+	err = stream.SendAndClose(&modelPB.TestModelInstanceBinaryFileUploadResponse{
+		Task:         task,
+		BatchOutputs: response,
+	})
 	return err
 }
 
@@ -1904,7 +1907,10 @@ func (h *handler) TriggerModelInstanceBinaryFileUpload(stream modelPB.ModelServi
 		return err
 	}
 
-	err = stream.SendAndClose(&modelPB.TriggerModelInstanceBinaryFileUploadResponse{BatchOutputs: response})
+	err = stream.SendAndClose(&modelPB.TriggerModelInstanceBinaryFileUploadResponse{
+		Task:         task,
+		BatchOutputs: response,
+	})
 	return err
 }
 
@@ -1955,7 +1961,11 @@ func (h *handler) TriggerModelInstance(ctx context.Context, req *modelPB.Trigger
 	if err != nil {
 		return &modelPB.TriggerModelInstanceResponse{}, status.Error(codes.InvalidArgument, err.Error())
 	}
-	return &modelPB.TriggerModelInstanceResponse{BatchOutputs: response}, nil
+
+	return &modelPB.TriggerModelInstanceResponse{
+		Task:         task,
+		BatchOutputs: response,
+	}, nil
 }
 
 func (h *handler) TestModelInstance(ctx context.Context, req *modelPB.TestModelInstanceRequest) (*modelPB.TestModelInstanceResponse, error) {
@@ -2009,7 +2019,10 @@ func (h *handler) TestModelInstance(ctx context.Context, req *modelPB.TestModelI
 		return &modelPB.TestModelInstanceResponse{}, status.Error(codes.Internal, err.Error())
 	}
 
-	return &modelPB.TestModelInstanceResponse{BatchOutputs: response}, nil
+	return &modelPB.TestModelInstanceResponse{
+		Task:         task,
+		BatchOutputs: response,
+	}, nil
 }
 
 func inferModelInstanceByUpload(w http.ResponseWriter, r *http.Request, pathParams map[string]string, mode string) {
@@ -2086,7 +2099,7 @@ func inferModelInstanceByUpload(w http.ResponseWriter, r *http.Request, pathPara
 			}
 		}
 		task := modelPB.ModelInstance_Task(modelInstanceInDB.Task)
-		var response []*modelPB.ModelInstanceInferenceResponse
+		var response []*modelPB.ModelInstanceOutput
 		if mode == "test" {
 			response, err = modelService.ModelInferTestMode(owner, modelInstanceInDB.UID, imgsBytes, task)
 		} else {
@@ -2099,7 +2112,10 @@ func inferModelInstanceByUpload(w http.ResponseWriter, r *http.Request, pathPara
 
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(200)
-		res, err := util.MarshalOptions.Marshal(&modelPB.TestModelInstanceBinaryFileUploadResponse{BatchOutputs: response})
+		res, err := util.MarshalOptions.Marshal(&modelPB.TestModelInstanceBinaryFileUploadResponse{
+			Task:         task,
+			BatchOutputs: response,
+		})
 		if err != nil {
 			makeJSONResponse(w, 500, "Error Predict Model", err.Error())
 			return

--- a/pkg/handler/mock_service_test.go
+++ b/pkg/handler/mock_service_test.go
@@ -251,10 +251,10 @@ func (mr *MockServiceMockRecorder) ListModelInstance(arg0, arg1, arg2, arg3 inte
 }
 
 // ModelInfer mocks base method.
-func (m *MockService) ModelInfer(arg0 uuid.UUID, arg1 [][]byte, arg2 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.ModelInstanceInferenceResponse, error) {
+func (m *MockService) ModelInfer(arg0 uuid.UUID, arg1 [][]byte, arg2 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.ModelInstanceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelInfer", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*modelv1alpha.ModelInstanceInferenceResponse)
+	ret0, _ := ret[0].([]*modelv1alpha.ModelInstanceOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -266,10 +266,10 @@ func (mr *MockServiceMockRecorder) ModelInfer(arg0, arg1, arg2 interface{}) *gom
 }
 
 // ModelInferTestMode mocks base method.
-func (m *MockService) ModelInferTestMode(arg0 string, arg1 uuid.UUID, arg2 [][]byte, arg3 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.ModelInstanceInferenceResponse, error) {
+func (m *MockService) ModelInferTestMode(arg0 string, arg1 uuid.UUID, arg2 [][]byte, arg3 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.ModelInstanceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelInferTestMode", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]*modelv1alpha.ModelInstanceInferenceResponse)
+	ret0, _ := ret[0].([]*modelv1alpha.ModelInstanceOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Because

- `task` is shared among all batch outputs, it should be at the same level of `batch_outputs`

This commit

- adopt the latest protobuf to move task field one level up.
- rename `ModelInstanceInferenceResponse` to `ModelInstanceOutput`