### PR TITLE
fix(config): use private port for mgmt-backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,9 +55,9 @@ type TritonServerConfig struct {
 
 // MgmtBackendConfig related to mgmt-backend
 type MgmtBackendConfig struct {
-	Host       string `koanf:"host"`
-	PublicPort int    `koanf:"publicport"`
-	HTTPS      struct {
+	Host        string `koanf:"host"`
+	PrivatePort int    `koanf:"privateport"`
+	HTTPS       struct {
 		Cert string `koanf:"cert"`
 		Key  string `koanf:"key"`
 	}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,7 +27,7 @@ tritonserver:
   modelstore: /model-repository
 mgmtbackend:
   host: mgmt-backend
-  publicport: 3084
+  privateport: 3084
   https:
     cert:
     key:

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,6 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385 h1:s1HBz/jqcXWI+1iECP2t6epkFLncLjsgJr69CGVRMF8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230311161800-000e8cb60385/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230314172914-1976737846cb h1:CxIAqYo7klOycw/qzTAmQJ0JHn74UuJjUzssPAF4KNw=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230314172914-1976737846cb/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.2-alpha h1:EQyHpgzZ26TEIL9UoaqchTf+LnKaidUGhKlUEFR68I8=

--- a/internal/external/external.go
+++ b/internal/external/external.go
@@ -36,7 +36,7 @@ func InitMgmtPrivateServiceClient() (mgmtPB.MgmtPrivateServiceClient, *grpc.Clie
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PublicPort), clientDialOpts)
+	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PrivatePort), clientDialOpts)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}


### PR DESCRIPTION
Because

- the mgmt-backend port used is the private port

This commit

- fix mgmt backend port naming
