### PR TITLE
chore: return 404 for non-exist user and 401 for non-existent headers

### DIFF
--- a/integration-test/rest_create_model_with_jwt.js
+++ b/integration-test/rest_create_model_with_jwt.js
@@ -42,8 +42,8 @@ export function CreateModelFromLocal() {
       })
 
       check(createClsModelRes, {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/multipart task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/multipart task cls response status 404`]: (r) =>
+          r.status === 404,
       });
     });
 
@@ -74,8 +74,8 @@ export function CreateModelFromLocal() {
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] DELETE /v1alpha/models/${model_id} status not 204`]: (r) =>
-          r.status !== 204
+        [`[with random "jwt-sub" header] DELETE /v1alpha/models/${model_id} status 404`]: (r) =>
+          r.status === 404
       });
 
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
@@ -112,8 +112,8 @@ export function CreateModelFromGitHub() {
       })
 
       check(createClsModelRes, {
-        [`[with random "jwt-sub" header] POST /v1alpha/models task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models task cls response status 404`]: (r) =>
+          r.status === 404,
       });
     });
 
@@ -130,8 +130,8 @@ export function CreateModelFromGitHub() {
       check(http.request("GET", `${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, null, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id}/watch status 401`]: (r) =>
-          r.status === 401
+        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id}/watch status 404`]: (r) =>
+          r.status === 404
       });
 
       let currentTime = new Date().getTime();

--- a/integration-test/rest_deploy_model_with_jwt.js
+++ b/integration-test/rest_deploy_model_with_jwt.js
@@ -59,8 +59,8 @@ export function DeployUndeployModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/deploy`, {}, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/deploy online task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/deploy online task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/deploy`, {}, {
@@ -86,8 +86,8 @@ export function DeployUndeployModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/undeploy`, {}, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/undeploy online task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/undeploy online task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/undeploy`, {}, {

--- a/integration-test/rest_infer_model_with_jwt.js
+++ b/integration-test/rest_infer_model_with_jwt.js
@@ -88,8 +88,8 @@ export function TestModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
@@ -116,8 +116,8 @@ export function TestModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls multiple images status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls multiple images status 404`]: (r) =>
+          r.status === 404,
       });
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
         headers: genHeaderwithJwtSub(`application/json`, userUid),
@@ -138,8 +138,8 @@ export function TestModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
@@ -167,8 +167,8 @@ export function TestModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls multiple images status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls multiple images status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test`, payload, {
@@ -185,8 +185,8 @@ export function TestModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test-multipart`, fd.body(), {
         headers: genHeaderwithJwtSub(`multipart/form-data; boundary=${fd.boundary}`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test-multipart`, fd.body(), {
@@ -205,8 +205,8 @@ export function TestModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test-multipart`, fd.body(), {
         headers: genHeaderwithJwtSub(`multipart/form-data; boundary=${fd.boundary}`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls multiple images status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls multiple images status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/test-multipart`, fd.body(), {

--- a/integration-test/rest_model_card_with_jwt.js
+++ b/integration-test/rest_model_card_with_jwt.js
@@ -58,8 +58,8 @@ export function GetModelCard() {
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/readme`, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id}/readme response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id}/readme response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/readme`, {

--- a/integration-test/rest_publish_model_with_jwt.js
+++ b/integration-test/rest_publish_model_with_jwt.js
@@ -57,15 +57,15 @@ export function PublishUnpublishModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/publish`, null, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/publish task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/publish task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/unpublish`, null, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/unpublish task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/unpublish task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/publish`, null, {

--- a/integration-test/rest_query_model_with_jwt.js
+++ b/integration-test/rest_query_model_with_jwt.js
@@ -55,15 +55,15 @@ export function GetModel() {
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}`, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}?view=VIEW_FULL`, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}`, {
@@ -104,22 +104,22 @@ export function ListModels() {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       })
       check(resp, {
-        [`[with random "jwt-sub" header] GET /v1alpha/models task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models?page_size=1&page_token=${resp.json().next_page_token}`, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models?view=VIEW_FULL`, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models?view=VIEW_FULL task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models?view=VIEW_FULL task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       resp = http.get(`${constant.apiPublicHost}/v1alpha/models?page_size=1`, {
@@ -190,15 +190,15 @@ export function LookupModel() {
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelUid}/lookUp`, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL`, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelUid}/lookUp`, {

--- a/integration-test/rest_update_model_with_jwt.js
+++ b/integration-test/rest_update_model_with_jwt.js
@@ -63,8 +63,8 @@ export function UpdateModel() {
       check(http.patch(`${constant.apiPublicHost}/v1alpha/models/${model_id}`, payload, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4())
       }), {
-        [`[with random "jwt-sub" header] PATCH /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
-          r.status === 401,
+        [`[with random "jwt-sub" header] PATCH /v1alpha/models/${model_id} task cls response status 404`]: (r) =>
+          r.status === 404,
       });
 
       check(http.patch(`${constant.apiPublicHost}/v1alpha/models/${model_id}`, payload, {


### PR DESCRIPTION
Because

- currently, if a user does not exist in mgmt-backend, returns 500 status error

This commit

- return 404 when a user does not exist
- return 401 when both `jwt-sub` and `owner-id` does not exist in the header 
- update tests
