### PR TITLE
chore: create cache dir in Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -47,7 +47,7 @@ COPY . .
 
 RUN chown -R nobody:nogroup /go
 RUN chown -R nobody:nogroup /tmp
-RUN chown -R nobody:nogroup /.cache
+RUN mkdir /.cache && chown -R nobody:nogroup /.cache
 
 ENV GOCACHE /go/.cache/go-build
 ENV GOENV /go/.config/go/env


### PR DESCRIPTION
Because

- support a caching model in model-backend

This commit

- add cache dir in Dockerfile
