### PR TITLE
chore: set up connector-backend mTLS connection for Temporal

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
-	"go.temporal.io/sdk/client"
 )
 
 // ServerConfig defines HTTP server configurations
@@ -117,7 +116,12 @@ type MaxBatchSizeConfig struct {
 
 // TemporalConfig related to Temporal
 type TemporalConfig struct {
-	ClientOptions client.Options `koanf:"clientoptions"`
+	HostPort   string
+	Namespace  string
+	Ca         string
+	Cert       string
+	Key        string
+	ServerName string
 }
 
 // AppConfig defines

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -56,15 +56,18 @@ maxbatchsizelimitation:
   semanticsegmentation: 8
   textgeneration: 1
 temporal:
-  clientoptions:
-    hostport: temporal:7233
+  hostport: temporal:7233
+  namespace: model-backend
+  ca:
+  cert:
+  key:
+  servername:
 controller:
   host: controller
   privateport: 3085
   https:
     cert:
     key:
-initmodel: 
+initmodel:
   enabled: false
   path: https://raw.githubusercontent.com/instill-ai/vdp/main/model-hub/model_hub_cpu.json
-    

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230413171411-babae2994c35
 	github.com/instill-ai/usage-client v0.2.3-alpha
-	github.com/instill-ai/x v0.2.0-alpha
+	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1302,8 +1302,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230413171411-babae2994c35 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230413171411-babae2994c35/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.3-alpha h1:jdbCH6WJ7eUVudGtuDWaEsWmGX09ZFUnAHx+8S2MnDY=
 github.com/instill-ai/usage-client v0.2.3-alpha/go.mod h1:G0bnSyJw3ul8iNTpAGNslB18Qux0aMZF08h+CRICumw=
-github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=
-github.com/instill-ai/x v0.2.0-alpha/go.mod h1:/UEx/zFyMo7so2ctBY0pzjmIoJB9Qz5Y4gvwU2FoU74=
+github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=
+github.com/instill-ai/x v0.3.0-alpha/go.mod h1:YVYjkbqc5FKatJ+jZa1S/8e4xHkQ8j9V3RYboqBpoR0=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=


### PR DESCRIPTION
Because

- for users who like to connect with Temporal Cloud directly, currently the only way is by mTLS auth

This commit

- enables Temporal client TLS configuration