### PR TITLE
chore: add server config maximagesize

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type ServerConfig struct {
 	DisableUsage bool     `koanf:"disableusage"`
 	Debug        bool     `koanf:"debug"`
 	ItMode       bool     `koanf:"itmode"`
+	MaxImageSize int      `koanf:"maximagesize"`
 }
 
 // config related to database

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,6 +11,7 @@ server:
   disableusage: false
   debug: true
   itmode: false
+  maximagesize: 12 # MB in unit
 database:
   username: postgres
   password: password

--- a/internal/util/const.go
+++ b/internal/util/const.go
@@ -40,7 +40,6 @@ const (
 )
 
 const MaxBatchSize int = 32
-const MaxImageSizeBytes int = 12 * MB
 
 const DEFAULT_GCP_SERVICE_ACCOUNT_FILE = "https://artifacts.instill.tech/default-service-account.json"
 

--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -12,6 +12,7 @@ import (
 
 	_ "golang.org/x/image/tiff"
 
+	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/internal/logger"
 	"github.com/instill-ai/model-backend/internal/util"
 
@@ -44,10 +45,10 @@ func parseImageFromURL(url string) (*image.Image, *imageMetadata, error) {
 		return nil, nil, fmt.Errorf("unable to read content body from image at %v", url)
 	}
 
-	if numBytes > int64(util.MaxImageSizeBytes) {
+	if numBytes > int64(config.Config.Server.MaxImageSize*util.MB) {
 		return nil, nil, fmt.Errorf(
 			"image size must be smaller than %vMB. Got %vMB",
-			float32(util.MaxImageSizeBytes)/float32(util.MB),
+			config.Config.Server.MaxImageSize,
 			float32(numBytes)/float32(util.MB),
 		)
 	}


### PR DESCRIPTION
Because

- max image size should be configurable

This commit

- add `maximagesize` in server config
