### PR TITLE
refactor: rename config variables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,10 +27,10 @@ type ServerConfig struct {
 	DisableUsage bool     `koanf:"disableusage"`
 	Debug        bool     `koanf:"debug"`
 	ItMode       bool     `koanf:"itmode"`
-	MaxImageSize int      `koanf:"maximagesize"`
+	MaxDataSize  int      `koanf:"maxdatasize"`
 }
 
-// config related to database
+// DatabaseConfig related to database
 type DatabaseConfig struct {
 	Username string `koanf:"username"`
 	Password string `koanf:"password"`
@@ -46,8 +46,9 @@ type DatabaseConfig struct {
 	}
 }
 
+// TritonServerConfig related to Triton server
 type TritonServerConfig struct {
-	GrpcUri    string `koanf:"grpcuri"`
+	GrpcURI    string `koanf:"grpcuri"`
 	ModelStore string `koanf:"modelstore"`
 }
 
@@ -68,12 +69,14 @@ type CacheConfig struct {
 	}
 }
 
-type UsageBackendConfig struct {
+// UsageServerConfig related to usage-server
+type UsageServerConfig struct {
 	TLSEnabled bool   `koanf:"tlsenabled"`
 	Host       string `koanf:"host"`
 	Port       int    `koanf:"port"`
 }
 
+// PipelineBackendConfig related to pipeline-backend
 type PipelineBackendConfig struct {
 	Host  string `koanf:"host"`
 	Port  int    `koanf:"port"`
@@ -83,6 +86,7 @@ type PipelineBackendConfig struct {
 	}
 }
 
+// MaxBatchSizeConfig defines the maximum size of the batch of a AI task
 type MaxBatchSizeConfig struct {
 	Unspecified          int `koanf:"unspecified"`
 	Classification       int `koanf:"classification"`
@@ -93,6 +97,7 @@ type MaxBatchSizeConfig struct {
 	SemanticSegmentation int `koanf:"semanticsegmentation"`
 }
 
+// TemporalConfig related to Temporal
 type TemporalConfig struct {
 	ClientOptions client.Options `koanf:"clientoptions"`
 }
@@ -104,7 +109,7 @@ type AppConfig struct {
 	TritonServer           TritonServerConfig    `koanf:"tritonserver"`
 	MgmtBackend            MgmtBackendConfig     `koanf:"mgmtbackend"`
 	Cache                  CacheConfig           `koanf:"cache"`
-	UsageBackend           UsageBackendConfig    `koanf:"usagebackend"`
+	UsageServer            UsageServerConfig     `koanf:"usageserver"`
 	PipelineBackend        PipelineBackendConfig `koanf:"pipelinebackend"`
 	MaxBatchSizeLimitation MaxBatchSizeConfig    `koanf:"maxbatchsizelimitation"`
 	Temporal               TemporalConfig        `koanf:"temporal"`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,8 +7,8 @@ server:
   edition: local-ce:dev
   disableusage: true
   debug: true
-  itmode: true
-  maximagesize: 12 # MB in unit
+  itmode: false
+  maxdatasize: 12 # MB in unit
 database:
   username: postgres
   password: password
@@ -34,7 +34,7 @@ cache:
   redis:
     redisoptions:
       addr: redis:6379
-usagebackend:
+usageserver:
   tlsenabled: true
   host: usage.instill.tech
   port: 443

--- a/internal/external/external.go
+++ b/internal/external/external.go
@@ -49,7 +49,7 @@ func InitUsageServiceClient() (usagePB.UsageServiceClient, *grpc.ClientConn) {
 	logger, _ := logger.GetZapLogger()
 
 	var clientDialOpts grpc.DialOption
-	if config.Config.UsageBackend.TLSEnabled {
+	if config.Config.UsageServer.TLSEnabled {
 		roots, err := x509.SystemCertPool()
 		if err != nil {
 			logger.Fatal(err.Error())
@@ -66,7 +66,7 @@ func InitUsageServiceClient() (usagePB.UsageServiceClient, *grpc.ClientConn) {
 	}
 
 	clientConn, err := grpc.Dial(
-		fmt.Sprintf("%v:%v", config.Config.UsageBackend.Host, config.Config.UsageBackend.Port),
+		fmt.Sprintf("%v:%v", config.Config.UsageServer.Host, config.Config.UsageServer.Port),
 		clientDialOpts,
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: backoff.Config{

--- a/internal/triton/triton.go
+++ b/internal/triton/triton.go
@@ -44,7 +44,7 @@ func NewTriton() Triton {
 }
 
 func (ts *triton) Init() {
-	grpcUri := config.Config.TritonServer.GrpcUri
+	grpcUri := config.Config.TritonServer.GrpcURI
 	// Connect to gRPC server
 	conn, err := grpc.Dial(grpcUri, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {

--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -45,10 +45,10 @@ func parseImageFromURL(url string) (*image.Image, *imageMetadata, error) {
 		return nil, nil, fmt.Errorf("unable to read content body from image at %v", url)
 	}
 
-	if numBytes > int64(config.Config.Server.MaxImageSize*util.MB) {
+	if numBytes > int64(config.Config.Server.MaxDataSize*util.MB) {
 		return nil, nil, fmt.Errorf(
 			"image size must be smaller than %vMB. Got %vMB",
-			config.Config.Server.MaxImageSize,
+			config.Config.Server.MaxDataSize,
 			float32(numBytes)/float32(util.MB),
 		)
 	}
@@ -79,10 +79,10 @@ func parseImageFromBase64(encoded string) (*image.Image, *imageMetadata, error) 
 		return nil, nil, fmt.Errorf("unable to decode base64 image")
 	}
 	numBytes := len(decoded)
-	if numBytes > config.Config.Server.MaxImageSize*util.MB {
+	if numBytes > config.Config.Server.MaxDataSize*util.MB {
 		return nil, nil, fmt.Errorf(
 			"image size must be smaller than %vMB. Got %vMB",
-			config.Config.Server.MaxImageSize,
+			config.Config.Server.MaxDataSize,
 			float32(numBytes)/float32(util.MB),
 		)
 	}
@@ -187,10 +187,10 @@ func parseImageFormDataInputsToBytes(req *http.Request) (imgsBytes [][]byte, img
 			return nil, nil, fmt.Errorf("unable to read content body from image")
 		}
 
-		if numBytes > int64(config.Config.Server.MaxImageSize*util.MB) {
+		if numBytes > int64(config.Config.Server.MaxDataSize*util.MB) {
 			return nil, nil, fmt.Errorf(
 				"image size must be smaller than %vMB. Got %vMB from image %v",
-				config.Config.Server.MaxImageSize,
+				config.Config.Server.MaxDataSize,
 				float32(numBytes)/float32(util.MB),
 				content.Filename,
 			)

--- a/pkg/handler/payload_test.go
+++ b/pkg/handler/payload_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestParseImageFromURL(t *testing.T) {
-	config.Config.Server.MaxImageSize = 12
+	config.Config.Server.MaxDataSize = 12
 
 	{
 		_, _, err := parseImageFromURL("https://artifacts.instill.tech/non-existing.jpg")
@@ -26,7 +26,7 @@ func TestParseImageFromURL(t *testing.T) {
 }
 
 func TestParseImageFromBase64(t *testing.T) {
-	config.Config.Server.MaxImageSize = 12
+	config.Config.Server.MaxDataSize = 12
 
 	{
 		_, _, err := parseImageFromBase64("test")


### PR DESCRIPTION
Because

- to make configuration variables consistent across different repos

This commit

- rename configuration variables accordingly
