### PR TITLE
chore: update deploy activity timeout to 300 minutes

### DIFF
--- a/internal/worker/model.go
+++ b/internal/worker/model.go
@@ -78,7 +78,7 @@ func (w *worker) DeployModelWorkflow(ctx workflow.Context, param *ModelInstanceP
 
 	ao := workflow.ActivityOptions{
 		TaskQueue:           TaskQueue,
-		StartToCloseTimeout: 60 * time.Minute,
+		StartToCloseTimeout: 300 * time.Minute,
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 


### PR DESCRIPTION
Because

- deploying a huge model take a long time to download the model weight

This commit

- increase deployment model activity timeout to 300 minutes
