### PR TITLE
chore: fix missing config struct tags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,12 +116,12 @@ type MaxBatchSizeConfig struct {
 
 // TemporalConfig related to Temporal
 type TemporalConfig struct {
-	HostPort   string
-	Namespace  string
-	Ca         string
-	Cert       string
-	Key        string
-	ServerName string
+	HostPort   string `koanf:"hostport"`
+	Namespace  string `koanf:"namespace"`
+	Ca         string `koanf:"ca"`
+	Cert       string `koanf:"cert"`
+	Key        string `koanf:"key"`
+	ServerName string `koanf:"servername"`
 }
 
 // AppConfig defines


### PR DESCRIPTION
Because

- the temopral config struct tags are missing

This commit

- add the corresponding tags