### PR TITLE
chore: update Visual Data Preparation to Versatile Data Pipeline

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -9,6 +9,6 @@ jobs:
   track_issue:
     uses: instill-ai/meta/.github/workflows/add-issue-to-prj.yml@main
     with:
-      project_number: 5 # Visual Data Preparation (VDP) project
+      project_number: 5 # Versatile Data Pipeline (VDP) project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -4,11 +4,11 @@ on:
   pull_request_target:
     types:
       - opened
-      
+
 jobs:
   track_pr:
     uses: instill-ai/meta/.github/workflows/add-pr-to-prj.yml@main
     with:
-      project_number: 5 # Visual Data Preparation (VDP) project
+      project_number: 5 # Versatile Data Pipeline (VDP) project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # model-backend
 
-`model-backend` manages all model resources including model definitions and model instances within [Visual Data Preparation (VDP)](https://github.com/instill-ai/vdp) to convert the unstructured visual data to the structured data.
+`model-backend` manages all model resources including model definitions and model instances within [Versatile Data Pipeline (VDP)](https://github.com/instill-ai/vdp) to convert the unstructured data to meaningful data representations.
 
 ## Local dev
 

--- a/integration-test/proto/model.proto
+++ b/integration-test/proto/model.proto
@@ -486,7 +486,7 @@ message GetModelInstanceCardResponse {
 //  Trigger methods
 ////////////////////////////////////
 
-// TaskOutput represents the output of a CV Task result from a model instance
+// TaskOutput represents the output of an AI task result from a model instance
 message TaskOutput {
   // The inference task output
   oneof output {


### PR DESCRIPTION
Because

- instead of Visual Data Preparation, VDP is Versatile Data Pipeline now. We realise that as a general ETL infrastructure, VDP is capable of processing all kinds of unstructured data, and we should not limit its usage to only visual data. That's why we replace the word Visual with Versatile. Besides, the term Data Preparation is a bit misleading, users often think it has something to do with data labelling or cleaning. The term Data Pipeline is definitely more precise to capture the core concept of VDP.
 
This commit

- update to Versatile Data Pipeline
