### PR TITLE
ci: rename env varible HOSTNAME to HOST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ integration-test:				## Run integration test
 		go install go.k6.io/xk6/cmd/xk6@latest;\
 		xk6 build --with github.com/szkiba/xk6-jose@latest --output ${K6BIN};\
 	fi
-	@TEST_FOLDER_ABS_PATH=${PWD} ${K6BIN} run -e HOSTNAME=$(HOSTNAME) integration-test/grpc.js --no-usage-report
-	@TEST_FOLDER_ABS_PATH=${PWD} ${K6BIN} run -e HOSTNAME=$(HOSTNAME) integration-test/rest.js --no-usage-report
+	@TEST_FOLDER_ABS_PATH=${PWD} ${K6BIN} run -e HOST=$(HOST) integration-test/grpc.js --no-usage-report
+	@TEST_FOLDER_ABS_PATH=${PWD} ${K6BIN} run -e HOST=$(HOST) integration-test/rest.js --no-usage-report
 	@if [ ${K6BIN} != "k6" ]; then rm -rf $(dirname ${K6BIN}); fi
 
 .PHONY: help

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -1,7 +1,7 @@
-let host = __ENV.HOSTNAME ? `${__ENV.HOSTNAME}` : "localhost"
+let host = __ENV.HOST ? `${__ENV.HOST}` : "localhost"
 let port = 8083
-if (__ENV.HOSTNAME=="api-gateway") { host = "localhost" }
-if (__ENV.HOSTNAME=="api-gateway") { port = 8000 }
+if (__ENV.HOST == "api-gateway") { host = "localhost" }
+if (__ENV.HOST == "api-gateway") { port = 8000 }
 export const gRPCHost = `${host}:${port}`
 export const apiHost = `http://${host}:${port}`
 


### PR DESCRIPTION
Because

- the original env variable `HOSTNAME` conflicts with the default container `HOSTNAME` 

This commit

- rename `HOSTNAME` to `HOST`
