### PR TITLE
test: refactor ListModelOperations test

### DIFF
--- a/integration-test/grpc_model_operation.js
+++ b/integration-test/grpc_model_operation.js
@@ -57,9 +57,23 @@ export function ListModelOperations() {
             "ListModelOperations response operations.length": (r) => r.message.operations.length > 0,
             "ListModelOperations response operations[0].name": (r) => r.message.operations[0].name != undefined,
             "ListModelOperations response operations[0].done": (r) => r.message.operations[0].done != undefined,
-            "ListModelOperations response operations[0].response": (r) => r.message.operations[0].response != undefined,
             "ListModelOperations response operations[0].metadata": (r) => r.message.operations[0].metadata === null,
         });
+
+         // Check the operation response by waiting for the operation is done
+        currentTime = new Date().getTime();
+        timeoutTime = new Date().getTime() + 120000;
+        while (timeoutTime > currentTime) {
+            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelOperations', {}, {})
+            if (res.status === 200 && res.message.operations[0].done === true) {
+                check(res, {
+                    "ListModelOperations response operations[0].response": (r) => r.message.operations[0].response != undefined,
+                })
+                break
+            }
+            sleep(1)
+            currentTime = new Date().getTime();
+        }
 
         // Check model creation finished
         let currentTime = new Date().getTime();

--- a/integration-test/grpc_model_operation.js
+++ b/integration-test/grpc_model_operation.js
@@ -60,24 +60,18 @@ export function ListModelOperations() {
             "ListModelOperations response operations[0].metadata": (r) => r.message.operations[0].metadata === null,
         });
 
-         // Check the operation response by waiting for the operation is done
-        let currentTime = new Date().getTime();
-        let timeoutTime = new Date().getTime() + 120000;
-        while (timeoutTime > currentTime) {
-            let res = client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelOperations', {}, {})
-            if (res.status === 200 && res.message.operations[0].done === true) {
-                check(res, {
-                    "ListModelOperations response operations[0].response": (r) => r.message.operations[0].response != undefined,
+        // Check the operation response by waiting for the operation is done
+        for (const op of client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelOperations', {}, {}).message.operations) {
+            if (op.done === true) {
+            check(op, {
+                "ListModelOperations operation has error or response fields": (r) => op.response != undefined || op.error != undefined,
                 })
-                break
             }
-            sleep(1)
-            currentTime = new Date().getTime();
         }
 
         // Check model creation finished
-        currentTime = new Date().getTime();
-        timeoutTime = new Date().getTime() + 120000;
+        let currentTime = new Date().getTime();
+        let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
             let res = client.invoke('vdp.model.v1alpha.ModelPublicService/WatchModel', {
                 name: `models/${model_id}`

--- a/integration-test/grpc_model_operation.js
+++ b/integration-test/grpc_model_operation.js
@@ -64,7 +64,7 @@ export function ListModelOperations() {
         for (const op of client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelOperations', {}, {}).message.operations) {
             if (op.done === true) {
             check(op, {
-                "ListModelOperations operation has error or response fields": (r) => op.response != undefined || op.error != undefined,
+                "ListModelOperations operation has error or response fields": (r) => op.response !== undefined || op.error !== undefined,
                 })
             }
         }

--- a/integration-test/grpc_model_operation.js
+++ b/integration-test/grpc_model_operation.js
@@ -61,8 +61,8 @@ export function ListModelOperations() {
         });
 
          // Check the operation response by waiting for the operation is done
-        currentTime = new Date().getTime();
-        timeoutTime = new Date().getTime() + 120000;
+        let currentTime = new Date().getTime();
+        let timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
             let res = client.invoke('vdp.model.v1alpha.ModelPublicService/ListModelOperations', {}, {})
             if (res.status === 200 && res.message.operations[0].done === true) {
@@ -76,8 +76,8 @@ export function ListModelOperations() {
         }
 
         // Check model creation finished
-        let currentTime = new Date().getTime();
-        let timeoutTime = new Date().getTime() + 120000;
+        currentTime = new Date().getTime();
+        timeoutTime = new Date().getTime() + 120000;
         while (timeoutTime > currentTime) {
             let res = client.invoke('vdp.model.v1alpha.ModelPublicService/WatchModel', {
                 name: `models/${model_id}`


### PR DESCRIPTION
Because

- `ListModelOperations` is flaky since the response field won't exist if an operation is not done 

This commit

- fix the `ListModelOperations` test
