### PR TITLE
chore: update protogen-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230118091257-f6a573de9891
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230119110528-4d8f9aecf2cb
 	github.com/instill-ai/usage-client v0.2.1-alpha
 	github.com/instill-ai/x v0.2.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -950,12 +950,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230114171039-adffe54b85f2 h1:60qyBKE2c/nvzYyZiRV0X0LFfQZFd3FrkjkVoVNkY/Y=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230114171039-adffe54b85f2/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230117135040-edc2acb82627 h1:dUiSaaqXh4Cdo+yq+YBXVTN4dEfQo86c03fq4CWE2QA=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230117135040-edc2acb82627/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230118091257-f6a573de9891 h1:VRWz7LBYCMJOOp9BvNx85PxvV+IhLwao6QfPgRH/uA4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230118091257-f6a573de9891/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230119110528-4d8f9aecf2cb h1:9m+CwjzGt1449aBC09CjYczADjSeV42vUUJZ1fRkUag=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230119110528-4d8f9aecf2cb/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.1-alpha h1:XXMCTDT2BWOgGwerOpxghzt6hW9J7/yUR1tkNRuGjjM=
 github.com/instill-ai/usage-client v0.2.1-alpha/go.mod h1:ThySPYe08Jy7OpfdtCZDckm19ET39K+KXGJ4lr+rOss=
 github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=


### PR DESCRIPTION
Because

- the `pipeline-backend` and `model-backend` need to adopt the latest `protogen-go` for the new `input_tasks`.

This commit

- update `go.mod` and `go.sum`
