### PR TITLE
fix: use user uid to create the model folder name

### DIFF
--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -34,6 +34,7 @@ func GetOwner(ctx context.Context) (string, error) {
 
 func GetOwnerFromHeader(r *http.Request) (string, error) {
 	owner := r.Header.Get("owner")
+	owner = strings.TrimPrefix(owner, "users/") // use user uid for internal process
 	return owner, nil
 }
 


### PR DESCRIPTION
Because

- user id=`users/{user uid}` then it creates a subfolder `users`  in model-repository when creating a model

This commit

- use only `user uid` in the model name
- close #288 