### PR TITLE
chore: change inference timeout to 5 minutes

### DIFF
--- a/internal/triton/triton.go
+++ b/internal/triton/triton.go
@@ -159,7 +159,7 @@ func (ts *triton) ModelConfigRequest(modelName string, modelInstance string) *in
 
 func (ts *triton) ModelInferRequest(task modelPB.ModelInstance_Task, inferInput InferInput, modelName string, modelInstance string, modelMetadata *inferenceserver.ModelMetadataResponse, modelConfig *inferenceserver.ModelConfigResponse) (*inferenceserver.ModelInferResponse, error) {
 	// Create context for our request with 5 minutes timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*60*time.Second)
 	defer cancel()
 
 	// Create request input tensors


### PR DESCRIPTION
Because

- make inference timeout consistency with the api-gateway

This commit

- change inference timeout to 5 minutes
