### PR TITLE
chore: adopt new pipeline recipe format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230509000136-ebf3c80b7cd4
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230519093047-ee0261f434fa
 	github.com/instill-ai/usage-client v0.2.3-alpha
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1300,6 +1300,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230509000136-ebf3c80b7cd4 h1:FN31oB55KUcvrj6aSYOWKQGnTT/fL4vg4PqUvkX7jV4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230509000136-ebf3c80b7cd4/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230519093047-ee0261f434fa h1:PTAyaWRFgJFvrSJIg1c+4XEvc0c8iqIBpQWXX6VGmeE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230519093047-ee0261f434fa/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.3-alpha h1:jdbCH6WJ7eUVudGtuDWaEsWmGX09ZFUnAHx+8S2MnDY=
 github.com/instill-ai/usage-client v0.2.3-alpha/go.mod h1:G0bnSyJw3ul8iNTpAGNslB18Qux0aMZF08h+CRICumw=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -680,7 +680,7 @@ func (s *service) DeleteModel(ctx context.Context, owner string, modelID string)
 		return err
 	}
 
-	filter := fmt.Sprintf("recipe.models:\"models/%s\"", modelInDB.UID)
+	filter := fmt.Sprintf("recipe.components.resource_name:\"models/%s\"", modelInDB.UID)
 
 	pipeResp, err := s.pipelinePublicServiceClient.ListPipelines(ctx, &pipelinePB.ListPipelinesRequest{
 		Filter: &filter,


### PR DESCRIPTION
Because

- we update new pipeline recipe format to support DAG

This commit

- adjust relevant code to support new recipe format
