### PR TITLE
chore: create and  add permission for nobody user in model-repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN chown -R nobody:nogroup /tmp
 # Need permission of /nonexistent folder for HuggingFace internal process.
 RUN mkdir /nonexistent > /dev/null && chown -R nobody:nogroup /nonexistent
 
-RUN mkdir /model-repository/users > /dev/null && chown -R nobody:nogroup /model-repository/users
+RUN mkdir -p /model-repository/users > /dev/null && chown -R nobody:nogroup /model-repository/users
 
 USER nobody:nogroup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN chown -R nobody:nogroup /tmp
 # Need permission of /nonexistent folder for HuggingFace internal process.
 RUN mkdir /nonexistent > /dev/null && chown -R nobody:nogroup /nonexistent
 
-RUN mkdir /model-repository > /dev/null && chown -R nobody:nogroup /model-repository
+RUN mkdir /model-repository/users > /dev/null && chown -R nobody:nogroup /model-repository/users
 
 USER nobody:nogroup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN chown -R nobody:nogroup /tmp
 # Need permission of /nonexistent folder for HuggingFace internal process.
 RUN mkdir /nonexistent > /dev/null && chown -R nobody:nogroup /nonexistent
 
+RUN mkdir /model-repository > /dev/null && chown -R nobody:nogroup /model-repository
+
 USER nobody:nogroup
 
 ARG SERVICE_NAME
@@ -68,4 +70,3 @@ COPY --from=build --chown=nobody:nogroup /usr/local/bin/avc /usr/local/bin/avc
 
 COPY --from=build --chown=nobody:nogroup /etc/vdp /etc/vdp
 COPY --from=build --chown=nobody:nogroup /vdp /vdp
-COPY --from=build --chown=nobody:nogroup /model-repository /model-repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN chown -R nobody:nogroup /tmp
 # Need permission of /nonexistent folder for HuggingFace internal process.
 RUN mkdir /nonexistent > /dev/null && chown -R nobody:nogroup /nonexistent
 
-RUN mkdir -p /model-repository/users > /dev/null && chown -R nobody:nogroup /model-repository/users
+RUN mkdir -p /model-repository > /dev/null && chown -R nobody:nogroup /model-repository
 
 USER nobody:nogroup
 


### PR DESCRIPTION
Because

- need permission on `/model-repository` when creating a model

This commit

- create folder `/model-repository` and add permission for `nobody` user
