### PR TITLE
feat: support model caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN tar -xf ArtiVC-v${ARTIVC_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/l
 RUN mkdir /etc/vdp
 RUN mkdir /vdp
 RUN mkdir /model-repository
+RUN mkdir /.cache
 
 FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_VERSION}
 
@@ -69,3 +70,4 @@ COPY --from=build --chown=nobody:nogroup /usr/local/bin/avc /usr/local/bin/avc
 COPY --from=build --chown=nobody:nogroup /etc/vdp /etc/vdp
 COPY --from=build --chown=nobody:nogroup /vdp /vdp
 COPY --from=build --chown=nobody:nogroup /model-repository /model-repository
+COPY --from=build --chown=nobody:nogroup /.cache /.cache

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -47,6 +47,7 @@ COPY . .
 
 RUN chown -R nobody:nogroup /go
 RUN chown -R nobody:nogroup /tmp
+RUN chown -R nobody:nogroup /.cache
 
 ENV GOCACHE /go/.cache/go-build
 ENV GOENV /go/.config/go/env

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ dev:							## Run dev container
 	@docker run -d --rm \
 		-v $(PWD):/${SERVICE_NAME} \
 		-v model-repository:/model-repository \
+		-v ~/.cache/instill:/.cache \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
 		--network instill-network \
 		--name ${SERVICE_NAME} \

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ type CacheConfig struct {
 	Redis struct {
 		RedisOptions redis.Options `koanf:"redisoptions"`
 	}
+	Model bool `koanf:"model"`
 }
 
 // UsageServerConfig related to usage-server

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,7 +35,7 @@ cache:
   redis:
     redisoptions:
       addr: redis:6379
-  model: false
+  model: true
 usageserver:
   tlsenabled: true
   host: usage.instill.tech

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,6 +35,7 @@ cache:
   redis:
     redisoptions:
       addr: redis:6379
+  model: true
 usageserver:
   tlsenabled: true
   host: usage.instill.tech

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,7 +35,7 @@ cache:
   redis:
     redisoptions:
       addr: redis:6379
-  model: true
+  model: false
 usageserver:
   tlsenabled: true
   host: usage.instill.tech

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -787,7 +787,7 @@ func createGitHubModel(h *PublicHandler, ctx context.Context, req *modelPB.Creat
 		}
 
 		if config.Config.Server.ItMode { // use local model for testing to remove internet connection issue while testing
-			cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("mkdir %s; cp -rf assets/model-dummy-cls/* %s", modelSrcDir, modelSrcDir))
+			cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("mkdir -p %s > /dev/null; cp -rf assets/model-dummy-cls/* %s", modelSrcDir, modelSrcDir))
 			if err := cmd.Run(); err != nil {
 				util.RemoveModelRepository(config.Config.TritonServer.ModelStore, owner, githubModel.ID, tag.Name)
 				return &modelPB.CreateModelResponse{}, err
@@ -1012,7 +1012,7 @@ func createArtiVCModel(h *PublicHandler, ctx context.Context, req *modelPB.Creat
 		rdid, _ := uuid.NewV4()
 		modelSrcDir := fmt.Sprintf("/tmp/%v", rdid.String())
 		if config.Config.Server.ItMode { // use local model for testing to remove internet connection issue while testing
-			cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("mkdir %s; cp -rf assets/model-dummy-cls/* %s", modelSrcDir, modelSrcDir))
+			cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("mkdir -p %s > /dev/null; cp -rf assets/model-dummy-cls/* %s", modelSrcDir, modelSrcDir))
 			if err := cmd.Run(); err != nil {
 				util.RemoveModelRepository(config.Config.TritonServer.ModelStore, owner, artivcModel.ID, tag)
 				return &modelPB.CreateModelResponse{}, err
@@ -1213,7 +1213,7 @@ func createHuggingFaceModel(h *PublicHandler, ctx context.Context, req *modelPB.
 	rdid, _ := uuid.NewV4()
 	configTmpDir := fmt.Sprintf("/tmp/%s", rdid.String())
 	if config.Config.Server.ItMode { // use local model for testing to remove internet connection issue while testing
-		cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("mkdir %s; cp -rf assets/tiny-vit-random/* %s", configTmpDir, configTmpDir))
+		cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("mkdir -p %s > /dev/null; cp -rf assets/tiny-vit-random/* %s", configTmpDir, configTmpDir))
 		if err := cmd.Run(); err != nil {
 			_ = os.RemoveAll(configTmpDir)
 			return &modelPB.CreateModelResponse{}, err

--- a/pkg/triton/triton.go
+++ b/pkg/triton/triton.go
@@ -933,11 +933,5 @@ func (ts *triton) IsTritonServerReady() bool {
 		return false
 	}
 	fmt.Printf("Triton Health - Live: %v\n", serverLiveResponse.Live)
-	if !serverLiveResponse.Live {
-		return false
-	}
-
-	serverReadyResponse := ts.ServerReadyRequest()
-	fmt.Printf("Triton Health - Ready: %v\n", serverReadyResponse.Ready)
-	return serverReadyResponse.Ready
+	return serverLiveResponse.Live
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -88,3 +88,6 @@ const (
 	TEXT_GENERATION_TOP_K      = int64(1)
 	TEXT_GENERATION_SEED       = int64(0)
 )
+
+const MODEL_CACHE_DIR = "/.cache/models"
+const MODEL_CACHE_FILE = "cached_models.json"

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -212,7 +212,7 @@ func UpdateModelPath(modelDir string, dstDir string, owner string, modelID strin
 	var readmeFilePath string
 	files := []FileMeta{}
 	var configFiles []string
-	var fileRe = regexp.MustCompile(`.git|.dvc|.dvcignore`)
+	var fileRe = regexp.MustCompile(`/.git|/.dvc|/.dvcignore`)
 	err := filepath.Walk(modelDir, func(path string, f os.FileInfo, err error) error {
 		if !fileRe.MatchString(path) {
 			files = append(files, FileMeta{
@@ -243,7 +243,6 @@ func UpdateModelPath(modelDir string, dstDir string, owner string, modelID strin
 		oldModelName := subStrs[0]
 		subStrs[0] = fmt.Sprintf("%v#%v#%v#%v", owner, modelID, oldModelName, modelInstance.ID)
 		var filePath = filepath.Join(dstDir, strings.Join(subStrs, "/"))
-
 		if f.fInfo.IsDir() { // create new folder
 			err = os.MkdirAll(filePath, os.ModePerm)
 
@@ -388,4 +387,17 @@ func SaveFile(stream modelPB.ModelPublicService_CreateModelBinaryFileUploadServe
 		}
 	}
 	return tmpFile, &uploadedModel, modelDefinitionID, nil
+}
+
+// CreateFolder creates a folder if it does not exist.
+func CreateFolder(dstDir string) error {
+	if _, err := os.Stat(dstDir); os.IsNotExist(err) {
+		err := os.MkdirAll(dstDir, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("folder already exists")
+	}
+	return nil
 }


### PR DESCRIPTION
Because

- the model downloading time is quite long for huge models

This commit

- support caching model into` ~/.cache/instill/models` when enabling the config `cache.model = true`
