### PR TITLE
fix: fix keypoint model payload parser

### DIFF
--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -102,6 +102,11 @@ func parseImageRequestInputsToBytes(req *modelPB.TriggerModelInstanceRequest) (i
 				ImgUrl:    taskInput.GetOcr().GetImageUrl(),
 				ImgBase64: taskInput.GetOcr().GetImageBase64(),
 			}
+		case *modelPB.TaskInput_Keypoint:
+			visionInp = triton.VisionInput{
+				ImgUrl:    taskInput.GetKeypoint().GetImageUrl(),
+				ImgBase64: taskInput.GetKeypoint().GetImageBase64(),
+			}
 		case *modelPB.TaskInput_InstanceSegmentation:
 			visionInp = triton.VisionInput{
 				ImgUrl:    taskInput.GetInstanceSegmentation().GetImageUrl(),


### PR DESCRIPTION
Because

- missing keypoint model payload parser

This commit

- add keypoint model payload parser
