### PR TITLE
chore: update ready enpoint to check search attribute ready

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -122,6 +122,7 @@ func main() {
 	w.RegisterWorkflow(cw.UnDeployModelWorkflow)
 	w.RegisterActivity(cw.UnDeployModelActivity)
 	w.RegisterWorkflow(cw.CreateModelWorkflow)
+	w.RegisterWorkflow(cw.HealthWorkflow)
 
 	err = w.Run(worker.InterruptCh())
 	if err != nil {

--- a/internal/util/const.go
+++ b/internal/util/const.go
@@ -60,9 +60,10 @@ var UnmarshalOptions protojson.UnmarshalOptions = protojson.UnmarshalOptions{
 type OperationType string
 
 const (
-	OperationTypeCreate   OperationType = "create"
-	OperationTypeDeploy   OperationType = "deploy"
-	OperationTypeUnDeploy OperationType = "undeploy"
+	OperationTypeCreate      OperationType = "create"
+	OperationTypeDeploy      OperationType = "deploy"
+	OperationTypeUnDeploy    OperationType = "undeploy"
+	OperationTypeHealthCheck OperationType = "healthcheck"
 )
 
 const DefaultPageSize = 10

--- a/internal/worker/model.go
+++ b/internal/worker/model.go
@@ -27,6 +27,30 @@ type ModelParams struct {
 	Owner string
 }
 
+func (w *worker) HealthWorkflow(ctx workflow.Context) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("HealthWorkflow started")
+
+	// Upsert search attributes.
+	attributes := map[string]interface{}{
+		"Type":             util.OperationTypeHealthCheck,
+		"ModelUID":         "ModelUID test",
+		"ModelInstanceUID": "ModelInstanceUID test",
+		"Owner":            "",
+	}
+
+	// This won't persist search attributes on server because commands are not sent to server,
+	// but local cache will be updated.
+	err := workflow.UpsertSearchAttributes(ctx, attributes)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("HealthWorkflow completed")
+
+	return nil
+}
+
 func (w *worker) DeployModelWorkflow(ctx workflow.Context, param *ModelInstanceParams) error {
 	logger := workflow.GetLogger(ctx)
 	logger.Info("DeployModelWorkflow started")

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -22,6 +22,7 @@ type Worker interface {
 	UnDeployModelWorkflow(ctx workflow.Context, param *ModelInstanceParams) error
 	UnDeployModelActivity(ctx context.Context, param *ModelInstanceParams) error
 	CreateModelWorkflow(ctx workflow.Context, param *ModelParams) error
+	HealthWorkflow(ctx workflow.Context) error
 }
 
 // worker represents resources required to run Temporal workflow and activity

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -524,6 +524,10 @@ func (h *handler) Readiness(ctx context.Context, pb *modelPB.ReadinessRequest) (
 		return &modelPB.ReadinessResponse{HealthCheckResponse: &healthcheckPB.HealthCheckResponse{Status: healthcheckPB.HealthCheckResponse_SERVING_STATUS_NOT_SERVING}}, nil
 	}
 
+	if h.service.HealthWorkflow() != nil {
+		return &modelPB.ReadinessResponse{HealthCheckResponse: &healthcheckPB.HealthCheckResponse{Status: healthcheckPB.HealthCheckResponse_SERVING_STATUS_NOT_SERVING}}, nil
+	}
+
 	return &modelPB.ReadinessResponse{HealthCheckResponse: &healthcheckPB.HealthCheckResponse{Status: healthcheckPB.HealthCheckResponse_SERVING_STATUS_SERVING}}, nil
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -59,6 +59,7 @@ type Service interface {
 	GetOperation(workflowId string) (*longrunningpb.Operation, *worker.ModelInstanceParams, string, error)
 	ListOperation(pageSize int, pageToken string) ([]*longrunningpb.Operation, []*worker.ModelInstanceParams, string, int64, error)
 	CancelOperation(workflowId string) error
+	HealthWorkflow() error
 }
 
 type service struct {


### PR DESCRIPTION
Because

- update ready endpoint

This commit

- check Temporal 's search attribute ready in the ready endpoint
