### PR TITLE
ci: adopt api-gateway

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
+# version
+GOLANG_VERSION=1.19.3
+UBUNTU_VERSION=20.04
+
 # service
 SERVICE_NAME=model-backend
 SERVICE_PORT=8083

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,15 +3,23 @@ name: Coverage
 on: [push, pull_request]
 
 jobs:
-
   codecov:
     name: codecov
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.botGitHubToken }}
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+          expand: true
 
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.18
+          go-version: ${{ env.GOLANG_VERSION }}
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -11,6 +11,16 @@ jobs:
   docker-hub:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.botGitHubToken }}
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+          expand: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -27,6 +37,8 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=model-backend
+            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
+            UBUNTU_VERSION=${{ env.UBUNTU_VERSION }}
           tags: instill/model-backend:latest
           cache-from: type=registry,ref=instill/model-backend:buildcache
           cache-to: type=registry,ref=instill/model-backend:buildcache,mode=max
@@ -50,6 +62,8 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=model-backend
+            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
+            UBUNTU_VERSION=${{ env.UBUNTU_VERSION }}
           tags: instill/model-backend:${{steps.set_version.outputs.no_v_tag}}
           cache-from: type=registry,ref=instill/model-backend:buildcache
           cache-to: type=registry,ref=instill/model-backend:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ FROM --platform=$BUILDPLATFORM ubuntu:20.04
 
 RUN apt update && \
     apt install -y bash \
-                   build-essential \
-                   python3 python3-setuptools python3-pip git git-lfs && \
+    build-essential \
+    python3 python3-setuptools python3-pip git git-lfs && \
     rm -rf /var/lib/apt/lists
 RUN pip3 install --upgrade pip setuptools wheel
 RUN pip3 install --no-cache-dir transformers==4.21.0 pillow torch==1.12.1 torchvision==0.13.1 onnxruntime==1.11.1 dvc[gs]==2.34.2
@@ -48,4 +48,3 @@ COPY --from=build /${SERVICE_NAME}-worker ./
 
 # ArtiVC tool to work with cloud storage
 COPY --from=build /src/third_party/ArtiVC/bin/avc /bin/avc
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=$BUILDPLATFORM golang:1.18.2 AS build
+ARG GOLANG_VERSION
+ARG UBUNTU_VERSION
+
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION} AS build
 
 ARG SERVICE_NAME
 
@@ -20,7 +23,7 @@ WORKDIR /src/third_party
 
 RUN git clone https://github.com/InfuseAI/ArtiVC && cd ArtiVC && git checkout tags/v0.9.0 && go get -d -v ./... && make build
 
-FROM --platform=$BUILDPLATFORM ubuntu:20.04
+FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_VERSION}
 
 RUN apt update && \
     apt install -y bash \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,8 @@
+ARG GOLANG_VERSION
+
 FROM loadimpact/k6:latest AS k6official
 
-FROM golang:1.18.2
+FROM golang:${GOLANG_VERSION}
 
 ARG SERVICE_NAME
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM loadimpact/k6:latest AS k6official
 
-FROM --platform=$BUILDPLATFORM golang:1.18.2
+FROM golang:1.18.2
 
 ARG SERVICE_NAME
 
@@ -8,7 +8,6 @@ COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/
 COPY --from=k6official /usr/bin/k6 /usr/bin/k6
 
 WORKDIR /${SERVICE_NAME}
-COPY . /${SERVICE_NAME}
 
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,18 @@ K6BIN := $(if $(shell command -v k6 2> /dev/null),k6,$(shell mktemp -d)/k6)
 
 .PHONY: dev
 dev:							## Run dev container
+	@docker compose ls -q | grep -q "instill-vdp" && true || \
+		(echo "Error: Run \"make dev PROFILE=model\" in vdp repository (https://github.com/instill-ai/vdp) in your local machine first." && exit 1)
 	@docker inspect --type container ${SERVICE_NAME} >/dev/null 2>&1 && echo "A container named ${SERVICE_NAME} is already running." || \
-	echo "Run dev container ${SERVICE_NAME}. To stop it, run \"make stop\"." && \
-	docker run -d --rm -v model-repository:/model-repository -v $(PWD):/${SERVICE_NAME} -v /var/run/docker.sock:/var/run/docker.sock \
-	-p ${SERVICE_PORT}:${SERVICE_PORT} \
-	--network instill-network \
-	--name ${SERVICE_NAME} \
-	instill/${SERVICE_NAME}:dev >/dev/null 2>&1
+		echo "Run dev container ${SERVICE_NAME}. To stop it, run \"make stop\"."
+	@docker run -d --rm \
+		-v model-repository:/model-repository \
+		-v $(PWD):/${SERVICE_NAME} \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-p ${SERVICE_PORT}:${SERVICE_PORT} \
+		--network instill-network \
+		--name ${SERVICE_NAME} \
+		instill/${SERVICE_NAME}:dev >/dev/null 2>&1
 
 .PHONY: logs
 logs:							## Tail container logs with -n 10
@@ -38,7 +43,7 @@ build-dev:							## Build dev docker image
 
 .PHONY: build
 build:							## Build dev docker image
-	docker build --build-arg SERVICE_NAME=${SERVICE_NAME} -f Dockerfile  -t instill/${SERVICE_NAME}:latest .	
+	@docker build --build-arg SERVICE_NAME=${SERVICE_NAME} -f Dockerfile.dev  -t instill/${SERVICE_NAME}:dev .
 
 .PHONY: go-gen
 go-gen:       					## Generate codes

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,10 @@ build-dev:							## Build dev docker image
 
 .PHONY: build
 build:							## Build dev docker image
-	@docker build --build-arg SERVICE_NAME=${SERVICE_NAME} -f Dockerfile.dev  -t instill/${SERVICE_NAME}:dev .
+	@docker build \
+		--build-arg SERVICE_NAME=${SERVICE_NAME} \
+		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
+		-f Dockerfile.dev  -t instill/${SERVICE_NAME}:dev .
 
 .PHONY: go-gen
 go-gen:       					## Generate codes

--- a/cmd/main/interceptor.go
+++ b/cmd/main/interceptor.go
@@ -11,8 +11,10 @@ import (
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+
 	"github.com/instill-ai/model-backend/internal/external"
 	"github.com/instill-ai/model-backend/pkg/repository"
+
 	mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
 )
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/reflection"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -111,11 +112,13 @@ func main() {
 			grpc_recovery.UnaryServerInterceptor(recoveryInterceptorOpt()),
 		)),
 	}
+
 	if config.Config.Server.HTTPS.Cert != "" && config.Config.Server.HTTPS.Key != "" {
 		grpcServerOpts = append(grpcServerOpts, grpc.Creds(creds))
 	}
 
 	grpcS := grpc.NewServer(grpcServerOpts...)
+	reflection.Register(grpcS)
 
 	triton := triton.NewTriton()
 	defer triton.Close()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/instill-ai/model-backend
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/longrunning v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/instill-ai/model-backend
 go 1.18
 
 require (
+	cloud.google.com/go/longrunning v0.3.0
 	github.com/allegro/bigcache v1.2.1
 	github.com/gernest/front v0.0.0-20210301115436-8a0b0a782d0a
 	github.com/ghodss/yaml v1.0.0
@@ -36,7 +37,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/longrunning v0.3.0 // indirect
 	github.com/catalinc/hashcash v0.0.0-20220723060415-5e3ec3e24f67 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -1,9 +1,19 @@
-let host = __ENV.HOST ? `${__ENV.HOST}` : "localhost"
-let port = 8083
-if (__ENV.HOST == "api-gateway") { host = "localhost" }
-if (__ENV.HOST == "api-gateway") { port = 8000 }
+let proto, host, port
+
+if (__ENV.HOST == "localhost") {
+    // api-gateway mode (outside container)
+    proto = "https"
+    host = "localhost"
+    port = 8080
+} else {
+    // container mode (inside container)
+    proto = "http"
+    host = "model-backend"
+    port = 8083
+}
+
 export const gRPCHost = `${host}:${port}`
-export const apiHost = `http://${host}:${port}`
+export const apiHost = `${proto}://${host}:${port}`
 
 export const cls_model = open(`${__ENV.TEST_FOLDER_ABS_PATH}/integration-test/data/dummy-cls-model.zip`, "b");
 export const det_model = open(`${__ENV.TEST_FOLDER_ABS_PATH}/integration-test//data/dummy-det-model.zip`, "b");

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -25,9 +25,7 @@ export default () => {
     // Liveness check
     {
         group("Model API: Liveness", () => {
-            client.connect(constant.gRPCHost, {
-                plaintext: true
-            });
+            client.connect(constant.gRPCHost);
             const response = client.invoke('vdp.model.v1alpha.ModelService/Liveness', {});
             check(response, {
                 'Status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -38,9 +36,7 @@ export default () => {
 
     // Readiness check
     group("Model API: Readiness", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
         const response = client.invoke('vdp.model.v1alpha.ModelService/Readiness', {});
         check(response, {
             'Status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -66,7 +62,7 @@ export default () => {
     // Publish Model API
     publishModel.PublishUnPublishModel()
 
-    // // Infer Model API
+    // Infer Model API
     inferModel.InferModel()
 
     // Query Model Instance API
@@ -80,9 +76,7 @@ export default () => {
 };
 
 export function teardown() {
-    client.connect(constant.gRPCHost, {
-        plaintext: true
-    });
+    client.connect(constant.gRPCHost);
     group("Model API: Delete all models created by this test", () => {
         for (const model of client.invoke('vdp.model.v1alpha.ModelService/ListModel', {}, {}).message.models) {
             check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', { name: model.name }), {

--- a/integration-test/grpc_create_model.js
+++ b/integration-test/grpc_create_model.js
@@ -14,9 +14,7 @@ const model_def_name = "model-definitions/github"
 export function CreateModel() {
     // CreateModelBinaryFileUpload check
     group("Model API: CreateModelBinaryFileUpload", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
         check(client.invoke('vdp.model.v1alpha.ModelService/CreateModelBinaryFileUpload', {}), {
             'Missing stream body status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
@@ -27,9 +25,7 @@ export function CreateModel() {
 
     // CreateModel check
     group("Model API: CreateModel with GitHub", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
         let model_id = randomString(10)
         check(client.invoke('vdp.model.v1alpha.ModelService/CreateModel', {
             model: {
@@ -58,7 +54,7 @@ export function CreateModel() {
             'DeployModelInstance operation name': (r) => r && r.message.operation.name !== undefined,
             'DeployModelInstance operation metadata': (r) => r && r.message.operation.metadata === null,
             'DeployModelInstance operation done': (r) => r && r.message.operation.done === false,
-        }); 
+        });
 
         // Check the model instance state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
         let currentTime = new Date().getTime();
@@ -70,7 +66,7 @@ export function CreateModel() {
             }
             sleep(1)
             currentTime = new Date().getTime();
-        }    
+        }
 
         check(client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', { name: `models/${model_id}/instances/v1.0`, inputs: [{ image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }] }, {}), {
             'TriggerModelInstance status': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_deploy_model.js
+++ b/integration-test/grpc_deploy_model.js
@@ -20,9 +20,7 @@ const model_def_name = "model-definitions/local"
 export function DeployUndeployModel() {
     // Deploy ModelInstance check
     group("Model API: Deploy ModelInstance", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -31,7 +29,7 @@ export function DeployUndeployModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>
@@ -76,7 +74,7 @@ export function DeployUndeployModel() {
             }
             sleep(1)
             currentTime = new Date().getTime();
-        }            
+        }
 
         check(client.invoke('vdp.model.v1alpha.ModelService/DeployModelInstance', { name: `models/non-existed/instances/latest` }), {
             'DeployModelInstance non-existed model name status not found': (r) => r && r.status === grpc.StatusNotFound,

--- a/integration-test/grpc_infer_model.js
+++ b/integration-test/grpc_infer_model.js
@@ -21,9 +21,7 @@ const model_def_name = "model-definitions/local"
 export function InferModel() {
     // TriggerModelInstance check
     group("Model API: TriggerModelInstance", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -32,7 +30,7 @@ export function InferModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>
@@ -77,7 +75,7 @@ export function InferModel() {
             }
             sleep(1)
             currentTime = new Date().getTime();
-        }                 
+        }
         res = client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', { name: `models/${model_id}/instances/latest`, inputs: [{ image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }] }, {})
         check(res, {
             'TriggerModelInstance status': (r) => r && r.status === grpc.StatusOK,
@@ -114,9 +112,7 @@ export function InferModel() {
 
     // TestModelInstance check
     group("Model API: TestModelInstance", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -125,7 +121,7 @@ export function InferModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>
@@ -170,7 +166,7 @@ export function InferModel() {
             }
             sleep(1)
             currentTime = new Date().getTime();
-        }            
+        }
 
         check(client.invoke('vdp.model.v1alpha.ModelService/TestModelInstance', { name: `models/${model_id}/instances/latest`, inputs: [{ image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }] }, {}), {
             'TestModelInstance status': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_publish_model.js
+++ b/integration-test/grpc_publish_model.js
@@ -21,9 +21,7 @@ const model_def_name = "model-definitions/local"
 export function PublishUnPublishModel() {
     // PublishModel/UnpublishModel check
     group("Model API: PublishModel/UnpublishModel", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -32,7 +30,7 @@ export function PublishUnPublishModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>

--- a/integration-test/grpc_query_model.js
+++ b/integration-test/grpc_query_model.js
@@ -20,9 +20,7 @@ const model_def_name = "model-definitions/local"
 export function GetModel() {
     // GetModel check
     group("Model API: GetModel", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -31,7 +29,7 @@ export function GetModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>
@@ -88,9 +86,7 @@ export function GetModel() {
 export function ListModel() {
     // ListModel check
     group("Model API: ListModel", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -99,7 +95,7 @@ export function ListModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>
@@ -152,9 +148,7 @@ export function ListModel() {
 export function LookupModel() {
     // LookUpModel check
     group("Model API: LookUpModel", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -163,7 +157,7 @@ export function LookupModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        let res = http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        let res = http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         })
         check(res, {

--- a/integration-test/grpc_query_model_definition.js
+++ b/integration-test/grpc_query_model_definition.js
@@ -12,9 +12,7 @@ const model_def_name = "model-definitions/github"
 
 export function GetModelDefinition() {
     group("Model API: GetModelDefinition", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
         check(client.invoke('vdp.model.v1alpha.ModelService/GetModelDefinition', { name: model_def_name }, {}), {
             "GetModelDefinition response status": (r) => r.status === grpc.StatusOK,
             "GetModelDefinition response modelDefinition.name": (r) => r.message.modelDefinition.name === model_def_name,
@@ -34,9 +32,7 @@ export function GetModelDefinition() {
 
 export function ListModelDefinition() {
     group("Model API: ListModelDefinition", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
         check(client.invoke('vdp.model.v1alpha.ModelService/ListModelDefinition', {}, {}), {
             "ListModelDefinition response status": (r) => r.status === grpc.StatusOK,
             "ListModelDefinition response modelDefinitions[2].name": (r) => r.message.modelDefinitions[2].name === "model-definitions/local",

--- a/integration-test/grpc_query_model_instance.js
+++ b/integration-test/grpc_query_model_instance.js
@@ -20,9 +20,7 @@ const model_def_name = "model-definitions/local"
 export function GetModelInstance() {
     // GetModelInstance check
     group("Model API: GetModelInstance", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -31,7 +29,7 @@ export function GetModelInstance() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>
@@ -88,9 +86,7 @@ export function GetModelInstance() {
 
     // LookUpModelInstance check
     group("Model API: LookUpModelInstance", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -99,7 +95,7 @@ export function GetModelInstance() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        let res_model = http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        let res_model = http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         })
         check(res_model, {
@@ -163,9 +159,7 @@ export function GetModelInstance() {
 export function ListModelInstance() {
     // ListModelInstance check
     group("Model API: ListModelInstance", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -174,7 +168,7 @@ export function ListModelInstance() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        let res_model = http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        let res_model = http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         })
         check(res_model, {
@@ -234,9 +228,7 @@ export function ListModelInstance() {
 export function LookupModelInstance() {
     // LookUpModelInstance check
     group("Model API: LookUpModelInstance", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -245,7 +237,7 @@ export function LookupModelInstance() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        let res_model = http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        let res_model = http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         })
         check(res_model, {

--- a/integration-test/grpc_update_model.js
+++ b/integration-test/grpc_update_model.js
@@ -21,9 +21,7 @@ const model_def_name = "model-definitions/local"
 export function UpdateModel() {
     // UpdateModel check
     group("Model API: UpdateModel", () => {
-        client.connect(constant.gRPCHost, {
-            plaintext: true
-        });
+        client.connect(constant.gRPCHost);
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -32,7 +30,7 @@ export function UpdateModel() {
         fd_cls.append("description", model_description);
         fd_cls.append("model_definition", model_def_name);
         fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
-        check(http.request("POST", `http://${constant.gRPCHost}/v1alpha/models/multipart`, fd_cls.body(), {
+        check(http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
             headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
         }), {
             "POST /v1alpha/models/multipart task cls response status": (r) =>


### PR DESCRIPTION
Because

- `api-gateway` is used for localhost integration test (outside container) from now on

This commit

- adopt the latest api-gateway CI setting
- tinker codes
