### PR TITLE
chore: adopt public/private APIs for model service

### DIFF
--- a/cmd/main/interceptor.go
+++ b/cmd/main/interceptor.go
@@ -33,11 +33,11 @@ func unaryAppendMetadataInterceptor(ctx context.Context, req interface{}, info *
 	}
 
 	// TODO: Replace with decoded JWT header
-	mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
-	defer mgmtAdminServiceClientConn.Close()
+	mgmtPrivateServiceClient, mgmtPrivateServiceClientConn := external.InitMgmtPrivateServiceClient()
+	defer mgmtPrivateServiceClientConn.Close()
 	userPageToken := ""
 	userPageSizeMax := int64(repository.MaxPageSize)
-	userResp, err := mgmtAdminServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
+	userResp, err := mgmtPrivateServiceClient.ListUsersAdmin(context.Background(), &mgmtPB.ListUsersAdminRequest{
 		PageSize:  &userPageSizeMax,
 		PageToken: &userPageToken,
 	})
@@ -62,11 +62,11 @@ func streamAppendMetadataInterceptor(srv interface{}, stream grpc.ServerStream, 
 	}
 
 	// TODO: Replace with decoded JWT header
-	mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
-	defer mgmtAdminServiceClientConn.Close()
+	mgmtPrivateServiceClient, mgmtPrivateServiceClientConn := external.InitMgmtPrivateServiceClient()
+	defer mgmtPrivateServiceClientConn.Close()
 	userPageToken := ""
 	userPageSizeMax := int64(repository.MaxPageSize)
-	userResp, er := mgmtAdminServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
+	userResp, er := mgmtPrivateServiceClient.ListUsersAdmin(context.Background(), &mgmtPB.ListUsersAdminRequest{
 		PageSize:  &userPageSizeMax,
 		PageToken: &userPageToken,
 	})

--- a/cmd/main/middleware.go
+++ b/cmd/main/middleware.go
@@ -14,11 +14,11 @@ import (
 func appendCustomHeaderMiddleware(next runtime.HandlerFunc) runtime.HandlerFunc {
 	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		// TODO: Replace with decoded JWT header
-		mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
-		defer mgmtAdminServiceClientConn.Close()
+		mgmtPrivateServiceClient, mgmtPrivateServiceClientConn := external.InitMgmtPrivateServiceClient()
+		defer mgmtPrivateServiceClientConn.Close()
 		userPageToken := ""
 		userPageSizeMax := int64(repository.MaxPageSize)
-		userResp, err := mgmtAdminServiceClient.ListUser(context.Background(), &mgmtPB.ListUserRequest{
+		userResp, err := mgmtPrivateServiceClient.ListUsersAdmin(context.Background(), &mgmtPB.ListUsersAdminRequest{
 			PageSize:  &userPageSizeMax,
 			PageToken: &userPageToken,
 		})

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230308122400-51986736325a
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385
 	github.com/instill-ai/usage-client v0.2.2-alpha
 	github.com/instill-ai/x v0.2.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230314172914-1976737846cb
 	github.com/instill-ai/usage-client v0.2.2-alpha
 	github.com/instill-ai/x v0.2.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -952,6 +952,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385 h1:s1HBz/jqcXWI+1iECP2t6epkFLncLjsgJr69CGVRMF8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230314172914-1976737846cb h1:CxIAqYo7klOycw/qzTAmQJ0JHn74UuJjUzssPAF4KNw=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230314172914-1976737846cb/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.2-alpha h1:EQyHpgzZ26TEIL9UoaqchTf+LnKaidUGhKlUEFR68I8=
 github.com/instill-ai/usage-client v0.2.2-alpha/go.mod h1:RpVnioKQBoJZsE1qTiZlPQUQXUALTGzhBl8ju9rm5+U=
 github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230308122400-51986736325a h1:pXAll60F53JR0Tyny5Glq8DQmWuU9BOqmoSMGl2oFf4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230308122400-51986736325a/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385 h1:s1HBz/jqcXWI+1iECP2t6epkFLncLjsgJr69CGVRMF8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.2-alpha h1:EQyHpgzZ26TEIL9UoaqchTf+LnKaidUGhKlUEFR68I8=
 github.com/instill-ai/usage-client v0.2.2-alpha/go.mod h1:RpVnioKQBoJZsE1qTiZlPQUQXUALTGzhBl8ju9rm5+U=
 github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -26,7 +26,7 @@ export const options = {
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 client.load(['proto'], 'healthcheck.proto');
 
 export function setup() { }
@@ -38,7 +38,7 @@ export default () => {
             client.connect(constant.gRPCHost, {
                 plaintext: true
             });
-            const response = client.invoke('vdp.model.v1alpha.ModelService/Liveness', {});
+            const response = client.invoke('vdp.model.v1alpha.ModelPublicService/Liveness', {});
             check(response, {
                 'Status is OK': (r) => r && r.status === grpc.StatusOK,
                 'Response status is SERVING_STATUS_SERVING': (r) => r && r.message.healthCheckResponse.status === "SERVING_STATUS_SERVING",
@@ -81,8 +81,8 @@ export function teardown() {
         plaintext: true
     });
     group("Model API: Delete all models created by this test", () => {
-        for (const model of client.invoke('vdp.model.v1alpha.ModelService/ListModel', {}, {}).message.models) {
-            check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        for (const model of client.invoke('vdp.model.v1alpha.ModelPublicService/ListModel', {}, {}).message.models) {
+            check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
                 name: model.name
             }), {
                 'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -46,48 +46,48 @@ export default () => {
         });
     }
 
-    // Create model API
-    createModel.CreateModel()
+    // // Create model API
+    // createModel.CreateModel()
 
-    // Update model API
-    updateModel.UpdateModel()
+    // // Update model API
+    // updateModel.UpdateModel()
 
-    // Deploy Model API
-    deployModel.DeployUndeployModel()
+    // // Deploy Model API
+    // deployModel.DeployUndeployModel()
 
-    // Query Model API
+    // // Query Model API
     queryModel.GetModel()
-    queryModel.ListModel()
-    queryModel.LookupModel()
+    // queryModel.ListModels()
+    // queryModel.LookupModel()
 
-    // Publish Model API
-    publishModel.PublishUnPublishModel()
+    // // Publish Model API
+    // publishModel.PublishUnPublishModel()
 
-    // Infer Model API
-    inferModel.InferModel()
+    // // Infer Model API
+    // inferModel.InferModel()
 
-    // Query Model Instance API
-    queryModelInstance.GetModelInstance()
-    queryModelInstance.ListModelInstance()
-    queryModelInstance.LookupModelInstance()
+    // // Query Model Instance API
+    // queryModelInstance.GetModelInstance()
+    // queryModelInstance.ListModelInstances()
+    // queryModelInstance.LookupModelInstance()
 
-    // Query Model Definition API
-    queryModelDefinition.GetModelDefinition()
-    queryModelDefinition.ListModelDefinition()
+    // // Query Model Definition API
+    // queryModelDefinition.GetModelDefinition()
+    // queryModelDefinition.ListModelDefinitions()
 };
 
 export function teardown() {
-    client.connect(constant.gRPCHost, {
-        plaintext: true
-    });
-    group("Model API: Delete all models created by this test", () => {
-        for (const model of client.invoke('vdp.model.v1alpha.ModelPublicService/ListModel', {}, {}).message.models) {
-            check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
-                name: model.name
-            }), {
-                'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,
-            });
-        }
-    });
-    client.close();
+    // client.connect(constant.gRPCHost, {
+    //     plaintext: true
+    // });
+    // group("Model API: Delete all models created by this test", () => {
+    //     for (const model of client.invoke('vdp.model.v1alpha.ModelPublicService/ListModels', {}, {}).message.models) {
+    //         check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
+    //             name: model.name
+    //         }), {
+    //             'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,
+    //         });
+    //     }
+    // });
+    // client.close();
 }

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -12,6 +12,7 @@ import * as inferModel from "./grpc_infer_model.js"
 import * as publishModel from "./grpc_publish_model.js"
 import * as queryModelInstance from "./grpc_query_model_instance.js"
 import * as queryModelDefinition from "./grpc_query_model_definition.js"
+import * as modelOperation from "./grpc_model_operation.js"
 
 import * as constant from "./const.js"
 
@@ -46,48 +47,52 @@ export default () => {
         });
     }
 
-    // // Create model API
-    // createModel.CreateModel()
+    // Create model API
+    createModel.CreateModel()
 
-    // // Update model API
-    // updateModel.UpdateModel()
+    // Update model API
+    updateModel.UpdateModel()
 
-    // // Deploy Model API
-    // deployModel.DeployUndeployModel()
+    // Deploy Model API
+    deployModel.DeployUndeployModel()
 
-    // // Query Model API
+    // Query Model API
     queryModel.GetModel()
-    // queryModel.ListModels()
-    // queryModel.LookupModel()
+    queryModel.ListModels()
+    queryModel.LookupModel()
 
-    // // Publish Model API
-    // publishModel.PublishUnPublishModel()
+    // Publish Model API
+    publishModel.PublishUnPublishModel()
 
-    // // Infer Model API
-    // inferModel.InferModel()
+    // Infer Model API
+    inferModel.InferModel()
 
-    // // Query Model Instance API
-    // queryModelInstance.GetModelInstance()
-    // queryModelInstance.ListModelInstances()
-    // queryModelInstance.LookupModelInstance()
+    // Query Model Instance API
+    queryModelInstance.GetModelInstance()
+    queryModelInstance.ListModelInstances()
+    queryModelInstance.LookupModelInstance()
 
-    // // Query Model Definition API
-    // queryModelDefinition.GetModelDefinition()
-    // queryModelDefinition.ListModelDefinitions()
+    // Query Model Definition API
+    queryModelDefinition.GetModelDefinition()
+    queryModelDefinition.ListModelDefinitions()
+
+    // Operation API
+    modelOperation.ListModelOperations()
+    modelOperation.CancelModelOperation()
 };
 
 export function teardown() {
-    // client.connect(constant.gRPCHost, {
-    //     plaintext: true
-    // });
-    // group("Model API: Delete all models created by this test", () => {
-    //     for (const model of client.invoke('vdp.model.v1alpha.ModelPublicService/ListModels', {}, {}).message.models) {
-    //         check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
-    //             name: model.name
-    //         }), {
-    //             'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,
-    //         });
-    //     }
-    // });
-    // client.close();
+    client.connect(constant.gRPCHost, {
+        plaintext: true
+    });
+    group("Model API: Delete all models created by this test", () => {
+        for (const model of client.invoke('vdp.model.v1alpha.ModelPublicService/ListModels', {}, {}).message.models) {
+            check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
+                name: model.name
+            }), {
+                'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,
+            });
+        }
+    });
+    client.close();
 }

--- a/integration-test/grpc_create_model.js
+++ b/integration-test/grpc_create_model.js
@@ -124,12 +124,13 @@ export function CreateModel() {
             'missing name status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelPublicService/CreateModel', {
+        let createModel = client.invoke('vdp.model.v1alpha.ModelPublicService/CreateModel', {
             model: {
                 id: randomString(10),
                 model_definition: model_def_name,
             }
-        }), {
+        })
+        check(createModel, {
             'missing github url status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
 

--- a/integration-test/grpc_create_model.js
+++ b/integration-test/grpc_create_model.js
@@ -11,7 +11,7 @@ import {
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 import * as constant from "./const.js"
 
@@ -23,7 +23,7 @@ export function CreateModel() {
         client.connect(constant.gRPCHost, {
             plaintext: true
         });
-        check(client.invoke('vdp.model.v1alpha.ModelService/CreateModelBinaryFileUpload', {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/CreateModelBinaryFileUpload', {}), {
             'Missing stream body status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
 
@@ -37,7 +37,7 @@ export function CreateModel() {
             plaintext: true
         });
         let model_id = randomString(10)
-        let createOperationRes = client.invoke('vdp.model.v1alpha.ModelService/CreateModel', {
+        let createOperationRes = client.invoke('vdp.model.v1alpha.ModelPublicService/CreateModel', {
             model: {
                 id: model_id,
                 model_definition: model_def_name,
@@ -55,7 +55,7 @@ export function CreateModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createOperationRes.message.operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -68,7 +68,7 @@ export function CreateModel() {
         let req = {
             name: `models/${model_id}/instances/v1.0-cpu`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeployModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeployModelInstance', req, {}), {
             'DeployModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'DeployModelInstance operation name': (r) => r && r.message.operation.name !== undefined,
             'DeployModelInstance operation metadata': (r) => r && r.message.operation.metadata === null,
@@ -79,7 +79,7 @@ export function CreateModel() {
         currentTime = new Date().getTime();
         timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            var res = client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+            var res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
                 name: `models/${model_id}/instances/v1.0-cpu`
             }, {})
             if (res.message.instance.state === "STATE_ONLINE") {
@@ -89,7 +89,7 @@ export function CreateModel() {
             currentTime = new Date().getTime();
         }
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TriggerModelInstance', {
             name: `models/${model_id}/instances/v1.0-cpu`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }
@@ -101,7 +101,7 @@ export function CreateModel() {
             'TriggerModelInstance output classification_outputs score': (r) => r && r.message.taskOutputs[0].classification.score === 1,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/CreateModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/CreateModel', {
             model: {
                 id: randomString(10),
                 model_definition: randomString(10),
@@ -113,7 +113,7 @@ export function CreateModel() {
             'status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/CreateModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/CreateModel', {
             model: {
                 model_definition: model_def_name,
                 configuration: {
@@ -124,7 +124,7 @@ export function CreateModel() {
             'missing name status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/CreateModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/CreateModel', {
             model: {
                 id: randomString(10),
                 model_definition: model_def_name,
@@ -133,7 +133,7 @@ export function CreateModel() {
             'missing github url status': (r) => r && r.status == grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_deploy_model.js
+++ b/integration-test/grpc_deploy_model.js
@@ -21,7 +21,7 @@ import * as constant from "./const.js"
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 const model_def_name = "model-definitions/local"
 
@@ -53,7 +53,7 @@ export function DeployUndeployModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -66,7 +66,7 @@ export function DeployUndeployModel() {
         let req = {
             name: `models/${model_id}/instances/latest`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeployModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeployModelInstance', req, {}), {
             'DeployModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'DeployModelInstance operation name': (r) => r && r.message.operation.name !== undefined,
             'DeployModelInstance operation metadata': (r) => r && r.message.operation.metadata === null,
@@ -77,7 +77,7 @@ export function DeployUndeployModel() {
         currentTime = new Date().getTime();
         timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            var res = client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+            var res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
                 name: `models/${model_id}/instances/latest`
             }, {})
             if (res.message.instance.state === "STATE_ONLINE") {
@@ -87,19 +87,19 @@ export function DeployUndeployModel() {
             currentTime = new Date().getTime();
         }
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeployModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeployModelInstance', {
             name: `models/non-existed/instances/latest`
         }), {
             'DeployModelInstance non-existed model name status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeployModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeployModelInstance', {
             name: `models/${model_id}/instances/non-existed`
         }, {}), {
             'DeployModelInstance non-existed instance name status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_infer_model.js
+++ b/integration-test/grpc_infer_model.js
@@ -21,7 +21,7 @@ import * as constant from "./const.js"
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 const model_def_name = "model-definitions/local"
 
@@ -54,7 +54,7 @@ export function InferModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -67,7 +67,7 @@ export function InferModel() {
         let req = {
             name: `models/${model_id}/instances/latest`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeployModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeployModelInstance', req, {}), {
             'DeployModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'DeployModelInstance operation name': (r) => r && r.message.operation.name !== undefined,
             'DeployModelInstance operation metadata': (r) => r && r.message.operation.metadata === null,
@@ -78,7 +78,7 @@ export function InferModel() {
         currentTime = new Date().getTime();
         timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            var res = client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+            var res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
                 name: `models/${model_id}/instances/latest`
             }, {})
             if (res.message.instance.state === "STATE_ONLINE") {
@@ -87,7 +87,7 @@ export function InferModel() {
             sleep(1)
             currentTime = new Date().getTime();
         }
-        res = client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', {
+        res = client.invoke('vdp.model.v1alpha.ModelPublicService/TriggerModelInstance', {
             name: `models/${model_id}/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }
@@ -100,7 +100,7 @@ export function InferModel() {
             'TriggerModelInstance output classification_outputs score': (r) => r && r.message.taskOutputs[0].classification.score === 1,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TriggerModelInstance', {
             name: `models/${model_id}/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/tiff-sample.tiff" }
@@ -113,7 +113,7 @@ export function InferModel() {
         });
 
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TriggerModelInstance', {
             name: `models/non-existed/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }
@@ -122,7 +122,7 @@ export function InferModel() {
             'TriggerModelInstance non-existed model name status': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TriggerModelInstance', {
             name: `models/${model_id}/instances/non-existed`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }
@@ -131,7 +131,7 @@ export function InferModel() {
             'TriggerModelInstance non-existed model version  status': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TriggerModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TriggerModelInstance', {
             name: `models/${model_id}/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/non-existed.jpg" }
@@ -140,7 +140,7 @@ export function InferModel() {
             'TriggerModelInstance non-existed model url status': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -175,7 +175,7 @@ export function InferModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -188,7 +188,7 @@ export function InferModel() {
         let req = {
             name: `models/${model_id}/instances/latest`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeployModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeployModelInstance', req, {}), {
             'DeployModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'DeployModelInstance operation name': (r) => r && r.message.operation.name !== undefined,
             'DeployModelInstance operation metadata': (r) => r && r.message.operation.metadata === null,
@@ -199,7 +199,7 @@ export function InferModel() {
         currentTime = new Date().getTime();
         timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            var res = client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+            var res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
                 name: `models/${model_id}/instances/latest`
             }, {})
             if (res.message.instance.state === "STATE_ONLINE") {
@@ -209,7 +209,7 @@ export function InferModel() {
             currentTime = new Date().getTime();
         }
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TestModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TestModelInstance', {
             name: `models/${model_id}/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }
@@ -221,7 +221,7 @@ export function InferModel() {
             'TestModelInstance output classification_outputs score': (r) => r && r.message.taskOutputs[0].classification.score === 1,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TestModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TestModelInstance', {
             name: `models/${model_id}/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/tiff-sample.tiff" }
@@ -233,7 +233,7 @@ export function InferModel() {
             'TestModelInstance output classification_outputs score': (r) => r && r.message.taskOutputs[0].classification.score !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TestModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TestModelInstance', {
             name: `models/non-existed/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }
@@ -242,7 +242,7 @@ export function InferModel() {
             'TestModelInstance non-existed model name status': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TestModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TestModelInstance', {
             name: `models/${model_id}/instances/non-existed`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/imgs/dog.jpg" }
@@ -251,7 +251,7 @@ export function InferModel() {
             'TestModelInstance non-existed model version  status': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/TestModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/TestModelInstance', {
             name: `models/${model_id}/instances/latest`,
             task_inputs: [{
                 classification: { image_url: "https://artifacts.instill.tech/non-existed.jpg" }
@@ -260,7 +260,7 @@ export function InferModel() {
             'TestModelInstance non-existed model url status': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'DeleteModel model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_model_operation.js
+++ b/integration-test/grpc_model_operation.js
@@ -1,0 +1,131 @@
+import grpc from 'k6/net/grpc';
+import {
+    check,
+    group,
+    sleep
+} from 'k6';
+import http from "k6/http";
+import {
+    FormData
+} from "https://jslib.k6.io/formdata/0.0.2/index.js";
+import {
+    randomString
+} from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
+
+import {
+    genHeader,
+} from "./helpers.js";
+
+import * as constant from "./const.js"
+
+const client = new grpc.Client();
+client.load(['proto'], 'model_definition.proto');
+client.load(['proto'], 'model.proto');
+client.load(['proto'], 'model_public_service.proto');
+
+const model_def_name = "model-definitions/local"
+
+export function ListModelOperations() {
+    // GetModel check
+    group("Model API: ListModelOperations", () => {
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
+
+        let fd_cls = new FormData();
+        let model_id = randomString(10)
+        let model_description = randomString(20)
+        fd_cls.append("id", model_id);
+        fd_cls.append("description", model_description);
+        fd_cls.append("model_definition", model_def_name);
+        fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
+        let createClsModelRes = http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
+            headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
+        })
+        check(createClsModelRes, {
+            "POST /v1alpha/models/multipart task cls response status": (r) =>
+                r.status === 201,
+            "POST /v1alpha/models/multipart task cls response operation.name": (r) =>
+                r.json().operation.name !== undefined,
+        });
+
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelOperations', {}, {}), {
+            "ListModelOperations response status": (r) => r.status === grpc.StatusOK,
+            "ListModelOperations response totalSize": (r) => r.message.totalSize >= 1,
+            "ListModelOperations response operations.length": (r) => r.message.operations.length > 0,
+            "ListModelOperations response operations[0].name": (r) => r.message.operations[0].name != undefined,
+            "ListModelOperations response operations[0].done": (r) => r.message.operations[0].done != undefined,
+            "ListModelOperations response operations[0].response": (r) => r.message.operations[0].response != undefined,
+            "ListModelOperations response operations[0].metadata": (r) => r.message.operations[0].metadata === null,
+        });
+
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
+            name: "models/" + model_id
+        }), {
+            'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,
+        });
+        client.close();
+    });
+};
+
+
+export function CancelModelOperation() {
+    // ListModel check
+    group("Model API: CancelModelOperation", () => {
+        client.connect(constant.gRPCHost, {
+            plaintext: true
+        });
+
+        let fd_cls = new FormData();
+        let model_id = randomString(10)
+        let model_description = randomString(20)
+        fd_cls.append("id", model_id);
+        fd_cls.append("description", model_description);
+        fd_cls.append("model_definition", model_def_name);
+        fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
+        let createClsModelRes = http.request("POST", `${constant.apiHost}/v1alpha/models/multipart`, fd_cls.body(), {
+            headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
+        })
+        check(createClsModelRes, {
+            "POST /v1alpha/models/multipart task cls response status": (r) =>
+                r.status === 201,
+            "POST /v1alpha/models/multipart task cls response operation.name": (r) =>
+                r.json().operation.name !== undefined,
+        });
+
+        // Check model creation finished
+        let currentTime = new Date().getTime();
+        let timeoutTime = new Date().getTime() + 120000;
+        while (timeoutTime > currentTime) {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
+                name: createClsModelRes.json().operation.name
+            }, {})
+            if (res.message.operation.done === true) {
+                break
+            }
+            sleep(1)
+            currentTime = new Date().getTime();
+        }
+
+        let deployResp = client.invoke('vdp.model.v1alpha.ModelPublicService/DeployModelInstance', {
+            name: `models/${model_id}/instances/latest`
+        }, {})
+        check(deployResp, {
+            'DeployModelInstance status': (r) => r && r.status === grpc.StatusOK,
+        });
+
+        sleep(0.1) // make sure the deploy operation is started
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/CancelModelOperation', {
+            name: deployResp.message.operation.name
+        }), {
+            'CancelModelOperation status is OK': (r) => r && r.status === grpc.StatusOK,
+        });
+
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
+            name: "models/" + model_id
+        }), {
+            'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,
+        });
+        client.close();
+    });
+};

--- a/integration-test/grpc_publish_model.js
+++ b/integration-test/grpc_publish_model.js
@@ -24,7 +24,7 @@ import * as constant from "./const.js"
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 const model_def_name = "model-definitions/local"
 
@@ -56,7 +56,7 @@ export function PublishUnPublishModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -66,7 +66,7 @@ export function PublishUnPublishModel() {
             currentTime = new Date().getTime();
         }
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/PublishModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/PublishModel', {
             name: "models/" + model_id
         }), {
             "PublishModel response status": (r) => r.status === grpc.StatusOK,
@@ -82,7 +82,7 @@ export function PublishUnPublishModel() {
             "PublishModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/UnpublishModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/UnpublishModel', {
             name: "models/" + model_id
         }), {
             "UnpublishModel response status": (r) => r.status === grpc.StatusOK,
@@ -98,19 +98,19 @@ export function PublishUnPublishModel() {
             "UnpublishModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/PublishModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/PublishModel', {
             name: "models/" + randomString(10)
         }), {
             "PublishModel response not found status": (r) => r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/UnpublishModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/UnpublishModel', {
             name: "models/" + randomString(10)
         }), {
             "UnpublishModel response not found status": (r) => r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_query_model.js
+++ b/integration-test/grpc_query_model.js
@@ -97,7 +97,7 @@ export function GetModel() {
 
 export function ListModels() {
     // ListModel check
-    group("Model API: ListModel", () => {
+    group("Model API: ListModels", () => {
         client.connect(constant.gRPCHost, {
             plaintext: true
         });
@@ -132,21 +132,21 @@ export function ListModels() {
             sleep(1)
             currentTime = new Date().getTime();
         }
-        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModel', {}, {}), {
-            "ListModel response status": (r) => r.status === grpc.StatusOK,
-            "ListModel response total_size": (r) => r.message.totalSize >= 1,
-            "ListModel response next_page_token": (r) => r.message.nextPageToken !== undefined,
-            "ListModel response models.length": (r) => r.message.models.length >= 1,
-            "ListModel response models[0].name": (r) => r.message.models[0].name === `models/${model_id}`,
-            "ListModel response models[0].uid": (r) => r.message.models[0].uid !== undefined,
-            "ListModel response models[0].id": (r) => r.message.models[0].id === model_id,
-            "ListModel response models[0].description": (r) => r.message.models[0].description !== undefined,
-            "ListModel response models[0].model_definition": (r) => r.message.models[0].modelDefinition === model_def_name,
-            "ListModel response models[0].configuration": (r) => r.message.models[0].configuration !== undefined,
-            "ListModel response models[0].visibility": (r) => r.message.models[0].visibility === "VISIBILITY_PRIVATE",
-            "ListModel response models[0].owner": (r) => r.message.models[0].user === 'users/local-user',
-            "ListModel response models[0].create_time": (r) => r.message.models[0].createTime !== undefined,
-            "ListModel response models[0].update_time": (r) => r.message.models[0].updateTime !== undefined,
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModels', {}, {}), {
+            "ListModels response status": (r) => r.status === grpc.StatusOK,
+            "ListModels response total_size": (r) => r.message.totalSize >= 1,
+            "ListModels response next_page_token": (r) => r.message.nextPageToken !== undefined,
+            "ListModels response models.length": (r) => r.message.models.length >= 1,
+            "ListModels response models[0].name": (r) => r.message.models[0].name === `models/${model_id}`,
+            "ListModels response models[0].uid": (r) => r.message.models[0].uid !== undefined,
+            "ListModels response models[0].id": (r) => r.message.models[0].id === model_id,
+            "ListModels response models[0].description": (r) => r.message.models[0].description !== undefined,
+            "ListModels response models[0].model_definition": (r) => r.message.models[0].modelDefinition === model_def_name,
+            "ListModels response models[0].configuration": (r) => r.message.models[0].configuration !== undefined,
+            "ListModels response models[0].visibility": (r) => r.message.models[0].visibility === "VISIBILITY_PRIVATE",
+            "ListModels response models[0].owner": (r) => r.message.models[0].user === 'users/local-user',
+            "ListModels response models[0].create_time": (r) => r.message.models[0].createTime !== undefined,
+            "ListModels response models[0].update_time": (r) => r.message.models[0].updateTime !== undefined,
         });
 
         check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {

--- a/integration-test/grpc_query_model.js
+++ b/integration-test/grpc_query_model.js
@@ -21,7 +21,7 @@ import * as constant from "./const.js"
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 const model_def_name = "model-definitions/local"
 
@@ -53,7 +53,7 @@ export function GetModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -63,7 +63,7 @@ export function GetModel() {
             currentTime = new Date().getTime();
         }
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/GetModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/GetModel', {
             name: "models/" + model_id
         }, {}), {
             "GetModel response status": (r) => r.status === grpc.StatusOK,
@@ -79,14 +79,14 @@ export function GetModel() {
             "GetModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/GetModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/GetModel', {
             name: "models/" + randomString(10)
         }, {}), {
             'GetModel non-existed model status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -124,7 +124,7 @@ export function ListModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -133,7 +133,7 @@ export function ListModel() {
             sleep(1)
             currentTime = new Date().getTime();
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/ListModel', {}, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModel', {}, {}), {
             "ListModel response status": (r) => r.status === grpc.StatusOK,
             "ListModel response total_size": (r) => r.message.totalSize >= 1,
             "ListModel response next_page_token": (r) => r.message.nextPageToken !== undefined,
@@ -150,7 +150,7 @@ export function ListModel() {
             "ListModel response models[0].update_time": (r) => r.message.models[0].updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -187,7 +187,7 @@ export function LookupModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -197,10 +197,10 @@ export function LookupModel() {
             currentTime = new Date().getTime();
         }
 
-        let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+        let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
             name: createClsModelRes.json().operation.name
         }, {})
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModel', {
             permalink: "models/" + res.message.operation.response.uid
         }, {}), {
             "LookUpModel response status": (r) => r.status === grpc.StatusOK,
@@ -216,13 +216,13 @@ export function LookupModel() {
             "LookUpModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModel', {
             permalink: "models/" + randomString(10)
         }, {}), {
             'LookUpModel non-existed model status not found': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_query_model.js
+++ b/integration-test/grpc_query_model.js
@@ -85,7 +85,6 @@ export function GetModel() {
             'GetModel non-existed model status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-
         check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
@@ -96,7 +95,7 @@ export function GetModel() {
 };
 
 
-export function ListModel() {
+export function ListModels() {
     // ListModel check
     group("Model API: ListModel", () => {
         client.connect(constant.gRPCHost, {
@@ -221,7 +220,6 @@ export function LookupModel() {
         }, {}), {
             'LookUpModel non-existed model status not found': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
-
         check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {

--- a/integration-test/grpc_query_model_definition.js
+++ b/integration-test/grpc_query_model_definition.js
@@ -35,7 +35,7 @@ export function GetModelDefinition() {
     });
 };
 
-export function ListModelDefinition() {
+export function ListModelDefinitions() {
     group("Model API: ListModelDefinition", () => {
         client.connect(constant.gRPCHost, {
             plaintext: true

--- a/integration-test/grpc_query_model_definition.js
+++ b/integration-test/grpc_query_model_definition.js
@@ -36,22 +36,22 @@ export function GetModelDefinition() {
 };
 
 export function ListModelDefinitions() {
-    group("Model API: ListModelDefinition", () => {
+    group("Model API: ListModelDefinitions", () => {
         client.connect(constant.gRPCHost, {
             plaintext: true
         });
-        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelDefinition', {}, {}), {
-            "ListModelDefinition response status": (r) => r.status === grpc.StatusOK,
-            "ListModelDefinition response modelDefinitions[2].name": (r) => r.message.modelDefinitions[2].name === "model-definitions/local",
-            "ListModelDefinition response modelDefinitions[2].uid": (r) => r.message.modelDefinitions[2].uid !== undefined,
-            "ListModelDefinition response modelDefinitions[2].id": (r) => r.message.modelDefinitions[2].id === "local",
-            "ListModelDefinition response modelDefinitions[2].title": (r) => r.message.modelDefinitions[2].title === "Local",
-            "ListModelDefinition response modelDefinitions[2].icon": (r) => r.message.modelDefinitions[2].icon !== undefined,
-            "ListModelDefinition response modelDefinitions[2].documentationUrl": (r) => r.message.modelDefinitions[2].documentationUrl !== undefined,
-            "ListModelDefinition response modelDefinitions[2].modelSpec": (r) => r.message.modelDefinitions[2].modelSpec !== undefined,
-            "ListModelDefinition response modelDefinitions[2].modelInstanceSpec": (r) => r.message.modelDefinitions[2].modelInstanceSpec !== undefined,
-            "ListModelDefinition response modelDefinitions[2].create_time": (r) => r.message.modelDefinitions[2].createTime !== undefined,
-            "ListModelDefinition response modelDefinitions[2].update_time": (r) => r.message.modelDefinitions[2].updateTime !== undefined,
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelDefinitions', {}, {}), {
+            "ListModelDefinitions response status": (r) => r.status === grpc.StatusOK,
+            "ListModelDefinitions response modelDefinitions[2].name": (r) => r.message.modelDefinitions[2].name === "model-definitions/local",
+            "ListModelDefinitions response modelDefinitions[2].uid": (r) => r.message.modelDefinitions[2].uid !== undefined,
+            "ListModelDefinitions response modelDefinitions[2].id": (r) => r.message.modelDefinitions[2].id === "local",
+            "ListModelDefinitions response modelDefinitions[2].title": (r) => r.message.modelDefinitions[2].title === "Local",
+            "ListModelDefinitions response modelDefinitions[2].icon": (r) => r.message.modelDefinitions[2].icon !== undefined,
+            "ListModelDefinitions response modelDefinitions[2].documentationUrl": (r) => r.message.modelDefinitions[2].documentationUrl !== undefined,
+            "ListModelDefinitions response modelDefinitions[2].modelSpec": (r) => r.message.modelDefinitions[2].modelSpec !== undefined,
+            "ListModelDefinitions response modelDefinitions[2].modelInstanceSpec": (r) => r.message.modelDefinitions[2].modelInstanceSpec !== undefined,
+            "ListModelDefinitions response modelDefinitions[2].create_time": (r) => r.message.modelDefinitions[2].createTime !== undefined,
+            "ListModelDefinitions response modelDefinitions[2].update_time": (r) => r.message.modelDefinitions[2].updateTime !== undefined,
         });
         client.close();
     });

--- a/integration-test/grpc_query_model_definition.js
+++ b/integration-test/grpc_query_model_definition.js
@@ -9,7 +9,7 @@ import * as constant from "./const.js"
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 const model_def_name = "model-definitions/github"
 
@@ -18,7 +18,7 @@ export function GetModelDefinition() {
         client.connect(constant.gRPCHost, {
             plaintext: true
         });
-        check(client.invoke('vdp.model.v1alpha.ModelService/GetModelDefinition', { name: model_def_name }, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelDefinition', { name: model_def_name }, {}), {
             "GetModelDefinition response status": (r) => r.status === grpc.StatusOK,
             "GetModelDefinition response modelDefinition.name": (r) => r.message.modelDefinition.name === model_def_name,
             "GetModelDefinition response modelDefinition.uid": (r) => r.message.modelDefinition.uid !== undefined,
@@ -40,7 +40,7 @@ export function ListModelDefinition() {
         client.connect(constant.gRPCHost, {
             plaintext: true
         });
-        check(client.invoke('vdp.model.v1alpha.ModelService/ListModelDefinition', {}, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelDefinition', {}, {}), {
             "ListModelDefinition response status": (r) => r.status === grpc.StatusOK,
             "ListModelDefinition response modelDefinitions[2].name": (r) => r.message.modelDefinitions[2].name === "model-definitions/local",
             "ListModelDefinition response modelDefinitions[2].uid": (r) => r.message.modelDefinitions[2].uid !== undefined,

--- a/integration-test/grpc_query_model_instance.js
+++ b/integration-test/grpc_query_model_instance.js
@@ -21,7 +21,7 @@ import * as constant from "./const.js"
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 const model_def_name = "model-definitions/local"
 
@@ -53,7 +53,7 @@ export function GetModelInstance() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -66,7 +66,7 @@ export function GetModelInstance() {
         let req = {
             name: `models/${model_id}/instances/latest`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', req, {}), {
             'GetModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'GetModelInstance instance id': (r) => r && r.message.instance.id === `latest`,
             'GetModelInstance instance name': (r) => r && r.message.instance.name === `models/${model_id}/instances/latest`,
@@ -79,19 +79,19 @@ export function GetModelInstance() {
             'GetModelInstance instance updateTime': (r) => r && r.message.instance.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
             name: `models/non-existed/instances/latest`
         }), {
             'UpdateModelInstance non-existed model name status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
             name: `models/${model_id}/instances/non-existed`
         }, {}), {
             'UpdateModelInstance non-existed instance name status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -126,7 +126,7 @@ export function GetModelInstance() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -136,10 +136,10 @@ export function GetModelInstance() {
             currentTime = new Date().getTime();
         }
 
-        let res_model = client.invoke('vdp.model.v1alpha.ModelService/GetModel', {
+        let res_model = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModel', {
             name: "models/" + model_id
         }, {})
-        let res_model_instance = client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+        let res_model_instance = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
             name: `models/${model_id}/instances/latest`
         }, {})
         check(res_model_instance, {
@@ -149,7 +149,7 @@ export function GetModelInstance() {
         let req = {
             permalink: `models/${res_model.message.model.uid}/instances/${res_model_instance.message.instance.uid}`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModelInstance', req, {}), {
             'LookUpModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'LookUpModelInstance instance id': (r) => r && r.message.instance.id === `latest`,
             'LookUpModelInstance instance name': (r) => r && r.message.instance.name === `models/${model_id}/instances/latest`,
@@ -162,19 +162,19 @@ export function GetModelInstance() {
             'LookUpModelInstance instance updateTime': (r) => r && r.message.instance.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModelInstance', {
             permalink: `models/non-existed/instances/${res_model_instance.message.instance.uid}`
         }), {
             'LookUpModelInstance non-existed model name status not found': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModelInstance', {
             permalink: `models/${res_model.message.model.uid}/instances/non-existed`
         }, {}), {
             'LookUpModelInstance non-existed instance name status not found': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -211,7 +211,7 @@ export function ListModelInstance() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -220,10 +220,10 @@ export function ListModelInstance() {
             sleep(1)
             currentTime = new Date().getTime();
         }
-        let res_model = client.invoke('vdp.model.v1alpha.ModelService/GetModel', {
+        let res_model = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModel', {
             name: "models/" + model_id
         }, {})
-        let res_model_instance = client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+        let res_model_instance = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
             name: `models/${model_id}/instances/latest`
         }, {})
         check(res_model_instance, {
@@ -233,7 +233,7 @@ export function ListModelInstance() {
         let req = {
             parent: `models/${res_model.message.model.id}`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/ListModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelInstance', req, {}), {
             'ListModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'ListModelInstance instances[0] id': (r) => r && r.message.instances[0].id === `latest`,
             'ListModelInstance instances[0] name': (r) => r && r.message.instances[0].name === `models/${model_id}/instances/latest`,
@@ -246,13 +246,13 @@ export function ListModelInstance() {
             'ListModelInstance instances[0] updateTime': (r) => r && r.message.instances[0].updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/ListModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelInstance', {
             parent: `models/non-existed`
         }), {
             'ListModelInstance non-existed model name status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,
@@ -289,7 +289,7 @@ export function LookupModelInstance() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -299,11 +299,11 @@ export function LookupModelInstance() {
             currentTime = new Date().getTime();
         }
 
-        let res_model = client.invoke('vdp.model.v1alpha.ModelService/GetModel', {
+        let res_model = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModel', {
             name: "models/" + model_id
         }, {})
 
-        let res_model_instance = client.invoke('vdp.model.v1alpha.ModelService/GetModelInstance', {
+        let res_model_instance = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelInstance', {
             name: `models/${model_id}/instances/latest`
         }, {})
         check(res_model_instance, {
@@ -313,7 +313,7 @@ export function LookupModelInstance() {
         let req = {
             permalink: `models/${res_model.message.model.uid}/instances/${res_model_instance.message.instance.uid}`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModelInstance', req, {}), {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModelInstance', req, {}), {
             'LookUpModelInstance status': (r) => r && r.status === grpc.StatusOK,
             'LookUpModelInstance instance id': (r) => r && r.message.instance.id === `latest`,
             'LookUpModelInstance instance name': (r) => r && r.message.instance.name === `models/${model_id}/instances/latest`,
@@ -326,19 +326,19 @@ export function LookupModelInstance() {
             'LookUpModelInstance instance updateTime': (r) => r && r.message.instance.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModelInstance', {
             permalink: `models/non-existed/instances/${res_model_instance.message.instance.uid}`
         }), {
             'LookUpModelInstance non-existed model name status invalid uid': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/LookUpModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/LookUpModelInstance', {
             permalink: `models/${res_model.message.model.uid}}/instances/non-existed`
         }, {}), {
             'LookUpModelInstance non-existed instance name invalid uid': (r) => r && r.status === grpc.StatusInvalidArgument,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/grpc_query_model_instance.js
+++ b/integration-test/grpc_query_model_instance.js
@@ -185,7 +185,7 @@ export function GetModelInstance() {
 
 export function ListModelInstances() {
     // ListModelInstance check
-    group("Model API: ListModelInstance", () => {
+    group("Model API: ListModelInstances", () => {
         client.connect(constant.gRPCHost, {
             plaintext: true
         });
@@ -233,23 +233,23 @@ export function ListModelInstances() {
         let req = {
             parent: `models/${res_model.message.model.id}`
         }
-        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelInstance', req, {}), {
-            'ListModelInstance status': (r) => r && r.status === grpc.StatusOK,
-            'ListModelInstance instances[0] id': (r) => r && r.message.instances[0].id === `latest`,
-            'ListModelInstance instances[0] name': (r) => r && r.message.instances[0].name === `models/${model_id}/instances/latest`,
-            'ListModelInstance instances[0] uid': (r) => r && r.message.instances[0].uid === res_model_instance.message.instance.uid,
-            'ListModelInstance instances[0] state': (r) => r && r.message.instances[0].state === "STATE_OFFLINE",
-            'ListModelInstance instances[0] task': (r) => r && r.message.instances[0].task === "TASK_CLASSIFICATION",
-            'ListModelInstance instances[0] modelDefinition': (r) => r && r.message.instances[0].modelDefinition === model_def_name,
-            'ListModelInstance instances[0] configuration': (r) => r && r.message.instances[0].configuration !== undefined,
-            'ListModelInstance instances[0] createTime': (r) => r && r.message.instances[0].createTime !== undefined,
-            'ListModelInstance instances[0] updateTime': (r) => r && r.message.instances[0].updateTime !== undefined,
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelInstances', req, {}), {
+            'ListModelInstances status': (r) => r && r.status === grpc.StatusOK,
+            'ListModelInstances instances[0] id': (r) => r && r.message.instances[0].id === `latest`,
+            'ListModelInstances instances[0] name': (r) => r && r.message.instances[0].name === `models/${model_id}/instances/latest`,
+            'ListModelInstances instances[0] uid': (r) => r && r.message.instances[0].uid === res_model_instance.message.instance.uid,
+            'ListModelInstances instances[0] state': (r) => r && r.message.instances[0].state === "STATE_OFFLINE",
+            'ListModelInstances instances[0] task': (r) => r && r.message.instances[0].task === "TASK_CLASSIFICATION",
+            'ListModelInstances instances[0] modelDefinition': (r) => r && r.message.instances[0].modelDefinition === model_def_name,
+            'ListModelInstances instances[0] configuration': (r) => r && r.message.instances[0].configuration !== undefined,
+            'ListModelInstances instances[0] createTime': (r) => r && r.message.instances[0].createTime !== undefined,
+            'ListModelInstances instances[0] updateTime': (r) => r && r.message.instances[0].updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelInstance', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelInstances', {
             parent: `models/non-existed`
         }), {
-            'ListModelInstance non-existed model name status not found': (r) => r && r.status === grpc.StatusNotFound,
+            'ListModelInstances non-existed model name status not found': (r) => r && r.status === grpc.StatusNotFound,
         });
 
         check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {

--- a/integration-test/grpc_query_model_instance.js
+++ b/integration-test/grpc_query_model_instance.js
@@ -183,7 +183,7 @@ export function GetModelInstance() {
     });
 };
 
-export function ListModelInstance() {
+export function ListModelInstances() {
     // ListModelInstance check
     group("Model API: ListModelInstance", () => {
         client.connect(constant.gRPCHost, {

--- a/integration-test/grpc_update_model.js
+++ b/integration-test/grpc_update_model.js
@@ -21,7 +21,7 @@ import * as constant from "./const.js"
 const client = new grpc.Client();
 client.load(['proto'], 'model_definition.proto');
 client.load(['proto'], 'model.proto');
-client.load(['proto'], 'model_service.proto');
+client.load(['proto'], 'model_public_service.proto');
 
 const model_def_name = "model-definitions/local"
 
@@ -54,7 +54,7 @@ export function UpdateModel() {
         let currentTime = new Date().getTime();
         let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelService/GetModelOperation', {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/GetModelOperation', {
                 name: createClsModelRes.json().operation.name
             }, {})
             if (res.message.operation.done === true) {
@@ -63,7 +63,7 @@ export function UpdateModel() {
             sleep(1)
             currentTime = new Date().getTime();
         }
-        let res = client.invoke('vdp.model.v1alpha.ModelService/UpdateModel', {
+        let res = client.invoke('vdp.model.v1alpha.ModelPublicService/UpdateModel', {
             model: {
                 name: "models/" + model_id,
                 description: "new_description"
@@ -84,7 +84,7 @@ export function UpdateModel() {
             "UpdateModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
         });
 
-        check(client.invoke('vdp.model.v1alpha.ModelService/DeleteModel', {
+        check(client.invoke('vdp.model.v1alpha.ModelPublicService/DeleteModel', {
             name: "models/" + model_id
         }), {
             'Delete model status is OK': (r) => r && r.status === grpc.StatusOK,

--- a/integration-test/proto/model.proto
+++ b/integration-test/proto/model.proto
@@ -13,6 +13,7 @@ import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 import "google/longrunning/operations.proto";
 
+import "./controller.proto";
 import "./model_definition.proto";
 import "./task_classification.proto";
 import "./task_detection.proto";
@@ -296,7 +297,7 @@ message DeleteModelRequest {
 // DeleteModelResponse represents an empty response
 message DeleteModelResponse {}
 
-// LookUpModelRequest represents a request to query a model instance by
+// LookUpModelRequest represents a request to query a model instance via
 // permalink
 message LookUpModelRequest {
   // Permalink of a model. For example:
@@ -420,7 +421,7 @@ message GetModelInstanceResponse {
   ModelInstance instance = 1;
 }
 
-// LookUpModelInstanceRequest represents a request to query a model instance by
+// LookUpModelInstanceRequest represents a request to query a model instance via
 // permalink
 message LookUpModelInstanceRequest {
   // Permalink of a model instance. For example:
@@ -524,6 +525,31 @@ message TaskInput {
   }
 }
 
+// TaskInputStream represents the input to trigger a model instance with stream method
+message TaskInputStream {
+  // Input type
+  oneof input {
+    // The classification input
+    ClassificationInputStream classification = 1;
+    // The detection input
+    DetectionInputStream detection = 2;
+    // The keypoint input
+    KeypointInputStream keypoint = 3;
+    // The ocr input
+    OcrInputStream ocr = 4;
+    // The instance segmentation input
+    InstanceSegmentationInputStream instance_segmentation = 5;
+    // The semantic segmentation input
+    SemanticSegmentationInputStream semantic_segmentation = 6;
+    // The text to image input
+    TextToImageInput text_to_image = 7;
+    // The text generation input
+    TextGenerationInput text_generation = 8;
+    // The unspecified task input
+    UnspecifiedInput unspecified = 9;
+  }
+}
+
 // TaskOutput represents the output of a CV Task result from a model instance
 message TaskOutput {
   // The inference task output
@@ -585,10 +611,8 @@ message TriggerModelInstanceBinaryFileUploadRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
   ];
-  // The list of file length for each uploaded binary file
-  repeated uint64 file_lengths = 2 [ (google.api.field_behavior) = REQUIRED ];
-  // Content of images in bytes
-  bytes content = 3 [ (google.api.field_behavior) = REQUIRED ];
+  // Input to trigger the model instance
+  TaskInputStream task_input = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // TriggerModelInstanceBinaryFileUploadResponse represents a response for the
@@ -632,10 +656,8 @@ message TestModelInstanceBinaryFileUploadRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
   ];
-  // The list of file length for each uploaded binary file
-  repeated uint64 file_lengths = 2 [ (google.api.field_behavior) = REQUIRED ];
-  // Content of images in bytes
-  bytes content = 3 [ (google.api.field_behavior) = REQUIRED ];
+  // Input to trigger the model instance
+  TaskInputStream task_input = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // TestModelInstanceBinaryFileUploadResponse represents a response for the
@@ -702,3 +724,71 @@ message CancelModelOperationRequest {
 // CancelModelOperationResponse represents a response for canceling a model
 // operation
 message CancelModelOperationResponse {}
+
+// ========== Admin endpoints
+
+// ListModelAdminRequest represents a request to list all models from all users by admin
+message ListModelAdminRequest {
+  // Page size: the maximum number of resources to return. The service may
+  // return fewer than this value. If unspecified, at most 10 models will be
+  // returned. The maximum value is 100; values above 100 will be coereced to
+  // 100.
+  optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
+  // Page token
+  optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListModelAdminResponse represents a response for a list of models
+message ListModelAdminResponse {
+  // a list of Models
+  repeated Model models = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of models
+  int64 total_size = 3;
+}
+
+// GetModelAdminRequest represents a request to query a model by admin
+message GetModelAdminRequest {
+  // Resource name of the model.
+  // For example "models/{model}"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Model",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "model.name"}
+    }
+  ];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// GetModelAdminResponse represents a response for a model
+message GetModelAdminResponse {
+  // The retrieved model
+  Model model = 1;
+}
+
+// LookUpModelAdminRequest represents a request to query a model instance via
+// permalink by admin
+message LookUpModelAdminRequest {
+  // Permalink of a model. For example:
+  // "models/{uid}"
+  string permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// LookUpModelResponse represents a response for a model instance
+message LookUpModelAdminResponse {
+  // A model resource
+  Model model = 1;
+}

--- a/integration-test/proto/model.proto
+++ b/integration-test/proto/model.proto
@@ -179,8 +179,8 @@ message ModelInstanceCard {
   string encoding = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
-// ListModelRequest represents a request to list all models
-message ListModelRequest {
+// ListModelsRequest represents a request to list all models
+message ListModelsRequest {
   // Page size: the maximum number of resources to return. The service may
   // return fewer than this value. If unspecified, at most 10 models will be
   // returned. The maximum value is 100; values above 100 will be coereced to
@@ -194,8 +194,8 @@ message ListModelRequest {
   optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// ListModelResponse represents a response for a list of models
-message ListModelResponse {
+// ListModelsResponse represents a response for a list of models
+message ListModelsResponse {
   // a list of Models
   repeated Model models = 1;
   // Next page token
@@ -364,9 +364,9 @@ message UnpublishModelResponse {
   Model model = 1;
 }
 
-// ListModelInstanceRequest represents a request to list all instances of a
+// ListModelInstancesRequest represents a request to list all instances of a
 // model
-message ListModelInstanceRequest {
+message ListModelInstancesRequest {
   // The name of the model whose instances we'd like to list.
   // e.g., "models/yolov4"
   string parent = 1 [
@@ -387,8 +387,8 @@ message ListModelInstanceRequest {
   optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// ListModelInstanceResponse represents a response for a list of model instances
-message ListModelInstanceResponse {
+// ListModelInstancesResponse represents a response for a list of model instances
+message ListModelInstancesResponse {
   // a list of Model instances
   repeated ModelInstance instances = 1;
   // Next page token
@@ -685,9 +685,9 @@ message GetModelOperationResponse {
   google.longrunning.Operation operation = 1;
 }
 
-// ListModelOperationRequest represents a request to list all model operations
+// ListModelOperationsRequest represents a request to list all model operations
 // including deploy and undeploy
-message ListModelOperationRequest {
+message ListModelOperationsRequest {
   // Page size: the maximum number of resources to return. The service may
   // return fewer than this value. If unspecified, at most 10 operations will be
   // returned. The maximum value is 100; values above 100 will be coereced to
@@ -703,9 +703,9 @@ message ListModelOperationRequest {
   optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// ListModelOperationResponse represents a response for a list of model
+// ListModelOperationsResponse represents a response for a list of model
 // operations including deploy and undeploy
-message ListModelOperationResponse {
+message ListModelOperationsResponse {
   // a list of model operations
   repeated google.longrunning.Operation operations = 1;
   // Next page token
@@ -726,8 +726,8 @@ message CancelModelOperationResponse {}
 
 // ========== Admin endpoints
 
-// ListModelAdminRequest represents a request to list all models from all users by admin
-message ListModelAdminRequest {
+// ListModelsAdminRequest represents a request to list all models from all users by admin
+message ListModelsAdminRequest {
   // Page size: the maximum number of resources to return. The service may
   // return fewer than this value. If unspecified, at most 10 models will be
   // returned. The maximum value is 100; values above 100 will be coereced to
@@ -741,8 +741,8 @@ message ListModelAdminRequest {
   optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// ListModelAdminResponse represents a response for a list of models
-message ListModelAdminResponse {
+// ListModelsAdminResponse represents a response for a list of models
+message ListModelsAdminResponse {
   // a list of Models
   repeated Model models = 1;
   // Next page token

--- a/integration-test/proto/model.proto
+++ b/integration-test/proto/model.proto
@@ -13,7 +13,6 @@ import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 import "google/longrunning/operations.proto";
 
-import "./controller.proto";
 import "./model_definition.proto";
 import "./task_classification.proto";
 import "./task_detection.proto";

--- a/integration-test/proto/model_definition.proto
+++ b/integration-test/proto/model_definition.proto
@@ -87,9 +87,9 @@ enum View {
   VIEW_FULL = 2;
 }
 
-// ListModelDefinitionRequest represents a request to list all supported model
+// ListModelDefinitionsRequest represents a request to list all supported model
 // definitions
-message ListModelDefinitionRequest {
+message ListModelDefinitionsRequest {
   // Page size: the maximum number of resources to return. The service may
   // return fewer than this value. If unspecified, at most 10 ModelDefinitions
   // will be returned. The maximum value is 100; values above 100 will be
@@ -104,9 +104,9 @@ message ListModelDefinitionRequest {
   optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// ListModelDefinitionResponse represents a response to list all supported model
+// ListModelDefinitionsResponse represents a response to list all supported model
 // definitions
-message ListModelDefinitionResponse {
+message ListModelDefinitionsResponse {
   // a list of ModelDefinition instances
   repeated ModelDefinition model_definitions = 1;
   // Next page token

--- a/integration-test/proto/model_private_service.proto
+++ b/integration-test/proto/model_private_service.proto
@@ -8,15 +8,14 @@ import "google/api/client.proto";
 
 import "./model.proto";
 
-// Model service responds to internal incoming model requests
+// Model service responds to internal access
 service ModelPrivateService {
-  option (google.api.default_host) = "api.instill.tech";
 
-    // ========== Admin API ==========
+    // ========== Admin API ========== 
 
-  // ListModelAdmin method receives a ListModelAdminRequest message and returns a
-  // ListModelAdminResponse
-  rpc ListModelAdmin(ListModelAdminRequest) returns (ListModelAdminResponse) {
+  // ListModelsAdmin method receives a ListModelsAdminRequest message and returns a
+  // ListModelsAdminResponse
+  rpc ListModelsAdmin(ListModelsAdminRequest) returns (ListModelsAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/models"
     };
@@ -31,13 +30,13 @@ service ModelPrivateService {
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpModelAdmin method receives a LookUpModelAdminRequest message and returns a
-  // LookUpModelAdminResponse
-  rpc LookUpModelAdmin(LookUpModelAdminRequest) returns (LookUpModelAdminResponse) {
+  // LookUpModelAdmin method receives a LookUpModelAdminRequest message and
+  // returns a LookUpModelAdminResponse
+  rpc LookUpModelAdmin(LookUpModelAdminRequest)
+      returns (LookUpModelAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/{permalink=models/*}/lookUp"
     };
     option (google.api.method_signature) = "permalink";
   }
-
 }

--- a/integration-test/proto/model_private_service.proto
+++ b/integration-test/proto/model_private_service.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package vdp.model.v1alpha;
+
+// Google API
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+
+import "./model.proto";
+
+// Model service responds to internal incoming model requests
+service ModelPrivateService {
+  option (google.api.default_host) = "api.instill.tech";
+
+    // ========== Admin API ==========
+
+  // ListModelAdmin method receives a ListModelAdminRequest message and returns a
+  // ListModelAdminResponse
+  rpc ListModelAdmin(ListModelAdminRequest) returns (ListModelAdminResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/models"
+    };
+  }
+
+  // GetModelAdmin method receives a GetModelAdminRequest message and returns a
+  // GetModelAdminResponse
+  rpc GetModelAdmin(GetModelAdminRequest) returns (GetModelAdminResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/{name=models/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // LookUpModelAdmin method receives a LookUpModelAdminRequest message and returns a
+  // LookUpModelAdminResponse
+  rpc LookUpModelAdmin(LookUpModelAdminRequest) returns (LookUpModelAdminResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/{permalink=models/*}/lookUp"
+    };
+    option (google.api.method_signature) = "permalink";
+  }
+
+}

--- a/integration-test/proto/model_public_service.proto
+++ b/integration-test/proto/model_public_service.proto
@@ -10,8 +10,8 @@ import "./healthcheck.proto";
 import "./model_definition.proto";
 import "./model.proto";
 
-// Model service responds to incoming model requests
-service ModelService {
+// Model service responds to external incoming model requests
+service ModelPublicService {
   option (google.api.default_host) = "api.instill.tech";
 
   // Liveness method receives a LivenessRequest message and returns a

--- a/integration-test/proto/model_public_service.proto
+++ b/integration-test/proto/model_public_service.proto
@@ -10,7 +10,7 @@ import "./healthcheck.proto";
 import "./model_definition.proto";
 import "./model.proto";
 
-// Model service responds to external incoming model requests
+// Model service responds to external access
 service ModelPublicService {
   option (google.api.default_host) = "api.instill.tech";
 
@@ -34,10 +34,10 @@ service ModelPublicService {
     };
   }
 
-  // ListModelDefinition method receives a ListModelDefinitionRequest message
-  // and returns a ListModelDefinitionResponse
-  rpc ListModelDefinition(ListModelDefinitionRequest)
-      returns (ListModelDefinitionResponse) {
+  // ListModelDefinitions method receives a ListModelDefinitionsRequest message
+  // and returns a ListModelDefinitionsResponse
+  rpc ListModelDefinitions(ListModelDefinitionsRequest)
+      returns (ListModelDefinitionsResponse) {
     option (google.api.http) = {
       get : "/v1alpha/model-definitions"
     };
@@ -53,9 +53,9 @@ service ModelPublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // ListModel method receives a ListModelRequest message and returns a
-  // ListModelResponse
-  rpc ListModel(ListModelRequest) returns (ListModelResponse) {
+  // ListModels method receives a ListModelsRequest message and returns a
+  // ListModelsResponse
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
     option (google.api.http) = {
       get : "/v1alpha/models"
     };
@@ -147,10 +147,10 @@ service ModelPublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // ListModelInstance method receives a ListModelInstanceRequest message and
-  // returns a ListModelInstanceResponse
-  rpc ListModelInstance(ListModelInstanceRequest)
-      returns (ListModelInstanceResponse) {
+  // ListModelInstances method receives a ListModelInstancesRequest message and
+  // returns a ListModelInstancesResponse
+  rpc ListModelInstances(ListModelInstancesRequest)
+      returns (ListModelInstancesResponse) {
     option (google.api.http) = {
       get : "/v1alpha/{parent=models/*}/instances"
     };
@@ -257,27 +257,29 @@ service ModelPublicService {
   // GetModelOperation method receives a
   // GetModelOperationRequest message and returns a
   // GetModelOperationResponse message.
-  rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
+  rpc GetModelOperation(GetModelOperationRequest)
+      returns (GetModelOperationResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/{name=operations/*}"
+      get : "/v1alpha/{name=operations/*}"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // ListModelOperation method receives a ListModelOperationRequest message
-  // and returns a ListModelOperationResponse
-  rpc ListModelOperation(ListModelOperationRequest) returns (ListModelOperationResponse) {
+  // ListModelOperations method receives a ListModelOperationsRequest message
+  // and returns a ListModelOperationsResponse
+  rpc ListModelOperations(ListModelOperationsRequest) returns (ListModelOperationsResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/operations"
+      get : "/v1alpha/operations"
     };
   }
 
   // CancelModelOperation method receives a CancelModelOperationRequest message
   // and returns a CancelModelOperationResponse
-  rpc CancelModelOperation(CancelModelOperationRequest) returns (CancelModelOperationResponse) {
+  rpc CancelModelOperation(CancelModelOperationRequest)
+      returns (CancelModelOperationResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=operations/*}/cancel"
-      body: "*"
+      post : "/v1alpha/{name=operations/*}/cancel"
+      body : "*"
     };
     option (google.api.method_signature) = "name";
   }

--- a/integration-test/proto/task_classification.proto
+++ b/integration-test/proto/task_classification.proto
@@ -16,6 +16,14 @@ message ClassificationInput {
   }
 }
 
+// ClassificationInputStream represents the input of classification task when using stream method
+message ClassificationInputStream {
+  // The list of file length for each uploaded binary file
+  repeated uint64 file_lengths = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes content = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // ClassificationOutput represents the output of classification task
 message ClassificationOutput {
   // Classification category

--- a/integration-test/proto/task_detection.proto
+++ b/integration-test/proto/task_detection.proto
@@ -28,6 +28,14 @@ message DetectionInput {
   }
 }
 
+// DetectionInputStream represents the input of detection task when using stream method
+message DetectionInputStream {
+  // The list of file length for each uploaded binary file
+  repeated uint64 file_lengths = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes content = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // DetectionOutput represents the output of detection task
 message DetectionOutput {
   // A list of detection objects

--- a/integration-test/proto/task_instance_segmentation.proto
+++ b/integration-test/proto/task_instance_segmentation.proto
@@ -30,6 +30,14 @@ message InstanceSegmentationInput {
   }
 }
 
+// InstanceSegmentationInputStream represents the input of instance segmentation task when using stream method
+message InstanceSegmentationInputStream {
+  // The list of file length for each uploaded binary file
+  repeated uint64 file_lengths = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes content = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // InstanceSegmentationOutput represents the output of instance segmentation
 // task
 message InstanceSegmentationOutput {

--- a/integration-test/proto/task_keypoint.proto
+++ b/integration-test/proto/task_keypoint.proto
@@ -38,6 +38,14 @@ message KeypointInput {
   }
 }
 
+// KeypointInputStream represents the input of keypoint detection task when using stream method
+message KeypointInputStream {
+  // The list of file length for each uploaded binary file
+  repeated uint64 file_lengths = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes content = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // KeypointOutput represents the output of keypoint detection task
 message KeypointOutput {
   // A list of keypoint objects

--- a/integration-test/proto/task_ocr.proto
+++ b/integration-test/proto/task_ocr.proto
@@ -28,6 +28,14 @@ message OcrInput {
   }
 }
 
+// OcrInputStream represents the input of ocr task when using stream method
+message OcrInputStream {
+  // The list of file length for each uploaded binary file
+  repeated uint64 file_lengths = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes content = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // OcrOutput represents the output of ocr task
 message OcrOutput {
   // A list of OCR objects

--- a/integration-test/proto/task_semantic_segmentation.proto
+++ b/integration-test/proto/task_semantic_segmentation.proto
@@ -24,6 +24,14 @@ message SemanticSegmentationInput {
   }
 }
 
+// SemanticSegmentationInputStream represents the input of semantic segmentation task when using stream method
+message SemanticSegmentationInputStream {
+  // The list of file length for each uploaded binary file
+  repeated uint64 file_lengths = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes content = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // SemanticSegmentationOutput represents the output of semantic segmentation
 // task
 message SemanticSegmentationOutput {

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -54,7 +54,7 @@ export default function (data) {
 
   // Query Model API
   queryModel.GetModel()
-  queryModel.ListModel()
+  queryModel.ListModels()
   queryModel.LookupModel()
 
   // Deploy/Undeploy Model API
@@ -68,11 +68,11 @@ export default function (data) {
 
   // Query Model Definition API
   queryModelDefinition.GetModelDefinition()
-  queryModelDefinition.ListModelDefinition()
+  queryModelDefinition.ListModelDefinitions()
 
   // Query Model Instance API
   queryModelInstance.GetModelInstance()
-  queryModelInstance.ListModelInstance()
+  queryModelInstance.ListModelInstances()
   queryModelInstance.LookupModelInstance()
 
   // Get model card

--- a/integration-test/rest_query_model.js
+++ b/integration-test/rest_query_model.js
@@ -119,7 +119,7 @@ export function GetModel() {
   }
 }
 
-export function ListModel() {
+export function ListModels() {
   // Model Backend API: Get model list
   {
     group("Model Backend API: Get model list", function () {

--- a/integration-test/rest_query_model_definition.js
+++ b/integration-test/rest_query_model_definition.js
@@ -12,7 +12,7 @@ import * as constant from "./const.js"
 
 const model_def_name = "model-definitions/local"
 
-export function ListModelDefinition() {
+export function ListModelDefinitions() {
   // Model Backend API: get model definition list
   {
     group("Model Backend API: get model definition list", function () {

--- a/integration-test/rest_query_model_instance.js
+++ b/integration-test/rest_query_model_instance.js
@@ -115,7 +115,7 @@ export function GetModelInstance() {
   }
 }
 
-export function ListModelInstance() {
+export function ListModelInstances() {
   // Model Backend API: Get model instance list - local model
   {
     group("Model Backend API: Get model instance list local model", function () {

--- a/internal/external/external.go
+++ b/internal/external/external.go
@@ -19,8 +19,8 @@ import (
 	usagePB "github.com/instill-ai/protogen-go/vdp/usage/v1alpha"
 )
 
-// InitMgmtAdminServiceClient initialises a MgmtAdminServiceClient instance
-func InitMgmtAdminServiceClient() (mgmtPB.MgmtAdminServiceClient, *grpc.ClientConn) {
+// InitMgmtPrivateServiceClient initialises a MgmtPrivateServiceClient instance
+func InitMgmtPrivateServiceClient() (mgmtPB.MgmtPrivateServiceClient, *grpc.ClientConn) {
 	logger, _ := logger.GetZapLogger()
 
 	var clientDialOpts grpc.DialOption
@@ -41,7 +41,7 @@ func InitMgmtAdminServiceClient() (mgmtPB.MgmtAdminServiceClient, *grpc.ClientCo
 		logger.Fatal(err.Error())
 	}
 
-	return mgmtPB.NewMgmtAdminServiceClient(clientConn), clientConn
+	return mgmtPB.NewMgmtPrivateServiceClient(clientConn), clientConn
 }
 
 // InitUsageServiceClient initializes a UsageServiceClient instance
@@ -86,8 +86,8 @@ func InitUsageServiceClient() (usagePB.UsageServiceClient, *grpc.ClientConn) {
 	return usagePB.NewUsageServiceClient(clientConn), clientConn
 }
 
-// InitPipelineServiceClient initialises a PipelineServiceClient instance
-func InitPipelineServiceClient() (pipelinePB.PipelineServiceClient, *grpc.ClientConn) {
+// InitPipelinePublicServiceClient initialises a PipelinePublicServiceClient instance
+func InitPipelinePublicServiceClient() (pipelinePB.PipelinePublicServiceClient, *grpc.ClientConn) {
 	logger, _ := logger.GetZapLogger()
 
 	var clientDialOpts grpc.DialOption
@@ -108,5 +108,5 @@ func InitPipelineServiceClient() (pipelinePB.PipelineServiceClient, *grpc.Client
 		logger.Fatal(err.Error())
 	}
 
-	return pipelinePB.NewPipelineServiceClient(clientConn), clientConn
+	return pipelinePB.NewPipelinePublicServiceClient(clientConn), clientConn
 }

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -324,7 +324,7 @@ func UpdateModelPath(modelDir string, dstDir string, owner string, modelID strin
 	return readmeFilePath, ensembleFilePath, nil
 }
 
-func SaveFile(stream modelPB.ModelService_CreateModelBinaryFileUploadServer) (outFile string, modelInfo *datamodel.Model, modelDefinitionID string, err error) {
+func SaveFile(stream modelPB.ModelPublicService_CreateModelBinaryFileUploadServer) (outFile string, modelInfo *datamodel.Model, modelDefinitionID string, err error) {
 	firstChunk := true
 	var fp *os.File
 	var fileData *modelPB.CreateModelBinaryFileUploadRequest

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -2590,7 +2590,7 @@ func (h *handler) GetModelOperation(ctx context.Context, req *modelPB.GetModelOp
 	}
 }
 
-func (h *handler) ListModelOperation(ctx context.Context, req *modelPB.ListModelOperationsRequest) (*modelPB.ListModelOperationsResponse, error) {
+func (h *handler) ListModelOperations(ctx context.Context, req *modelPB.ListModelOperationsRequest) (*modelPB.ListModelOperationsResponse, error) {
 	pageSize := util.DefaultPageSize
 	if req.PageSize != nil {
 		pageSize = int(*req.PageSize)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1462,26 +1462,26 @@ func (h *handler) CreateModel(ctx context.Context, req *modelPB.CreateModelReque
 
 }
 
-func (h *handler) ListModel(ctx context.Context, req *modelPB.ListModelRequest) (*modelPB.ListModelResponse, error) {
+func (h *handler) ListModels(ctx context.Context, req *modelPB.ListModelsRequest) (*modelPB.ListModelsResponse, error) {
 	owner, err := resource.GetOwner(ctx)
 	if err != nil {
-		return &modelPB.ListModelResponse{}, err
+		return &modelPB.ListModelsResponse{}, err
 	}
-	dbModels, nextPageToken, totalSize, err := h.service.ListModel(owner, req.GetView(), int(req.GetPageSize()), req.GetPageToken())
+	dbModels, nextPageToken, totalSize, err := h.service.ListModels(owner, req.GetView(), int(req.GetPageSize()), req.GetPageToken())
 	if err != nil {
-		return &modelPB.ListModelResponse{}, err
+		return &modelPB.ListModelsResponse{}, err
 	}
 
 	pbModels := []*modelPB.Model{}
 	for _, dbModel := range dbModels {
 		modelDef, err := h.service.GetModelDefinitionByUid(dbModel.ModelDefinitionUid)
 		if err != nil {
-			return &modelPB.ListModelResponse{}, err
+			return &modelPB.ListModelsResponse{}, err
 		}
 		pbModels = append(pbModels, DBModelToPBModel(&modelDef, &dbModel))
 	}
 
-	resp := modelPB.ListModelResponse{
+	resp := modelPB.ListModelsResponse{
 		Models:        pbModels,
 		NextPageToken: nextPageToken,
 		TotalSize:     totalSize,
@@ -1720,29 +1720,29 @@ func (h *handler) LookUpModelInstance(ctx context.Context, req *modelPB.LookUpMo
 	return &modelPB.LookUpModelInstanceResponse{Instance: pbModelInstance}, nil
 }
 
-func (h *handler) ListModelInstance(ctx context.Context, req *modelPB.ListModelInstanceRequest) (*modelPB.ListModelInstanceResponse, error) {
+func (h *handler) ListModelInstances(ctx context.Context, req *modelPB.ListModelInstancesRequest) (*modelPB.ListModelInstancesResponse, error) {
 	owner, err := resource.GetOwner(ctx)
 	if err != nil {
-		return &modelPB.ListModelInstanceResponse{}, err
+		return &modelPB.ListModelInstancesResponse{}, err
 	}
 
 	modelID, err := resource.GetID(req.Parent)
 	if err != nil {
-		return &modelPB.ListModelInstanceResponse{}, err
+		return &modelPB.ListModelInstancesResponse{}, err
 	}
 	modelInDB, err := h.service.GetModelById(owner, modelID, req.GetView())
 	if err != nil {
-		return &modelPB.ListModelInstanceResponse{}, err
+		return &modelPB.ListModelInstancesResponse{}, err
 	}
 
 	modelDef, err := h.service.GetModelDefinitionByUid(modelInDB.ModelDefinitionUid)
 	if err != nil {
-		return &modelPB.ListModelInstanceResponse{}, err
+		return &modelPB.ListModelInstancesResponse{}, err
 	}
 
-	dbModelInstances, nextPageToken, totalSize, err := h.service.ListModelInstance(modelInDB.UID, req.GetView(), int(req.GetPageSize()), req.GetPageToken())
+	dbModelInstances, nextPageToken, totalSize, err := h.service.ListModelInstances(modelInDB.UID, req.GetView(), int(req.GetPageSize()), req.GetPageToken())
 	if err != nil {
-		return &modelPB.ListModelInstanceResponse{}, err
+		return &modelPB.ListModelInstancesResponse{}, err
 	}
 
 	pbInstances := []*modelPB.ModelInstance{}
@@ -1750,7 +1750,7 @@ func (h *handler) ListModelInstance(ctx context.Context, req *modelPB.ListModelI
 		pbInstances = append(pbInstances, DBModelInstanceToPBModelInstance(&modelDef, &modelInDB, &dbModelInstance))
 	}
 
-	resp := modelPB.ListModelInstanceResponse{
+	resp := modelPB.ListModelInstancesResponse{
 		Instances:     pbInstances,
 		NextPageToken: nextPageToken,
 		TotalSize:     totalSize,
@@ -2505,11 +2505,11 @@ func (h *handler) GetModelDefinition(ctx context.Context, req *modelPB.GetModelD
 	return &modelPB.GetModelDefinitionResponse{ModelDefinition: pbModelInstance}, nil
 }
 
-func (h *handler) ListModelDefinition(ctx context.Context, req *modelPB.ListModelDefinitionRequest) (*modelPB.ListModelDefinitionResponse, error) {
+func (h *handler) ListModelDefinitions(ctx context.Context, req *modelPB.ListModelDefinitionsRequest) (*modelPB.ListModelDefinitionsResponse, error) {
 
-	dbModelDefinitions, nextPageToken, totalSize, err := h.service.ListModelDefinition(req.GetView(), int(req.GetPageSize()), req.GetPageToken())
+	dbModelDefinitions, nextPageToken, totalSize, err := h.service.ListModelDefinitions(req.GetView(), int(req.GetPageSize()), req.GetPageToken())
 	if err != nil {
-		return &modelPB.ListModelDefinitionResponse{}, err
+		return &modelPB.ListModelDefinitionsResponse{}, err
 	}
 
 	pbDefinitions := []*modelPB.ModelDefinition{}
@@ -2517,7 +2517,7 @@ func (h *handler) ListModelDefinition(ctx context.Context, req *modelPB.ListMode
 		pbDefinitions = append(pbDefinitions, DBModelDefinitionToPBModelDefinition(&dbModelDefinition))
 	}
 
-	resp := modelPB.ListModelDefinitionResponse{
+	resp := modelPB.ListModelDefinitionsResponse{
 		ModelDefinitions: pbDefinitions,
 		NextPageToken:    nextPageToken,
 		TotalSize:        totalSize,
@@ -2590,17 +2590,17 @@ func (h *handler) GetModelOperation(ctx context.Context, req *modelPB.GetModelOp
 	}
 }
 
-func (h *handler) ListModelOperation(ctx context.Context, req *modelPB.ListModelOperationRequest) (*modelPB.ListModelOperationResponse, error) {
+func (h *handler) ListModelOperation(ctx context.Context, req *modelPB.ListModelOperationsRequest) (*modelPB.ListModelOperationsResponse, error) {
 	pageSize := util.DefaultPageSize
 	if req.PageSize != nil {
 		pageSize = int(*req.PageSize)
 	}
 	operations, _, nextPageToken, totalSize, err := h.service.ListOperation(pageSize, req.PageToken)
 	if err != nil {
-		return &modelPB.ListModelOperationResponse{}, err
+		return &modelPB.ListModelOperationsResponse{}, err
 	}
 
-	return &modelPB.ListModelOperationResponse{
+	return &modelPB.ListModelOperationsResponse{
 		Operations:    operations,
 		NextPageToken: nextPageToken,
 		TotalSize:     totalSize,

--- a/pkg/handler/mock_service_test.go
+++ b/pkg/handler/mock_service_test.go
@@ -234,27 +234,10 @@ func (mr *MockServiceMockRecorder) GetTritonModels(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTritonModels", reflect.TypeOf((*MockService)(nil).GetTritonModels), arg0)
 }
 
-// ListModel mocks base method.
-func (m *MockService) ListModel(arg0 string, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.Model, string, int64, error) {
+// ListModelDefinitions mocks base method.
+func (m *MockService) ListModelDefinitions(arg0 modelv1alpha.View, arg1 int, arg2 string) ([]datamodel.ModelDefinition, string, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModel", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]datamodel.Model)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(int64)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
-}
-
-// ListModel indicates an expected call of ListModel.
-func (mr *MockServiceMockRecorder) ListModel(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModel", reflect.TypeOf((*MockService)(nil).ListModel), arg0, arg1, arg2, arg3)
-}
-
-// ListModelDefinition mocks base method.
-func (m *MockService) ListModelDefinition(arg0 modelv1alpha.View, arg1 int, arg2 string) ([]datamodel.ModelDefinition, string, int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelDefinition", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListModelDefinitions", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]datamodel.ModelDefinition)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(int64)
@@ -262,16 +245,16 @@ func (m *MockService) ListModelDefinition(arg0 modelv1alpha.View, arg1 int, arg2
 	return ret0, ret1, ret2, ret3
 }
 
-// ListModelDefinition indicates an expected call of ListModelDefinition.
-func (mr *MockServiceMockRecorder) ListModelDefinition(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ListModelDefinitions indicates an expected call of ListModelDefinitions.
+func (mr *MockServiceMockRecorder) ListModelDefinitions(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinition", reflect.TypeOf((*MockService)(nil).ListModelDefinition), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinitions", reflect.TypeOf((*MockService)(nil).ListModelDefinitions), arg0, arg1, arg2)
 }
 
-// ListModelInstance mocks base method.
-func (m *MockService) ListModelInstance(arg0 uuid.UUID, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.ModelInstance, string, int64, error) {
+// ListModelInstances mocks base method.
+func (m *MockService) ListModelInstances(arg0 uuid.UUID, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.ModelInstance, string, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelInstance", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ListModelInstances", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]datamodel.ModelInstance)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(int64)
@@ -279,10 +262,27 @@ func (m *MockService) ListModelInstance(arg0 uuid.UUID, arg1 modelv1alpha.View, 
 	return ret0, ret1, ret2, ret3
 }
 
-// ListModelInstance indicates an expected call of ListModelInstance.
-func (mr *MockServiceMockRecorder) ListModelInstance(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// ListModelInstances indicates an expected call of ListModelInstances.
+func (mr *MockServiceMockRecorder) ListModelInstances(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelInstance", reflect.TypeOf((*MockService)(nil).ListModelInstance), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelInstances", reflect.TypeOf((*MockService)(nil).ListModelInstances), arg0, arg1, arg2, arg3)
+}
+
+// ListModels mocks base method.
+func (m *MockService) ListModels(arg0 string, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.Model, string, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListModels", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]datamodel.Model)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(int64)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// ListModels indicates an expected call of ListModels.
+func (mr *MockServiceMockRecorder) ListModels(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModels", reflect.TypeOf((*MockService)(nil).ListModels), arg0, arg1, arg2, arg3)
 }
 
 // ListOperation mocks base method.

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -19,19 +19,19 @@ type Repository interface {
 	GetModelByUid(owner string, modelUID uuid.UUID, view modelPB.View) (datamodel.Model, error)
 	DeleteModel(modelUID uuid.UUID) error
 	UpdateModel(modelUID uuid.UUID, updatedModel datamodel.Model) error
-	ListModel(owner string, view modelPB.View, pageSize int, pageToken string) (models []datamodel.Model, nextPageToken string, totalSize int64, err error)
+	ListModels(owner string, view modelPB.View, pageSize int, pageToken string) (models []datamodel.Model, nextPageToken string, totalSize int64, err error)
 	CreateModelInstance(instance datamodel.ModelInstance) error
 	UpdateModelInstance(modelInstanceUID uuid.UUID, instanceInfo datamodel.ModelInstance) error
 	GetModelInstance(modelUID uuid.UUID, instanceID string, view modelPB.View) (datamodel.ModelInstance, error)
 	GetModelInstanceByUid(modelUID uuid.UUID, modelInstanceUid uuid.UUID, view modelPB.View) (datamodel.ModelInstance, error)
 	GetModelInstances(modelUID uuid.UUID) ([]datamodel.ModelInstance, error)
-	ListModelInstance(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) (instances []datamodel.ModelInstance, nextPageToken string, totalSize int64, err error)
+	ListModelInstances(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) (instances []datamodel.ModelInstance, nextPageToken string, totalSize int64, err error)
 	CreateTritonModel(model datamodel.TritonModel) error
 	GetTritonModels(modelInstanceUID uuid.UUID) ([]datamodel.TritonModel, error)
 	GetTritonEnsembleModel(modelInstanceUID uuid.UUID) (datamodel.TritonModel, error)
 	GetModelDefinition(id string) (datamodel.ModelDefinition, error)
 	GetModelDefinitionByUid(uid uuid.UUID) (datamodel.ModelDefinition, error)
-	ListModelDefinition(view modelPB.View, pageSize int, pageToken string) (definitions []datamodel.ModelDefinition, nextPageToken string, totalSize int64, err error)
+	ListModelDefinitions(view modelPB.View, pageSize int, pageToken string) (definitions []datamodel.ModelDefinition, nextPageToken string, totalSize int64, err error)
 }
 
 // DefaultPageSize is the default pagination page size when page size is not assigned
@@ -107,7 +107,7 @@ func (r *repository) GetModelByUid(owner string, modelUID uuid.UUID, view modelP
 	return model, nil
 }
 
-func (r *repository) ListModel(owner string, view modelPB.View, pageSize int, pageToken string) (models []datamodel.Model, nextPageToken string, totalSize int64, err error) {
+func (r *repository) ListModels(owner string, view modelPB.View, pageSize int, pageToken string) (models []datamodel.Model, nextPageToken string, totalSize int64, err error) {
 	if result := r.db.Model(&datamodel.Model{}).Where("owner = ?", owner).Count(&totalSize); result.Error != nil {
 		return nil, "", 0, status.Errorf(codes.Internal, result.Error.Error())
 	}
@@ -229,7 +229,7 @@ func (r *repository) GetModelInstances(modelUID uuid.UUID) ([]datamodel.ModelIns
 	return instances, nil
 }
 
-func (r *repository) ListModelInstance(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) (instances []datamodel.ModelInstance, nextPageToken string, totalSize int64, err error) {
+func (r *repository) ListModelInstances(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) (instances []datamodel.ModelInstance, nextPageToken string, totalSize int64, err error) {
 
 	if result := r.db.Model(&datamodel.ModelInstance{}).Where("model_uid = ?", modelUID).Count(&totalSize); result.Error != nil {
 		return nil, "", 0, status.Errorf(codes.Internal, result.Error.Error())
@@ -339,7 +339,7 @@ func (r *repository) GetModelDefinitionByUid(uid uuid.UUID) (datamodel.ModelDefi
 	return definitionDB, nil
 }
 
-func (r *repository) ListModelDefinition(view modelPB.View, pageSize int, pageToken string) (definitions []datamodel.ModelDefinition, nextPageToken string, totalSize int64, err error) {
+func (r *repository) ListModelDefinitions(view modelPB.View, pageSize int, pageToken string) (definitions []datamodel.ModelDefinition, nextPageToken string, totalSize int64, err error) {
 	if result := r.db.Model(&datamodel.ModelDefinition{}).Count(&totalSize); result.Error != nil {
 		return nil, "", 0, status.Errorf(codes.Internal, result.Error.Error())
 	}

--- a/pkg/service/mock_repository_test.go
+++ b/pkg/service/mock_repository_test.go
@@ -227,27 +227,10 @@ func (mr *MockRepositoryMockRecorder) GetTritonModels(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTritonModels", reflect.TypeOf((*MockRepository)(nil).GetTritonModels), arg0)
 }
 
-// ListModel mocks base method.
-func (m *MockRepository) ListModel(arg0 string, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.Model, string, int64, error) {
+// ListModelDefinitions mocks base method.
+func (m *MockRepository) ListModelDefinitions(arg0 modelv1alpha.View, arg1 int, arg2 string) ([]datamodel.ModelDefinition, string, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModel", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]datamodel.Model)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(int64)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
-}
-
-// ListModel indicates an expected call of ListModel.
-func (mr *MockRepositoryMockRecorder) ListModel(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModel", reflect.TypeOf((*MockRepository)(nil).ListModel), arg0, arg1, arg2, arg3)
-}
-
-// ListModelDefinition mocks base method.
-func (m *MockRepository) ListModelDefinition(arg0 modelv1alpha.View, arg1 int, arg2 string) ([]datamodel.ModelDefinition, string, int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelDefinition", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListModelDefinitions", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]datamodel.ModelDefinition)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(int64)
@@ -255,16 +238,16 @@ func (m *MockRepository) ListModelDefinition(arg0 modelv1alpha.View, arg1 int, a
 	return ret0, ret1, ret2, ret3
 }
 
-// ListModelDefinition indicates an expected call of ListModelDefinition.
-func (mr *MockRepositoryMockRecorder) ListModelDefinition(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ListModelDefinitions indicates an expected call of ListModelDefinitions.
+func (mr *MockRepositoryMockRecorder) ListModelDefinitions(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinition", reflect.TypeOf((*MockRepository)(nil).ListModelDefinition), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinitions", reflect.TypeOf((*MockRepository)(nil).ListModelDefinitions), arg0, arg1, arg2)
 }
 
-// ListModelInstance mocks base method.
-func (m *MockRepository) ListModelInstance(arg0 uuid.UUID, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.ModelInstance, string, int64, error) {
+// ListModelInstances mocks base method.
+func (m *MockRepository) ListModelInstances(arg0 uuid.UUID, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.ModelInstance, string, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelInstance", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ListModelInstances", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]datamodel.ModelInstance)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(int64)
@@ -272,10 +255,27 @@ func (m *MockRepository) ListModelInstance(arg0 uuid.UUID, arg1 modelv1alpha.Vie
 	return ret0, ret1, ret2, ret3
 }
 
-// ListModelInstance indicates an expected call of ListModelInstance.
-func (mr *MockRepositoryMockRecorder) ListModelInstance(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// ListModelInstances indicates an expected call of ListModelInstances.
+func (mr *MockRepositoryMockRecorder) ListModelInstances(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelInstance", reflect.TypeOf((*MockRepository)(nil).ListModelInstance), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelInstances", reflect.TypeOf((*MockRepository)(nil).ListModelInstances), arg0, arg1, arg2, arg3)
+}
+
+// ListModels mocks base method.
+func (m *MockRepository) ListModels(arg0 string, arg1 modelv1alpha.View, arg2 int, arg3 string) ([]datamodel.Model, string, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListModels", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]datamodel.Model)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(int64)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// ListModels indicates an expected call of ListModels.
+func (mr *MockRepositoryMockRecorder) ListModels(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModels", reflect.TypeOf((*MockRepository)(nil).ListModels), arg0, arg1, arg2, arg3)
 }
 
 // UpdateModel mocks base method.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -44,18 +44,18 @@ type Service interface {
 	PublishModel(owner string, modelID string) (datamodel.Model, error)
 	UnpublishModel(owner string, modelID string) (datamodel.Model, error)
 	UpdateModel(modelUID uuid.UUID, model *datamodel.Model) (datamodel.Model, error)
-	ListModel(owner string, view modelPB.View, pageSize int, pageToken string) ([]datamodel.Model, string, int64, error)
+	ListModels(owner string, view modelPB.View, pageSize int, pageToken string) ([]datamodel.Model, string, int64, error)
 	ModelInfer(modelInstanceUID uuid.UUID, inferInput InferInput, task modelPB.ModelInstance_Task) ([]*modelPB.TaskOutput, error)
 	ModelInferTestMode(owner string, modelInstanceUID uuid.UUID, inferInput InferInput, task modelPB.ModelInstance_Task) ([]*modelPB.TaskOutput, error)
 	GetModelInstance(modelUID uuid.UUID, instanceID string, view modelPB.View) (datamodel.ModelInstance, error)
 	GetModelInstanceByUid(modelUID uuid.UUID, instanceUID uuid.UUID, view modelPB.View) (datamodel.ModelInstance, error)
 	UpdateModelInstance(modelInstanceUID uuid.UUID, instanceInfo datamodel.ModelInstance) error
-	ListModelInstance(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelInstance, string, int64, error)
+	ListModelInstances(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelInstance, string, int64, error)
 	DeployModelInstanceAsync(owner string, modelUID uuid.UUID, modelInstanceUID uuid.UUID) (string, error)
 	UndeployModelInstanceAsync(owner string, modelUID uuid.UUID, modelInstanceUID uuid.UUID) (string, error)
 	GetModelDefinition(id string) (datamodel.ModelDefinition, error)
 	GetModelDefinitionByUid(uid uuid.UUID) (datamodel.ModelDefinition, error)
-	ListModelDefinition(view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelDefinition, string, int64, error)
+	ListModelDefinitions(view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelDefinition, string, int64, error)
 	GetTritonEnsembleModel(modelInstanceUID uuid.UUID) (datamodel.TritonModel, error)
 	GetTritonModels(modelInstanceUID uuid.UUID) ([]datamodel.TritonModel, error)
 	GetOperation(workflowId string) (*longrunningpb.Operation, *worker.ModelInstanceParams, string, error)
@@ -602,8 +602,8 @@ func (s *service) ModelInfer(modelInstanceUID uuid.UUID, inferInput InferInput, 
 	}
 }
 
-func (s *service) ListModel(owner string, view modelPB.View, pageSize int, pageToken string) ([]datamodel.Model, string, int64, error) {
-	return s.repository.ListModel(owner, view, pageSize, pageToken)
+func (s *service) ListModels(owner string, view modelPB.View, pageSize int, pageToken string) ([]datamodel.Model, string, int64, error) {
+	return s.repository.ListModels(owner, view, pageSize, pageToken)
 }
 
 func (s *service) DeleteModel(owner string, modelID string) error {
@@ -750,8 +750,8 @@ func (s *service) GetModelInstanceByUid(modelUID uuid.UUID, modelInstanceUid uui
 	return s.repository.GetModelInstanceByUid(modelUID, modelInstanceUid, view)
 }
 
-func (s *service) ListModelInstance(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelInstance, string, int64, error) {
-	return s.repository.ListModelInstance(modelUID, view, pageSize, pageToken)
+func (s *service) ListModelInstances(modelUID uuid.UUID, view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelInstance, string, int64, error) {
+	return s.repository.ListModelInstances(modelUID, view, pageSize, pageToken)
 }
 
 func (s *service) GetModelDefinition(id string) (datamodel.ModelDefinition, error) {
@@ -762,8 +762,8 @@ func (s *service) GetModelDefinitionByUid(uid uuid.UUID) (datamodel.ModelDefinit
 	return s.repository.GetModelDefinitionByUid(uid)
 }
 
-func (s *service) ListModelDefinition(view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelDefinition, string, int64, error) {
-	return s.repository.ListModelDefinition(view, pageSize, pageToken)
+func (s *service) ListModelDefinitions(view modelPB.View, pageSize int, pageToken string) ([]datamodel.ModelDefinition, string, int64, error) {
+	return s.repository.ListModelDefinitions(view, pageSize, pageToken)
 }
 
 func (s *service) GetTritonEnsembleModel(modelInstanceUID uuid.UUID) (datamodel.TritonModel, error) {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -65,20 +65,20 @@ type Service interface {
 }
 
 type service struct {
-	repository            repository.Repository
-	triton                triton.Triton
-	redisClient           *redis.Client
-	pipelineServiceClient pipelinePB.PipelineServiceClient
-	temporalClient        client.Client
+	repository                  repository.Repository
+	triton                      triton.Triton
+	redisClient                 *redis.Client
+	pipelinePublicServiceClient pipelinePB.PipelinePublicServiceClient
+	temporalClient              client.Client
 }
 
-func NewService(r repository.Repository, t triton.Triton, p pipelinePB.PipelineServiceClient, rc *redis.Client, tc client.Client) Service {
+func NewService(r repository.Repository, t triton.Triton, p pipelinePB.PipelinePublicServiceClient, rc *redis.Client, tc client.Client) Service {
 	return &service{
-		repository:            r,
-		triton:                t,
-		pipelineServiceClient: p,
-		redisClient:           rc,
-		temporalClient:        tc,
+		repository:                  r,
+		triton:                      t,
+		pipelinePublicServiceClient: p,
+		redisClient:                 rc,
+		temporalClient:              tc,
 	}
 }
 
@@ -616,7 +616,7 @@ func (s *service) DeleteModel(owner string, modelID string) error {
 
 	filter := fmt.Sprintf("recipe.model_instances:\"models/%s\"", modelInDB.UID)
 
-	pipeResp, err := s.pipelineServiceClient.ListPipeline(context.Background(), &pipelinePB.ListPipelineRequest{
+	pipeResp, err := s.pipelinePublicServiceClient.ListPipelines(context.Background(), &pipelinePB.ListPipelinesRequest{
 		Filter: &filter,
 	})
 	if err != nil {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -316,12 +316,12 @@ func TestListModell(t *testing.T) {
 		mockRepository := NewMockRepository(ctrl)
 		mockRepository.
 			EXPECT().
-			ListModel(OWNER, modelPB.View_VIEW_FULL, int(100), "").
+			ListModels(OWNER, modelPB.View_VIEW_FULL, int(100), "").
 			Return([]datamodel.Model{}, "", int64(100), nil).
 			Times(1)
 		s := service.NewService(mockRepository, nil, nil, nil, nil)
 
-		_, _, _, err := s.ListModel(OWNER, modelPB.View_VIEW_FULL, 100, "")
+		_, _, _, err := s.ListModels(OWNER, modelPB.View_VIEW_FULL, 100, "")
 		assert.NoError(t, err)
 	})
 }
@@ -407,7 +407,7 @@ func TestGetModelInstanceByUid(t *testing.T) {
 	})
 }
 
-func TestListModelInstance(t *testing.T) {
+func TestListModelInstances(t *testing.T) {
 	t.Run("TestListModelInstance", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
@@ -415,12 +415,12 @@ func TestListModelInstance(t *testing.T) {
 		mockRepository := NewMockRepository(ctrl)
 		mockRepository.
 			EXPECT().
-			ListModelInstance(modelUID, modelPB.View_VIEW_FULL, 100, "").
+			ListModelInstances(modelUID, modelPB.View_VIEW_FULL, 100, "").
 			Return([]datamodel.ModelInstance{}, "", int64(100), nil).
 			Times(1)
 		s := service.NewService(mockRepository, nil, nil, nil, nil)
 
-		_, _, _, err := s.ListModelInstance(modelUID, modelPB.View_VIEW_FULL, 100, "")
+		_, _, _, err := s.ListModelInstances(modelUID, modelPB.View_VIEW_FULL, 100, "")
 		assert.NoError(t, err)
 	})
 }
@@ -512,19 +512,19 @@ func TestGetModelDefinition(t *testing.T) {
 	})
 }
 
-func TestListModelDefinition(t *testing.T) {
+func TestListModelDefinitions(t *testing.T) {
 	t.Run("TestListModelDefinition", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
 		mockRepository := NewMockRepository(ctrl)
 		mockRepository.
 			EXPECT().
-			ListModelDefinition(modelPB.View_VIEW_FULL, int(100), "").
+			ListModelDefinitions(modelPB.View_VIEW_FULL, int(100), "").
 			Return([]datamodel.ModelDefinition{}, "", int64(100), nil).
 			Times(1)
 		s := service.NewService(mockRepository, nil, nil, nil, nil)
 
-		_, _, _, err := s.ListModelDefinition(modelPB.View_VIEW_FULL, 100, "")
+		_, _, _, err := s.ListModelDefinitions(modelPB.View_VIEW_FULL, 100, "")
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -96,7 +96,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 			var mTask = make(map[datamodel.ModelInstanceTask]bool) // use for creating unique task list
 			var mDef = make(map[string]bool)                       // use for creating unique model definition list
 			for {
-				dbModels, modelNextPageToken, _, err := u.repository.ListModel(fmt.Sprintf("users/%s", user.GetUid()), modelPB.View_VIEW_BASIC, repository.MaxPageSize, modelPageToken)
+				dbModels, modelNextPageToken, _, err := u.repository.ListModels(fmt.Sprintf("users/%s", user.GetUid()), modelPB.View_VIEW_BASIC, repository.MaxPageSize, modelPageToken)
 				if err != nil {
 					logger.Error(fmt.Sprintf("%s", err))
 				}
@@ -115,7 +115,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 					}
 
 					for {
-						dbInstances, instanceNextPageToken, _, err := u.repository.ListModelInstance(model.UID, modelPB.View_VIEW_BASIC, repository.MaxPageSize, instancePageToken)
+						dbInstances, instanceNextPageToken, _, err := u.repository.ListModelInstances(model.UID, modelPB.View_VIEW_BASIC, repository.MaxPageSize, instancePageToken)
 						if err != nil {
 							logger.Error(fmt.Sprintf("%s", err))
 						}

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -28,15 +28,15 @@ type Usage interface {
 }
 
 type usage struct {
-	repository        repository.Repository
-	mgmtAdminServiceClient mgmtPB.MgmtAdminServiceClient
-	redisClient       *redis.Client
-	reporter          usageReporter.Reporter
-	version           string
+	repository               repository.Repository
+	mgmtPrivateServiceClient mgmtPB.MgmtPrivateServiceClient
+	redisClient              *redis.Client
+	reporter                 usageReporter.Reporter
+	version                  string
 }
 
 // NewUsage initiates a usage instance
-func NewUsage(ctx context.Context, r repository.Repository, u mgmtPB.MgmtAdminServiceClient, rc *redis.Client, usc usagePB.UsageServiceClient) Usage {
+func NewUsage(ctx context.Context, r repository.Repository, u mgmtPB.MgmtPrivateServiceClient, rc *redis.Client, usc usagePB.UsageServiceClient) Usage {
 	logger, _ := logger.GetZapLogger()
 
 	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
@@ -52,11 +52,11 @@ func NewUsage(ctx context.Context, r repository.Repository, u mgmtPB.MgmtAdminSe
 	}
 
 	return &usage{
-		repository:        r,
-		mgmtAdminServiceClient: u,
-		redisClient:       rc,
-		reporter:          reporter,
-		version:           version,
+		repository:               r,
+		mgmtPrivateServiceClient: u,
+		redisClient:              rc,
+		reporter:                 reporter,
+		version:                  version,
 	}
 }
 
@@ -73,7 +73,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 	userPageToken := ""
 	userPageSizeMax := int64(repository.MaxPageSize)
 	for {
-		userResp, err := u.mgmtAdminServiceClient.ListUser(ctx, &mgmtPB.ListUserRequest{
+		userResp, err := u.mgmtPrivateServiceClient.ListUsersAdmin(ctx, &mgmtPB.ListUsersAdminRequest{
 			PageSize:  &userPageSizeMax,
 			PageToken: &userPageToken,
 		})


### PR DESCRIPTION
Because

- adopt the updated protobuf public/private APIs

This commit

- update integration-test proto files
- update model service to adopt public/private APIs
- add gRPC operation test cases
