### PR TITLE
fix: create single triton client

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -204,17 +204,17 @@ func main() {
 	)
 
 	// Register custom route for  POST /v1alpha/models/{name=models/*}/test-multipart which makes model inference for REST multiple-part form-data
-	if err := publicGwS.HandlePath("POST", "/v1alpha/{name=models/*}/test-multipart", middleware.AppendCustomHeaderMiddleware(handler.HandleTestModelByUpload)); err != nil {
+	if err := publicGwS.HandlePath("POST", "/v1alpha/{name=models/*}/test-multipart", middleware.AppendCustomHeaderMiddleware(service, handler.HandleTestModelByUpload)); err != nil {
 		panic(err)
 	}
 
 	// Register custom route for  POST /v1alpha/models/{name=models/*}/trigger-multipart which makes model inference for REST multiple-part form-data
-	if err := publicGwS.HandlePath("POST", "/v1alpha/{name=models/*}/trigger-multipart", middleware.AppendCustomHeaderMiddleware(handler.HandleTriggerModelByUpload)); err != nil {
+	if err := publicGwS.HandlePath("POST", "/v1alpha/{name=models/*}/trigger-multipart", middleware.AppendCustomHeaderMiddleware(service, handler.HandleTriggerModelByUpload)); err != nil {
 		panic(err)
 	}
 
 	// Register custom route for  POST /models/multipart which uploads model for REST multiple-part form-data
-	if err := publicGwS.HandlePath("POST", "/v1alpha/models/multipart", middleware.AppendCustomHeaderMiddleware(handler.HandleCreateModelByMultiPartFormData)); err != nil {
+	if err := publicGwS.HandlePath("POST", "/v1alpha/models/multipart", middleware.AppendCustomHeaderMiddleware(service, handler.HandleCreateModelByMultiPartFormData)); err != nil {
 		panic(err)
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -4,8 +4,7 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
-
-	"github.com/instill-ai/model-backend/config"
+	"go.uber.org/zap/zapcore"
 )
 
 var logger *zap.Logger
@@ -14,11 +13,16 @@ var once sync.Once
 func GetZapLogger() (*zap.Logger, error) {
 	var err error
 	once.Do(func() {
-		if config.Config.Server.Debug {
-			logger, err = zap.NewDevelopment()
-		} else {
-			logger, err = zap.NewProduction()
-		}
+		// if config.Config.Server.Debug {
+		// 	logger, err = zap.NewDevelopment()
+		// } else {
+		// 	logger, err = zap.NewProduction()
+		// }
+		config := zap.NewProductionConfig()
+		config.DisableCaller = true
+		config.DisableStacktrace = true
+		config.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
+		logger, err = config.Build()
 	})
 
 	return logger, err

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/instill-ai/model-backend/pkg/constant"
+	"github.com/instill-ai/model-backend/pkg/service"
 )
 
-func AppendCustomHeaderMiddleware(next runtime.HandlerFunc) runtime.HandlerFunc {
+type fn func(service.Service, http.ResponseWriter, *http.Request, map[string]string)
+
+func AppendCustomHeaderMiddleware(s service.Service, next fn) runtime.HandlerFunc {
 	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		r.Header.Add(constant.HeaderOwnerIDKey, constant.DefaultOwnerID)
-		next(w, r, pathParams)
+		next(s, w, r, pathParams)
 	})
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -38,6 +38,8 @@ type InferInput interface{}
 
 type Service interface {
 	GetMgmtPrivateServiceClient() mgmtPB.MgmtPrivateServiceClient
+	GetRepository() repository.Repository
+	GetRedisClient() *redis.Client
 
 	CreateModelAsync(ctx context.Context, owner string, model *datamodel.Model) (string, error)
 	GetModelById(ctx context.Context, owner string, modelID string, view modelPB.View) (datamodel.Model, error)
@@ -96,6 +98,15 @@ func NewService(r repository.Repository, t triton.Triton, m mgmtPB.MgmtPrivateSe
 		temporalClient:              tc,
 		controllerClient:            cs,
 	}
+}
+
+func (s *service) GetRepository() repository.Repository {
+	return s.repository
+}
+
+// GetRedisClient returns the redis client
+func (s *service) GetRedisClient() *redis.Client {
+	return s.redisClient
 }
 
 // GetMgmtPrivateServiceClient returns the management private service client
@@ -252,7 +263,6 @@ func (s *service) WatchModel(ctx context.Context, name string) (*controllerPB.Ge
 }
 
 func (s *service) ModelInfer(ctx context.Context, modelUID uuid.UUID, inferInput InferInput, task modelPB.Model_Task) ([]*modelPB.TaskOutput, error) {
-
 	ensembleModel, err := s.repository.GetTritonEnsembleModel(modelUID)
 	if err != nil {
 		return nil, fmt.Errorf("triton model not found")

--- a/pkg/triton/triton.go
+++ b/pkg/triton/triton.go
@@ -124,7 +124,7 @@ func (ts *triton) ServerReadyRequest() *inferenceserver.ServerReadyResponse {
 
 func (ts *triton) ModelReadyRequest(modelName string, modelInstance string) *inferenceserver.ModelReadyResponse {
 	// Create context for our request with 10 second timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Create ready request for a given model
@@ -142,7 +142,7 @@ func (ts *triton) ModelReadyRequest(modelName string, modelInstance string) *inf
 
 func (ts *triton) ModelMetadataRequest(modelName string, modelInstance string) *inferenceserver.ModelMetadataResponse {
 	// Create context for our request with 10 second timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Create status request for a given model
@@ -160,7 +160,7 @@ func (ts *triton) ModelMetadataRequest(modelName string, modelInstance string) *
 
 func (ts *triton) ModelConfigRequest(modelName string, modelInstance string) *inferenceserver.ModelConfigResponse {
 	// Create context for our request with 10 second timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Create status request for a given model
@@ -917,7 +917,7 @@ func (ts *triton) LoadModelRequest(modelName string) (*inferenceserver.Repositor
 
 func (ts *triton) UnloadModelRequest(modelName string) (*inferenceserver.RepositoryModelUnloadResponse, error) {
 	// Create context for our request with 10 second timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Create status request for a given model
@@ -931,7 +931,7 @@ func (ts *triton) UnloadModelRequest(modelName string) (*inferenceserver.Reposit
 
 func (ts *triton) ListModelsRequest() *inferenceserver.RepositoryIndexResponse {
 	// Create context for our request with 10 second timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Create status request for a given model
@@ -951,6 +951,6 @@ func (ts *triton) IsTritonServerReady() bool {
 	if serverLiveResponse == nil {
 		return false
 	}
-	fmt.Printf("Triton Health - Live: %v\n", serverLiveResponse.Live)
+	// fmt.Printf("Triton Health - Live: %v\n", serverLiveResponse.Live)
 	return serverLiveResponse.Live
 }


### PR DESCRIPTION

Because

- grpc triton client should not create per multipart request

This commit

- create a single triton client and pass to multipart handler methods
