### PR TITLE
fix: create a subfolder in model-repository if needed

### DIFF
--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -138,8 +138,7 @@ func Unzip(filePath string, dstDir string, owner string, uploadedModel *datamode
 		}
 		// ensure the parent folder existed
 		if _, err := os.Stat(filepath.Base(filePath)); os.IsNotExist(err) {
-			err = os.MkdirAll(filePath, os.ModePerm)
-			if err != nil {
+			if err := os.MkdirAll(filePath, os.ModePerm); err != nil {
 				return "", "", err
 			}
 		}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -136,6 +136,14 @@ func Unzip(filePath string, dstDir string, owner string, uploadedModel *datamode
 		if err := ValidateFilePath(filePath); err != nil {
 			return "", "", err
 		}
+		// ensure the parent folder existed
+		if _, err := os.Stat(filepath.Base(filePath)); os.IsNotExist(err) {
+			err = os.MkdirAll(filePath, os.ModePerm)
+			if err != nil {
+				return "", "", err
+			}
+		}
+
 		dstFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 		if err != nil {
 			return "", "", err


### PR DESCRIPTION
Because

- need to create a subfolder `users` when creating a model in `model-repository`

This commit

- add code to check parent folder and create it if not existed
- close #288 
