### PR TITLE
chore: add private methods for controller-model

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,13 +38,21 @@ jobs:
           sudo kill -9 `sudo lsof -t -i:8084`
           sudo lsof -i -P -n | grep LISTEN
 
-      - name: Free disk space
-        run: |
-          df --human-readable
-          sudo apt clean
-          docker rmi $(docker image ls --all --quiet)
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df --human-readable
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/assets/model-dummy-cls/post/1/model.py
+++ b/assets/model-dummy-cls/post/1/model.py
@@ -1,11 +1,7 @@
 import numpy as np
 import json
-import sys
-import os
 
-from pathlib import Path
 from typing import List
-from PIL import Image
 
 from triton_python_backend_utils import get_output_config_by_name, triton_string_to_numpy
 from c_python_backend_utils import Tensor, InferenceResponse, InferenceRequest

--- a/assets/model-dummy-cls/pre/1/model.py
+++ b/assets/model-dummy-cls/pre/1/model.py
@@ -1,11 +1,9 @@
-import io
 import numpy as np
 import json
 
 from typing import List
-from PIL import Image
 
-from triton_python_backend_utils import get_output_config_by_name, triton_string_to_numpy, get_input_config_by_name
+from triton_python_backend_utils import get_output_config_by_name, triton_string_to_numpy
 from c_python_backend_utils import Tensor, InferenceResponse, InferenceRequest
 
 class TritonPythonModel(object):

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -42,7 +42,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	// setup tracing and metrics
+	// setup tracing
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if tp, err := custom_otel.SetupTracing(ctx, "model-backend-init"); err != nil {
@@ -50,14 +50,6 @@ func main() {
 	} else {
 		defer func() {
 			err = tp.Shutdown(ctx)
-		}()
-	}
-
-	if mp, err := custom_otel.SetupMetrics(ctx, "model-backend-init"); err != nil {
-		panic(err)
-	} else {
-		defer func() {
-			err = mp.Shutdown(ctx)
 		}()
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230622154941-b51cc4cf49d0
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567
 	github.com/instill-ai/usage-client v0.2.4-alpha
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1303,8 +1303,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230622154941-b51cc4cf49d0 h1:dgp/7h66FUQwMoWsFZC/auRKJlBHQ2aACdfskl2W6RA=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230622154941-b51cc4cf49d0/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567 h1:e4X/bumXkCgCoZKYN2t+2agP8KfDbW3sps8wQrE+OJQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha h1:mYXd62eZsmGKBlzwMcdEgTBgn8zlbagYUHro6+p50c8=
 github.com/instill-ai/usage-client v0.2.4-alpha/go.mod h1:BMxgyr02sqH6SeITXSV4M1ewwvfklzXIc5yzIqaN0c8=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -2062,7 +2062,6 @@ func (h *PublicHandler) DeployModel(ctx context.Context, req *modelPB.DeployMode
 	}
 
 	state, err := h.service.GetResourceState(ctx, dbModel.UID)
-
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return &modelPB.DeployModelResponse{}, err


### PR DESCRIPTION
Because

- allow `controller-model` to move `model` current state to desire state

This commit

- add deploy/undeploy private method for `controller-model`
