### PR TITLE
fix: model instance state update to unspecified state

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -180,6 +180,11 @@ func (r *repository) UpdateModelInstance(modelInstanceUID uuid.UUID, instanceInf
 	if result := r.db.Model(&datamodel.ModelInstance{}).Where(map[string]interface{}{"uid": modelInstanceUID}).Updates(&instanceInfo); result.Error != nil {
 		return status.Errorf(codes.Internal, "Error %v", result.Error)
 	}
+	if instanceInfo.State == datamodel.ModelInstanceState(modelPB.ModelInstance_STATE_UNSPECIFIED) {
+		if result := r.db.Model(&datamodel.ModelInstance{}).Where(map[string]interface{}{"uid": modelInstanceUID}).Updates(map[string]interface{}{"state": instanceInfo.State}); result.Error != nil {
+			return status.Errorf(codes.Internal, "Error %v", result.Error)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Because

- gorm does not update zero value when using struct

This commit

- use map for updating unspecified (zero value) model instance state
