### PR TITLE
chore: refactor integration test mode

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (pipeline)
         uses: actions/checkout@v3
@@ -130,7 +130,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (connector)
         uses: actions/checkout@v3
@@ -144,7 +144,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (mgmt)
         uses: actions/checkout@v3
@@ -158,4 +158,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,15 @@ unit-test:       				## Run unit test
 
 .PHONY: integration-test
 integration-test:				## Run integration test
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/grpc.js --no-usage-report --quiet
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/rest.js --no-usage-report --quiet
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/rest_with_jwt.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/grpc.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/rest.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/rest_with_jwt.js --no-usage-report --quiet
 
 .PHONY: help
 help:       	 				## Show this help

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -1,32 +1,29 @@
 let proto, host, publicPort, privatePort, mgmtHost, mgmtPrivatePort
 
-if (__ENV.MODE == "api-gateway") {
-    // api-gateway mode for accessing api-gateway directly
+if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
+    fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+  }
+  
+  export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+  
+  if (__ENV.API_GATEWAY_PROTOCOL) {
+    if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
+      fail("only allow `http` or `https` for API_GATEWAY_PROTOCOL")
+    }
+    proto = __ENV.API_GATEWAY_PROTOCOL
+  } else {
     proto = "http"
-    host = "api-gateway"
+  }
+  
+  if (apiGatewayMode) {
+    // api gateway mode
+    host = __ENV.API_GATEWAY_HOST
     publicPort = 8080
     privatePort = 3083
-    mgmtHost = "api-gateway"
-    mgmtPrivatePort = 3084
-} else if (__ENV.MODE == "localhost") {
-    // localhost mode for accessing api-gateway from localhost
-    proto = "http"
-    host = "localhost"
-    publicPort = 8080
-    privatePort = 3083
-    mgmtHost = "localhost"
-    mgmtPrivatePort = 3084
-} else if (__ENV.MODE == "internal") {
-    // internal mode for accessing api-gateway from container
-    proto = "http"
-    host = "host.docker.internal"
-    publicPort = 8080
-    privatePort = 3083
-    mgmtHost = "host.docker.internal"
+    mgmtHost = __ENV.API_GATEWAY_PORT
     mgmtPrivatePort = 3084
 } else {
     // direct microservice mode
-    proto = "http"
     host = "model-backend"
     publicPort = 8083
     privatePort = 3083

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -49,7 +49,7 @@ export default () => {
     }
 
     // Private API
-    if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+    if (!constant.apiGatewayMode) {
         queryModelPrivate.GetModel()
         queryModelPrivate.ListModels()
         queryModelPrivate.LookUpModel()

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -46,7 +46,7 @@ export default function (data) {
   }
 
   // Query Model API by admin
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+  if (!constant.apiGatewayMode) {
     queryModelPrivate.GetModelAdmin()
     queryModelPrivate.ListModelsAdmin()
     queryModelPrivate.LookupModelAdmin()

--- a/integration-test/rest_with_jwt.js
+++ b/integration-test/rest_with_jwt.js
@@ -38,7 +38,7 @@ export default function (data) {
     });
   }
 
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost") {
+  if (!constant.apiGatewayMode) {
     // Test Model API
     testModel.TestModel()
 


### PR DESCRIPTION
Because

- Need to simplify the integration test mode

This commit

- Add `API_GATEWAY_HOST`, `API_GATEWAY_PORT` and `API_GATEWAY_PROTOCOL` var. to simplify the integration test setting
