### PR TITLE
chore: check model file with prefix suffix

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -78,7 +78,7 @@ func findDVCPaths(dir string) []string {
 func findModelFiles(dir string) []string {
 	var modelPaths []string = []string{}
 	_ = filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
-		if strings.HasSuffix(f.Name(), ".onnx") || strings.HasSuffix(f.Name(), ".pt") {
+		if strings.HasSuffix(f.Name(), ".onnx") || strings.HasSuffix(f.Name(), ".pt") || strings.HasSuffix(f.Name(), ".bias") || strings.HasSuffix(f.Name(), ".weight") || strings.HasPrefix(f.Name(), "onnx__") {
 			modelPaths = append(modelPaths, path)
 		}
 		return nil


### PR DESCRIPTION
Because

- diffusion model has `.bias` and `.weight` extension for model weight file

This commit

- add `.bias` and `.weight` extension when finding the model weight
