### PR TITLE
test: use http for api-gateway

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -2,12 +2,12 @@ let proto, host, port
 
 if (__ENV.MODE == "api-gateway") {
     // api-gateway mode
-    proto = "https"
+    proto = "http"
     host = "api-gateway"
     port = 8080
 } else if (__ENV.MODE == "localhost") {
     // localhost mode for GitHub Actions
-    proto = "https"
+    proto = "http"
     host = "localhost"
     port = 8080
 } else {

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -25,13 +25,15 @@ client.load(['proto'], 'model.proto');
 client.load(['proto'], 'model_service.proto');
 client.load(['proto'], 'healthcheck.proto');
 
-export function setup() {}
+export function setup() { }
 
 export default () => {
     // Liveness check
     {
         group("Model API: Liveness", () => {
-            client.connect(constant.gRPCHost);
+            client.connect(constant.gRPCHost, {
+                plaintext: true
+            });
             const response = client.invoke('vdp.model.v1alpha.ModelService/Liveness', {});
             check(response, {
                 'Status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -42,7 +44,9 @@ export default () => {
 
     // Readiness check
     group("Model API: Readiness", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
         const response = client.invoke('vdp.model.v1alpha.ModelService/Readiness', {});
         check(response, {
             'Status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -82,7 +86,9 @@ export default () => {
 };
 
 export function teardown() {
-    client.connect(constant.gRPCHost);
+    client.connect(constant.gRPCHost, {
+        plaintext: true
+    });
     group("Model API: Delete all models created by this test", () => {
         for (const model of client.invoke('vdp.model.v1alpha.ModelService/ListModel', {}, {}).message.models) {
             check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {

--- a/integration-test/grpc_create_model.js
+++ b/integration-test/grpc_create_model.js
@@ -20,7 +20,9 @@ const model_def_name = "model-definitions/github"
 export function CreateModel() {
     // CreateModelBinaryFileUpload check
     group("Model API: CreateModelBinaryFileUpload", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
         check(client.invoke('vdp.model.v1alpha.ModelService/CreateModelBinaryFileUpload', {}), {
             'Missing stream body status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
@@ -31,7 +33,9 @@ export function CreateModel() {
 
     // CreateModel check
     group("Model API: CreateModel with GitHub", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
         let model_id = randomString(10)
         let createOperationRes = client.invoke('vdp.model.v1alpha.ModelService/CreateModel', {
             model: {
@@ -131,7 +135,7 @@ export function CreateModel() {
         }), {
             'missing name status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
-        
+
         check(client.invoke('vdp.model.v1alpha.ModelService/CreateModel', {
             model: {
                 id: randomString(10),

--- a/integration-test/grpc_deploy_model.js
+++ b/integration-test/grpc_deploy_model.js
@@ -28,7 +28,9 @@ const model_def_name = "model-definitions/local"
 export function DeployUndeployModel() {
     // Deploy ModelInstance check
     group("Model API: Deploy ModelInstance", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)

--- a/integration-test/grpc_infer_model.js
+++ b/integration-test/grpc_infer_model.js
@@ -29,7 +29,9 @@ const model_def_name = "model-definitions/local"
 export function InferModel() {
     // TriggerModelInstance check
     group("Model API: TriggerModelInstance", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -148,7 +150,9 @@ export function InferModel() {
 
     // TestModelInstance check
     group("Model API: TestModelInstance", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)

--- a/integration-test/grpc_publish_model.js
+++ b/integration-test/grpc_publish_model.js
@@ -31,7 +31,9 @@ const model_def_name = "model-definitions/local"
 export function PublishUnPublishModel() {
     // PublishModel/UnpublishModel check
     group("Model API: PublishModel/UnpublishModel", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)

--- a/integration-test/grpc_query_model.js
+++ b/integration-test/grpc_query_model.js
@@ -28,7 +28,9 @@ const model_def_name = "model-definitions/local"
 export function GetModel() {
     // GetModel check
     group("Model API: GetModel", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -97,7 +99,9 @@ export function GetModel() {
 export function ListModel() {
     // ListModel check
     group("Model API: ListModel", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -158,7 +162,9 @@ export function ListModel() {
 export function LookupModel() {
     // LookUpModel check
     group("Model API: LookUpModel", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)

--- a/integration-test/grpc_query_model_definition.js
+++ b/integration-test/grpc_query_model_definition.js
@@ -15,7 +15,9 @@ const model_def_name = "model-definitions/github"
 
 export function GetModelDefinition() {
     group("Model API: GetModelDefinition", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
         check(client.invoke('vdp.model.v1alpha.ModelService/GetModelDefinition', { name: model_def_name }, {}), {
             "GetModelDefinition response status": (r) => r.status === grpc.StatusOK,
             "GetModelDefinition response modelDefinition.name": (r) => r.message.modelDefinition.name === model_def_name,
@@ -35,7 +37,9 @@ export function GetModelDefinition() {
 
 export function ListModelDefinition() {
     group("Model API: ListModelDefinition", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
         check(client.invoke('vdp.model.v1alpha.ModelService/ListModelDefinition', {}, {}), {
             "ListModelDefinition response status": (r) => r.status === grpc.StatusOK,
             "ListModelDefinition response modelDefinitions[2].name": (r) => r.message.modelDefinitions[2].name === "model-definitions/local",

--- a/integration-test/grpc_query_model_instance.js
+++ b/integration-test/grpc_query_model_instance.js
@@ -28,7 +28,9 @@ const model_def_name = "model-definitions/local"
 export function GetModelInstance() {
     // GetModelInstance check
     group("Model API: GetModelInstance", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -99,7 +101,9 @@ export function GetModelInstance() {
 
     // LookUpModelInstance check
     group("Model API: LookUpModelInstance", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -182,7 +186,9 @@ export function GetModelInstance() {
 export function ListModelInstance() {
     // ListModelInstance check
     group("Model API: ListModelInstance", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)
@@ -258,7 +264,9 @@ export function ListModelInstance() {
 export function LookupModelInstance() {
     // LookUpModelInstance check
     group("Model API: LookUpModelInstance", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)

--- a/integration-test/grpc_update_model.js
+++ b/integration-test/grpc_update_model.js
@@ -29,7 +29,9 @@ const model_def_name = "model-definitions/local"
 export function UpdateModel() {
     // UpdateModel check
     group("Model API: UpdateModel", () => {
-        client.connect(constant.gRPCHost);
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
 
         let fd_cls = new FormData();
         let model_id = randomString(10)


### PR DESCRIPTION
Because

- the `api-gateway` supports h2c for gRPC over plaintext

This commit

- change the gRPC integration test protocol from `https` to `http`
