### PR TITLE
chore: fix predeploy model uuid

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -94,6 +94,38 @@ type Model struct {
 	TritonModels []TritonModel `gorm:"foreignKey:ModelUID;references:UID;constraint:OnDelete:CASCADE;"`
 }
 
+// Temporary model type for migration
+type PreDeployModel struct {
+	BaseStatic
+
+	// Model id
+	ID string `json:"id,omitempty"`
+
+	// Model description
+	Description sql.NullString
+
+	// Model definition
+	ModelDefinitionUid uuid.UUID `gorm:"model_definition_uid,omitempty"`
+
+	// Model definition configuration
+	Configuration datatypes.JSON `json:"configuration,omitempty"`
+
+	// Model visibility
+	Visibility ModelVisibility `json:"visibility,omitempty"`
+
+	// Model owner
+	Owner string `json:"owner,omitempty"`
+
+	// Model task
+	Task ModelTask `json:"task,omitempty"`
+
+	// Model state
+	State ModelState `json:"state,omitempty"`
+
+	// Not stored in DB, only used for processing
+	TritonModels []TritonModel `gorm:"foreignKey:ModelUID;references:UID;constraint:OnDelete:CASCADE;"`
+}
+
 // Triton model
 type TritonModel struct {
 	BaseDynamic

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -15,6 +15,7 @@ import (
 
 type Repository interface {
 	CreateModel(model datamodel.Model) error
+	CreatePreDeployModel(model datamodel.PreDeployModel) error
 	GetModelById(owner string, modelID string, view modelPB.View) (datamodel.Model, error)
 	GetModelByUid(owner string, modelUID uuid.UUID, view modelPB.View) (datamodel.Model, error)
 	DeleteModel(modelUID uuid.UUID) error
@@ -82,6 +83,14 @@ var GetModelSelectedFieldsWOConfiguration = []string{
 func (r *repository) CreateModel(model datamodel.Model) error {
 	if result := r.db.Model(&datamodel.Model{}).Create(&model); result.Error != nil {
 		return status.Errorf(codes.Internal, "Error %v", result.Error)
+	}
+
+	return nil
+}
+
+func (r *repository) CreatePreDeployModel(model datamodel.PreDeployModel) error {
+	if result := r.db.Model(&datamodel.Model{}).Create(&model); result.Error != nil {
+		return result.Error
 	}
 
 	return nil

--- a/pkg/service/mock_repository_test.go
+++ b/pkg/service/mock_repository_test.go
@@ -50,6 +50,20 @@ func (mr *MockRepositoryMockRecorder) CreateModel(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModel", reflect.TypeOf((*MockRepository)(nil).CreateModel), arg0)
 }
 
+// CreatePreDeployModel mocks base method.
+func (m *MockRepository) CreatePreDeployModel(arg0 datamodel.PreDeployModel) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePreDeployModel", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreatePreDeployModel indicates an expected call of CreatePreDeployModel.
+func (mr *MockRepositoryMockRecorder) CreatePreDeployModel(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePreDeployModel", reflect.TypeOf((*MockRepository)(nil).CreatePreDeployModel), arg0)
+}
+
 // CreateTritonModel mocks base method.
 func (m *MockRepository) CreateTritonModel(arg0 datamodel.TritonModel) error {
 	m.ctrl.T.Helper()

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -296,13 +296,13 @@ func (w *worker) CreateModelWorkflow(ctx workflow.Context, param *ModelParams) e
 	controllerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	isPreDeployModel, err := GetPreDeployGitHubModelUUID(param.Model)
+	preDeployModel, err := GetPreDeployGitHubModelUUID(param.Model)
 	if err != nil {
 		return err
 	}
 
-	if isPreDeployModel != nil {
-		if err := w.repository.CreatePreDeployModel(*isPreDeployModel); err != nil {
+	if preDeployModel != nil {
+		if err := w.repository.CreatePreDeployModel(*preDeployModel); err != nil {
 			updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{
 				ModelState: modelPB.Model_STATE_ERROR,
 			}

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -301,10 +301,6 @@ func (w *worker) CreateModelWorkflow(ctx workflow.Context, param *ModelParams) e
 		return err
 	}
 
-	// fmt.Println("======================================================================================================")
-	// fmt.Println(isPreDeployModel)
-	// fmt.Println("======================================================================================================")
-
 	if isPreDeployModel != nil {
 		if err := w.repository.CreatePreDeployModel(*isPreDeployModel); err != nil {
 			updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -296,9 +296,26 @@ func (w *worker) CreateModelWorkflow(ctx workflow.Context, param *ModelParams) e
 	controllerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := w.repository.CreateModel(param.Model); err != nil {
-		updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{
-			ModelState: modelPB.Model_STATE_ERROR,
+	isPreDeployModel, err := GetPreDeployGitHubModelUUID(param.Model)
+	if err != nil {
+		return err
+	}
+
+	// fmt.Println("======================================================================================================")
+	// fmt.Println(isPreDeployModel)
+	// fmt.Println("======================================================================================================")
+
+	if isPreDeployModel != nil {
+		if err := w.repository.CreatePreDeployModel(*isPreDeployModel); err != nil {
+			updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{
+				ModelState: modelPB.Model_STATE_ERROR,
+			}
+		}
+	} else {
+		if err := w.repository.CreateModel(param.Model); err != nil {
+			updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{
+				ModelState: modelPB.Model_STATE_ERROR,
+			}
 		}
 	}
 

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -1,0 +1,115 @@
+package worker
+
+import (
+	"encoding/json"
+	// "fmt"
+
+	"github.com/gofrs/uuid"
+	"github.com/instill-ai/model-backend/config"
+	"github.com/instill-ai/model-backend/pkg/datamodel"
+	"github.com/instill-ai/model-backend/pkg/util"
+	modelPB "github.com/instill-ai/protogen-go/vdp/model/v1alpha"
+)
+
+type PreModelConfig struct {
+	ID              string            `json:"id"`
+	Description     string            `json:"description"`
+	Task            string            `json:"task"`
+	ModelDefinition string            `json:"model_definition"`
+	Configuration   map[string]string `json:"configuration"`
+}
+
+var preDeployModelMap = map[string]map[string]string{
+	"mask-rcnn": {
+		"uid":                  "37e01efd-acb2-4a69-a67f-bc06599f2473",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_INSTANCE_SEGMENTATION",
+	},
+	"stomata-mask-rcnn": {
+		"uid":                  "2aaf321d-a533-47ea-8616-39a5205797ca",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_INSTANCE_SEGMENTATION",
+	},
+	"lraspp": {
+		"uid":                  "86a903d7-a67b-4318-89a0-b701ed58daed",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_INSTANCE_SEGMENTATION",
+	},
+	"stable-diffusion-1-5-fp16-txt2img": {
+		"uid":                  "40bf6822-8a8c-4f9f-a0b9-c233b5404973",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_TEXT_TO_IMAGE",
+	},
+	"gpt-2": {
+		"uid":                  "6332a144-8e14-4c4d-8d1c-7653bc17d2ff",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_TEXT_GENERATION",
+	},
+	"mobilenetv2": {
+		"uid":                  "0b9c26f2-9d51-43ed-ae0f-30b3f280e7be",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_CLASSIFICATION",
+	},
+	"yolov7": {
+		"uid":                  "82a1a29c-0c3b-4b4e-83a8-7ea6a80bf7b7",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_DETECTION",
+	},
+	"yolov7-pose": {
+		"uid":                  "7ee5e127-3dc1-4c8f-947c-966b6281e772",
+		"owner":                "users/eeaf4fe1-5725-4802-98b9-6165bd2b1e58",
+		"model_definition_uid": "909c3278-f7d1-461c-9352-87741bef11d3",
+		"task":                 "TASK_KEYPOINT",
+	},
+}
+
+func GetPreDeployGitHubModelUUID(model datamodel.Model) (*datamodel.PreDeployModel, error) {
+	var preDeployModelConfigs []PreModelConfig
+	err := util.GetJSON(config.Config.InitModel.Path, &preDeployModelConfigs)
+	if err != nil {
+		return nil, err
+	}
+
+	modelConfig := datamodel.GitHubModelConfiguration{}
+	err = json.Unmarshal(model.Configuration, &modelConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var githubModel *datamodel.PreDeployModel
+
+	for _, preDeployModelConfigs := range preDeployModelConfigs {
+		if modelConfig.Repository == preDeployModelConfigs.Configuration["repository"] &&
+			modelConfig.Tag == preDeployModelConfigs.Configuration["tag"] {
+
+			uid, _ := uuid.FromString(preDeployModelMap[preDeployModelConfigs.ID]["uid"])
+			modelDefinitionUID, _ := uuid.FromString(preDeployModelMap[preDeployModelConfigs.ID]["model_definition_uid"])
+
+			githubModel = &datamodel.PreDeployModel{
+				BaseStatic: datamodel.BaseStatic{
+					UID:        uid,
+					CreateTime: model.CreateTime,
+					UpdateTime: model.UpdateTime,
+					DeleteTime: model.DeleteTime,
+				},
+				ID:                 model.ID,
+				ModelDefinitionUid: modelDefinitionUID,
+				Owner:              preDeployModelMap[preDeployModelConfigs.ID]["owner"],
+				Visibility:         datamodel.ModelVisibility(modelPB.Model_VISIBILITY_PUBLIC),
+				State:              model.State,
+				Task:               model.Task,
+				Description:        model.Description,
+				Configuration:      model.Configuration,
+				TritonModels:       model.TritonModels,
+			}
+		}
+	}
+	return githubModel, nil
+}

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"encoding/json"
-	// "fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/instill-ai/model-backend/config"


### PR DESCRIPTION
Because

- avoid pipelines become orphan when redeploying models and db

This commit

- fix the uuids of predeploy models
