### PR TITLE
fix: fix usage client nil issue when mgmt-backend not ready

### DIFF
--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -79,6 +79,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 		})
 		if err != nil {
 			logger.Error(fmt.Sprintf("[mgmt-backend: ListUser] %s", err))
+			break
 		}
 
 		// Roll all model resources on a user


### PR DESCRIPTION
Because

- in case mgmt-backend is not ready, model-backend should not panic and crash

This commit

- fix the issue by breaking the usage report loop 
