### PR TITLE
chore: tinker codes

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,7 +7,7 @@ server:
   edition: local-ce:dev
   disableusage: true
   debug: true
-  itmode: false
+  itmode: true
   maximagesize: 12 # MB in unit
 database:
   username: postgres


### PR DESCRIPTION
Because

- `ITMODE` should be set to true for local development
- Temporal provides no API for checking the readiness of namespace created in the Temporal cluster. Waiting for 10s looks to be the only solution at the moment according to the official [doc](https://docs.temporal.io/application-development/features#register-namespace):
```
Note that Namespace registration using this API takes up to 10 seconds to complete. 
Ensure that you wait for this registration to complete before starting the Workflow 
Execution against the Namespace.
```

This commit

- set `ITMOD=true` in `config.yaml`
- add sleep for 10 seconds when launching the Temporal worker
