### PR TITLE
refactor: rename BatchOutput to TaskOutput

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220911092846-074c65eae91d
+	github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220912044511-0ab17e86726e
 	github.com/instill-ai/usage-client v0.1.2-alpha
 	github.com/instill-ai/x v0.2.0-alpha
 	github.com/knadh/koanf v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -708,6 +708,8 @@ github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220824151607-dde62e8b8354 h1:
 github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220824151607-dde62e8b8354/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220911092846-074c65eae91d h1:mV5iqEwWWW7eard8NxU/W1q6p2C/wMbR/YmQGqxmN9Q=
 github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220911092846-074c65eae91d/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220912044511-0ab17e86726e h1:XCMsBKtRbME8AWm8VlXQS2tZb/IeZmVtsOBkTm9sxhQ=
+github.com/instill-ai/protogen-go v0.3.1-alpha.0.20220912044511-0ab17e86726e/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.1.2-alpha h1:aGZKqZSZu4FB4ov1lyaJVIuoD6MQ+zDBUFqSYWVauSE=
 github.com/instill-ai/usage-client v0.1.2-alpha/go.mod h1:Vi+RgL2YNT+hfztD33JzqFl/Y7/SsV+NpWGIjUgig3s=
 github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -2130,8 +2130,8 @@ func (h *handler) TestModelInstanceBinaryFileUpload(stream modelPB.ModelService_
 	}
 
 	err = stream.SendAndClose(&modelPB.TestModelInstanceBinaryFileUploadResponse{
-		Task:         task,
-		BatchOutputs: response,
+		Task:        task,
+		TaskOutputs: response,
 	})
 	return err
 }
@@ -2207,8 +2207,8 @@ func (h *handler) TriggerModelInstanceBinaryFileUpload(stream modelPB.ModelServi
 	}
 
 	err = stream.SendAndClose(&modelPB.TriggerModelInstanceBinaryFileUploadResponse{
-		Task:         task,
-		BatchOutputs: response,
+		Task:        task,
+		TaskOutputs: response,
 	})
 	return err
 }
@@ -2286,8 +2286,8 @@ func (h *handler) TriggerModelInstance(ctx context.Context, req *modelPB.Trigger
 	}
 
 	return &modelPB.TriggerModelInstanceResponse{
-		Task:         task,
-		BatchOutputs: response,
+		Task:        task,
+		TaskOutputs: response,
 	}, nil
 }
 
@@ -2367,8 +2367,8 @@ func (h *handler) TestModelInstance(ctx context.Context, req *modelPB.TestModelI
 	}
 
 	return &modelPB.TestModelInstanceResponse{
-		Task:         task,
-		BatchOutputs: response,
+		Task:        task,
+		TaskOutputs: response,
 	}, nil
 }
 
@@ -2448,7 +2448,7 @@ func inferModelInstanceByUpload(w http.ResponseWriter, r *http.Request, pathPara
 			}
 		}
 		task := modelPB.ModelInstance_Task(modelInstanceInDB.Task)
-		var response []*modelPB.BatchOutput
+		var response []*modelPB.TaskOutput
 		if mode == "test" {
 			response, err = modelService.ModelInferTestMode(owner, modelInstanceInDB.UID, imgsBytes, task)
 		} else {
@@ -2485,8 +2485,8 @@ func inferModelInstanceByUpload(w http.ResponseWriter, r *http.Request, pathPara
 		w.Header().Add("Content-Type", "application/json+problem")
 		w.WriteHeader(200)
 		res, err := util.MarshalOptions.Marshal(&modelPB.TestModelInstanceBinaryFileUploadResponse{
-			Task:         task,
-			BatchOutputs: response,
+			Task:        task,
+			TaskOutputs: response,
 		})
 		if err != nil {
 			makeJSONResponse(w, 500, "Error Predict Model", err.Error())

--- a/pkg/handler/mock_service_test.go
+++ b/pkg/handler/mock_service_test.go
@@ -251,10 +251,10 @@ func (mr *MockServiceMockRecorder) ListModelInstance(arg0, arg1, arg2, arg3 inte
 }
 
 // ModelInfer mocks base method.
-func (m *MockService) ModelInfer(arg0 uuid.UUID, arg1 [][]byte, arg2 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.BatchOutput, error) {
+func (m *MockService) ModelInfer(arg0 uuid.UUID, arg1 [][]byte, arg2 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.TaskOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelInfer", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*modelv1alpha.BatchOutput)
+	ret0, _ := ret[0].([]*modelv1alpha.TaskOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -266,10 +266,10 @@ func (mr *MockServiceMockRecorder) ModelInfer(arg0, arg1, arg2 interface{}) *gom
 }
 
 // ModelInferTestMode mocks base method.
-func (m *MockService) ModelInferTestMode(arg0 string, arg1 uuid.UUID, arg2 [][]byte, arg3 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.BatchOutput, error) {
+func (m *MockService) ModelInferTestMode(arg0 string, arg1 uuid.UUID, arg2 [][]byte, arg3 modelv1alpha.ModelInstance_Task) ([]*modelv1alpha.TaskOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelInferTestMode", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]*modelv1alpha.BatchOutput)
+	ret0, _ := ret[0].([]*modelv1alpha.TaskOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Because

- naming consistency

This commit

- rename BatchOutput to TaskOutput