### PR TITLE
chore: rename mgmt fields and variables

### DIFF
--- a/cmd/main/interceptor.go
+++ b/cmd/main/interceptor.go
@@ -33,11 +33,11 @@ func unaryAppendMetadataInterceptor(ctx context.Context, req interface{}, info *
 	}
 
 	// TODO: Replace with decoded JWT header
-	userServiceClient, userServiceClientConn := external.InitMgmtAdminServiceClient()
-	defer userServiceClientConn.Close()
+	mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
+	defer mgmtAdminServiceClientConn.Close()
 	userPageToken := ""
 	userPageSizeMax := int64(repository.MaxPageSize)
-	userResp, err := userServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
+	userResp, err := mgmtAdminServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
 		PageSize:  &userPageSizeMax,
 		PageToken: &userPageToken,
 	})
@@ -62,11 +62,11 @@ func streamAppendMetadataInterceptor(srv interface{}, stream grpc.ServerStream, 
 	}
 
 	// TODO: Replace with decoded JWT header
-	userServiceClient, userServiceClientConn := external.InitMgmtAdminServiceClient()
-	defer userServiceClientConn.Close()
+	mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
+	defer mgmtAdminServiceClientConn.Close()
 	userPageToken := ""
 	userPageSizeMax := int64(repository.MaxPageSize)
-	userResp, er := userServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
+	userResp, er := mgmtAdminServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
 		PageSize:  &userPageSizeMax,
 		PageToken: &userPageToken,
 	})

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -123,8 +123,8 @@ func main() {
 	triton := triton.NewTriton()
 	defer triton.Close()
 
-	userServiceClient, userServiceClientConn := external.InitMgmtAdminServiceClient()
-	defer userServiceClientConn.Close()
+	mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
+	defer mgmtAdminServiceClientConn.Close()
 
 	pipelineServiceClient, pipelineServiceClientConn := external.InitPipelineServiceClient()
 	defer pipelineServiceClientConn.Close()
@@ -185,7 +185,7 @@ func main() {
 	if !config.Config.Server.DisableUsage {
 		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
 		defer usageServiceClientConn.Close()
-		usg = usage.NewUsage(ctx, repository, userServiceClient, redisClient, usageServiceClient)
+		usg = usage.NewUsage(ctx, repository, mgmtAdminServiceClient, redisClient, usageServiceClient)
 		if usg != nil {
 			usg.StartReporter(ctx)
 		}

--- a/cmd/main/middleware.go
+++ b/cmd/main/middleware.go
@@ -14,11 +14,11 @@ import (
 func appendCustomHeaderMiddleware(next runtime.HandlerFunc) runtime.HandlerFunc {
 	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		// TODO: Replace with decoded JWT header
-		userServiceClient, userServiceClientConn := external.InitMgmtAdminServiceClient()
-		defer userServiceClientConn.Close()
+		mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
+		defer mgmtAdminServiceClientConn.Close()
 		userPageToken := ""
 		userPageSizeMax := int64(repository.MaxPageSize)
-		userResp, err := userServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
+		userResp, err := mgmtAdminServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
 			PageSize:  &userPageSizeMax,
 			PageToken: &userPageToken,
 		})

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -29,7 +29,7 @@ type Usage interface {
 
 type usage struct {
 	repository        repository.Repository
-	userServiceClient mgmtPB.MgmtAdminServiceClient
+	mgmtAdminServiceClient mgmtPB.MgmtAdminServiceClient
 	redisClient       *redis.Client
 	reporter          usageReporter.Reporter
 	version           string
@@ -53,7 +53,7 @@ func NewUsage(ctx context.Context, r repository.Repository, u mgmtPB.MgmtAdminSe
 
 	return &usage{
 		repository:        r,
-		userServiceClient: u,
+		mgmtAdminServiceClient: u,
 		redisClient:       rc,
 		reporter:          reporter,
 		version:           version,
@@ -73,7 +73,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 	userPageToken := ""
 	userPageSizeMax := int64(repository.MaxPageSize)
 	for {
-		userResp, err := u.userServiceClient.ListUser(ctx, &mgmtPB.ListUserRequest{
+		userResp, err := u.mgmtAdminServiceClient.ListUser(ctx, &mgmtPB.ListUserRequest{
 			PageSize:  &userPageSizeMax,
 			PageToken: &userPageToken,
 		})


### PR DESCRIPTION
Because

- fields naming related to mgmt-backend are wrong

This commit

- fix naming
