### PR TITLE
chore: update dummy ArtiVC model for integration test

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1155,7 +1155,7 @@ func createArtiVCModel(h *handler, ctx context.Context, req *modelPB.CreateModel
 		}
 		_ = os.RemoveAll(tmpDir)
 	} else {
-		tags = append(tags, "v1.0") // use local model for integration test mode
+		tags = append(tags, "v1.0-cpu") // use local model for integration test mode
 	}
 	for _, tag := range tags {
 		instanceConfig := datamodel.ArtiVCModelInstanceConfiguration{


### PR DESCRIPTION
Because

- when running an integration test in the console or other services, the internet connection could impact to test result. So use dummy model for integration test to make test result stable

This commit

- add dummy model for ArtiVC model
