### PR TITLE
chore: update init database

### DIFF
--- a/cmd/init/db.go
+++ b/cmd/init/db.go
@@ -30,7 +30,7 @@ func createModelDefinitionRecord(
 		ReleaseStage:      releaseStage,
 	}
 
-	if result := db.Model(&datamodel.ModelDefinition{}).Create(&modelDef); result.Error != nil {
+	if result := db.Model(&datamodel.ModelDefinition{}).FirstOrCreate(&modelDef); result.Error != nil {
 		return result.Error
 	}
 


### PR DESCRIPTION

Because

-  run init database container again and got the error duplicate key

This commit

- if already initialized database then continue to run
