### PR TITLE
chore: update utility for file matching

### DIFF
--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -205,8 +205,9 @@ func UpdateModelPath(modelDir string, dstDir string, owner string, modelID strin
 	var readmeFilePath string
 	files := []FileMeta{}
 	var configFiles []string
+	var fileRe = regexp.MustCompile(`.git|.dvc|.dvcignore`)
 	err := filepath.Walk(modelDir, func(path string, f os.FileInfo, err error) error {
-		if !strings.Contains(path, ".git") {
+		if !fileRe.MatchString(path) {
 			files = append(files, FileMeta{
 				path:  path,
 				fInfo: f,

--- a/internal/worker/model.go
+++ b/internal/worker/model.go
@@ -124,7 +124,8 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelInstancePa
 			rdid, _ := uuid.NewV4()
 			modelSrcDir := fmt.Sprintf("/tmp/%s", rdid.String())
 
-			if err := util.GitHubCloneWLargeFile(modelSrcDir, instanceConfig); err != nil {
+			cloneLargeFile := true
+			if err := util.GitHubClone(cloneLargeFile, modelSrcDir, instanceConfig); err != nil {
 				_ = os.RemoveAll(modelSrcDir)
 				return err
 			}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -652,7 +652,8 @@ func createGitHubModel(h *handler, ctx context.Context, req *modelPB.CreateModel
 				return &modelPB.CreateModelResponse{}, err
 			}
 		} else {
-			err = util.GitHubCloneWOLargeFile(modelSrcDir, instanceConfig)
+			cloneLargeFile := false
+			err = util.GitHubClone(cloneLargeFile, modelSrcDir, instanceConfig)
 			if err != nil {
 				st, err := sterr.CreateErrorResourceInfo(
 					codes.FailedPrecondition,


### PR DESCRIPTION
Because

- avoid piling up dvc files in model store

This commit

- add logic clause to not copying dvc related files into model store

Closes #279