### PR TITLE
chore(logging): support context propagation to temporal worker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
 	go.temporal.io/api v1.18.2-0.20230324225508-f2c7ab685b44
 	go.temporal.io/sdk v1.21.1
+	go.temporal.io/sdk/contrib/opentelemetry v0.2.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/image v0.5.0
 	golang.org/x/net v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1085,12 +1085,14 @@ github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4Oe
 github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
 github.com/gogo/status v1.1.1 h1:DuHXlSFHNKqTQ+/ACf5Vs6r4X/dH2EgIzR9Vr+H65kg=
 github.com/gogo/status v1.1.1/go.mod h1:jpG3dM5QPcqu19Hg8lkUhBFBa3TcLs1DG7+2Jqci7oU=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -1765,6 +1767,7 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -1862,6 +1865,7 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0/go.mod h1:
 go.opentelemetry.io/contrib/propagators/b3 v1.17.0 h1:ImOVvHnku8jijXqkwCSyYKRDt2YrnGXD4BbhcpfbfJo=
 go.opentelemetry.io/contrib/propagators/b3 v1.17.0/go.mod h1:IkfUfMpKWmynvvE0264trz0sf32NRTZL4nuAN9AbWRc=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
+go.opentelemetry.io/otel v1.2.0/go.mod h1:aT17Fk0Z1Nor9e0uisf98LrntPGMnk4frBO9+dkf69I=
 go.opentelemetry.io/otel v1.3.0/go.mod h1:PWIKzi6JCp7sM0k9yZ43VX+T345uNbAkDKwHVjb2PTs=
 go.opentelemetry.io/otel v1.16.0 h1:Z7GVAX/UkAXPKsy94IU+i6thsQS4nb7LviLpnaNeW8s=
 go.opentelemetry.io/otel v1.16.0/go.mod h1:vl0h9NUa1D5s1nv3A5vZOYWn8av4K8Ml6JDeHrT/bx4=
@@ -1889,6 +1893,7 @@ go.opentelemetry.io/otel/metric v1.16.0 h1:RbrpwVG1Hfv85LgnZ7+txXioPDoh6EdbZHo26
 go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
 go.opentelemetry.io/otel/oteltest v0.20.0/go.mod h1:L7bgKf9ZB7qCwT9Up7i9/pn0PWIa9FqQ2IQ8LoxiGnw=
 go.opentelemetry.io/otel/sdk v0.20.0/go.mod h1:g/IcepuwNsoiX5Byy2nNV0ySUF1em498m7hBWC279Yc=
+go.opentelemetry.io/otel/sdk v1.2.0/go.mod h1:jNN8QtpvbsKhgaC6V5lHiejMoKD+V8uadoSafgHPx1U=
 go.opentelemetry.io/otel/sdk v1.3.0/go.mod h1:rIo4suHNhQwBIPg9axF8V9CA72Wz2mKF1teNrup8yzs=
 go.opentelemetry.io/otel/sdk v1.16.0 h1:Z1Ok1YsijYL0CSJpHt4cS3wDDh7p572grzNrBMiMWgE=
 go.opentelemetry.io/otel/sdk v1.16.0/go.mod h1:tMsIuKXuuIWPBAOrH+eHtvhTL+SntFtXF9QD68aP6p4=
@@ -1897,6 +1902,7 @@ go.opentelemetry.io/otel/sdk/metric v0.20.0/go.mod h1:knxiS8Xd4E/N+ZqKmUPf3gTTZ4
 go.opentelemetry.io/otel/sdk/metric v0.39.0 h1:Kun8i1eYf48kHH83RucG93ffz0zGV1sh46FAScOTuDI=
 go.opentelemetry.io/otel/sdk/metric v0.39.0/go.mod h1:piDIRgjcK7u0HCL5pCA4e74qpK/jk3NiUoAHATVAmiI=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
+go.opentelemetry.io/otel/trace v1.2.0/go.mod h1:N5FLswTubnxKxOJHM7XZC074qpeEdLy3CgAVsdMucK0=
 go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=
 go.opentelemetry.io/otel/trace v1.16.0 h1:8JRpaObFoW0pxuVPapkgH8UhHQj+bJW8jJsCZEu5MQs=
 go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
@@ -1905,11 +1911,15 @@ go.opentelemetry.io/proto/otlp v0.11.0/go.mod h1:QpEjXPrNQzrFDZgoTo49dgHR9RYRSrg
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
+go.temporal.io/api v1.5.0/go.mod h1:BqKxEJJYdxb5dqf0ODfzfMxh8UEQ5L3zKS51FiIYYkA=
 go.temporal.io/api v1.16.0/go.mod h1:u3qLbaVTffmcZQbf9ueB+16LKmhkftH79SJOV517MDk=
 go.temporal.io/api v1.18.2-0.20230324225508-f2c7ab685b44 h1:ilEY3HPpO6UwiwopVMuXkPOvppjPlT8QlqoG+jPVDXo=
 go.temporal.io/api v1.18.2-0.20230324225508-f2c7ab685b44/go.mod h1:VAc6LF2ckIwAbMEMv+eo+3yw4SjIzwosukjiwXajCJc=
+go.temporal.io/sdk v1.12.0/go.mod h1:lSp3lH1lI0TyOsus0arnO3FYvjVXBZGi/G7DjnAnm6o=
 go.temporal.io/sdk v1.21.1 h1:SJCzSsZLBsFiHniJ+E7Yy74pcAs1lg7NbFnsUJ4ggIM=
 go.temporal.io/sdk v1.21.1/go.mod h1:Pq3Mp7p0lWNFM+YS2guBy8V/lJySh329AcyS+Wj/Wmo=
+go.temporal.io/sdk/contrib/opentelemetry v0.2.0 h1:RnkifCSdsr9X7vJOFjqWQ0Ik+Jod3poIuvSfyTCb208=
+go.temporal.io/sdk/contrib/opentelemetry v0.2.0/go.mod h1:YxR7u+g+eR7lCZHtd0amxPWwlWkZKm6uivLTjLG/NjA=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -2089,6 +2099,7 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -2280,6 +2291,7 @@ golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210903071746-97244b99971b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -325,7 +325,7 @@ func makeJSONResponse(w http.ResponseWriter, status int, title string, detail st
 }
 
 func (h *PublicHandler) Liveness(ctx context.Context, pb *modelPB.LivenessRequest) (*modelPB.LivenessResponse, error) {
-	if !h.triton.IsTritonServerReady() {
+	if !h.triton.IsTritonServerReady(ctx) {
 		return &modelPB.LivenessResponse{
 			HealthCheckResponse: &healthcheckPB.HealthCheckResponse{
 				Status: healthcheckPB.HealthCheckResponse_SERVING_STATUS_NOT_SERVING,
@@ -337,7 +337,7 @@ func (h *PublicHandler) Liveness(ctx context.Context, pb *modelPB.LivenessReques
 }
 
 func (h *PublicHandler) Readiness(ctx context.Context, pb *modelPB.ReadinessRequest) (*modelPB.ReadinessResponse, error) {
-	if !h.triton.IsTritonServerReady() {
+	if !h.triton.IsTritonServerReady(ctx) {
 		return &modelPB.ReadinessResponse{
 			HealthCheckResponse: &healthcheckPB.HealthCheckResponse{
 				Status: healthcheckPB.HealthCheckResponse_SERVING_STATUS_NOT_SERVING,

--- a/pkg/service/mock_triton_test.go
+++ b/pkg/service/mock_triton_test.go
@@ -62,89 +62,89 @@ func (mr *MockTritonMockRecorder) Init() *gomock.Call {
 }
 
 // IsTritonServerReady mocks base method.
-func (m *MockTriton) IsTritonServerReady() bool {
+func (m *MockTriton) IsTritonServerReady(arg0 context.Context) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTritonServerReady")
+	ret := m.ctrl.Call(m, "IsTritonServerReady", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsTritonServerReady indicates an expected call of IsTritonServerReady.
-func (mr *MockTritonMockRecorder) IsTritonServerReady() *gomock.Call {
+func (mr *MockTritonMockRecorder) IsTritonServerReady(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTritonServerReady", reflect.TypeOf((*MockTriton)(nil).IsTritonServerReady))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTritonServerReady", reflect.TypeOf((*MockTriton)(nil).IsTritonServerReady), arg0)
 }
 
 // ListModelsRequest mocks base method.
-func (m *MockTriton) ListModelsRequest() *inferenceserver.RepositoryIndexResponse {
+func (m *MockTriton) ListModelsRequest(arg0 context.Context) *inferenceserver.RepositoryIndexResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelsRequest")
+	ret := m.ctrl.Call(m, "ListModelsRequest", arg0)
 	ret0, _ := ret[0].(*inferenceserver.RepositoryIndexResponse)
 	return ret0
 }
 
 // ListModelsRequest indicates an expected call of ListModelsRequest.
-func (mr *MockTritonMockRecorder) ListModelsRequest() *gomock.Call {
+func (mr *MockTritonMockRecorder) ListModelsRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelsRequest", reflect.TypeOf((*MockTriton)(nil).ListModelsRequest))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelsRequest", reflect.TypeOf((*MockTriton)(nil).ListModelsRequest), arg0)
 }
 
 // LoadModelRequest mocks base method.
-func (m *MockTriton) LoadModelRequest(arg0 string) (*inferenceserver.RepositoryModelLoadResponse, error) {
+func (m *MockTriton) LoadModelRequest(arg0 context.Context, arg1 string) (*inferenceserver.RepositoryModelLoadResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadModelRequest", arg0)
+	ret := m.ctrl.Call(m, "LoadModelRequest", arg0, arg1)
 	ret0, _ := ret[0].(*inferenceserver.RepositoryModelLoadResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadModelRequest indicates an expected call of LoadModelRequest.
-func (mr *MockTritonMockRecorder) LoadModelRequest(arg0 interface{}) *gomock.Call {
+func (mr *MockTritonMockRecorder) LoadModelRequest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadModelRequest", reflect.TypeOf((*MockTriton)(nil).LoadModelRequest), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadModelRequest", reflect.TypeOf((*MockTriton)(nil).LoadModelRequest), arg0, arg1)
 }
 
 // ModelConfigRequest mocks base method.
-func (m *MockTriton) ModelConfigRequest(arg0, arg1 string) *inferenceserver.ModelConfigResponse {
+func (m *MockTriton) ModelConfigRequest(arg0 context.Context, arg1, arg2 string) *inferenceserver.ModelConfigResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelConfigRequest", arg0, arg1)
+	ret := m.ctrl.Call(m, "ModelConfigRequest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*inferenceserver.ModelConfigResponse)
 	return ret0
 }
 
 // ModelConfigRequest indicates an expected call of ModelConfigRequest.
-func (mr *MockTritonMockRecorder) ModelConfigRequest(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockTritonMockRecorder) ModelConfigRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConfigRequest", reflect.TypeOf((*MockTriton)(nil).ModelConfigRequest), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConfigRequest", reflect.TypeOf((*MockTriton)(nil).ModelConfigRequest), arg0, arg1, arg2)
 }
 
 // ModelInferRequest mocks base method.
-func (m *MockTriton) ModelInferRequest(arg0 modelv1alpha.Model_Task, arg1 triton.InferInput, arg2, arg3 string, arg4 *inferenceserver.ModelMetadataResponse, arg5 *inferenceserver.ModelConfigResponse) (*inferenceserver.ModelInferResponse, error) {
+func (m *MockTriton) ModelInferRequest(arg0 context.Context, arg1 modelv1alpha.Model_Task, arg2 triton.InferInput, arg3, arg4 string, arg5 *inferenceserver.ModelMetadataResponse, arg6 *inferenceserver.ModelConfigResponse) (*inferenceserver.ModelInferResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelInferRequest", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "ModelInferRequest", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*inferenceserver.ModelInferResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ModelInferRequest indicates an expected call of ModelInferRequest.
-func (mr *MockTritonMockRecorder) ModelInferRequest(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockTritonMockRecorder) ModelInferRequest(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelInferRequest", reflect.TypeOf((*MockTriton)(nil).ModelInferRequest), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelInferRequest", reflect.TypeOf((*MockTriton)(nil).ModelInferRequest), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // ModelMetadataRequest mocks base method.
-func (m *MockTriton) ModelMetadataRequest(arg0, arg1 string) *inferenceserver.ModelMetadataResponse {
+func (m *MockTriton) ModelMetadataRequest(arg0 context.Context, arg1, arg2 string) *inferenceserver.ModelMetadataResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelMetadataRequest", arg0, arg1)
+	ret := m.ctrl.Call(m, "ModelMetadataRequest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*inferenceserver.ModelMetadataResponse)
 	return ret0
 }
 
 // ModelMetadataRequest indicates an expected call of ModelMetadataRequest.
-func (mr *MockTritonMockRecorder) ModelMetadataRequest(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockTritonMockRecorder) ModelMetadataRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelMetadataRequest", reflect.TypeOf((*MockTriton)(nil).ModelMetadataRequest), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelMetadataRequest", reflect.TypeOf((*MockTriton)(nil).ModelMetadataRequest), arg0, arg1, arg2)
 }
 
 // ModelReadyRequest mocks base method.
@@ -177,44 +177,44 @@ func (mr *MockTritonMockRecorder) PostProcess(arg0, arg1, arg2 interface{}) *gom
 }
 
 // ServerLiveRequest mocks base method.
-func (m *MockTriton) ServerLiveRequest() *inferenceserver.ServerLiveResponse {
+func (m *MockTriton) ServerLiveRequest(arg0 context.Context) *inferenceserver.ServerLiveResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServerLiveRequest")
+	ret := m.ctrl.Call(m, "ServerLiveRequest", arg0)
 	ret0, _ := ret[0].(*inferenceserver.ServerLiveResponse)
 	return ret0
 }
 
 // ServerLiveRequest indicates an expected call of ServerLiveRequest.
-func (mr *MockTritonMockRecorder) ServerLiveRequest() *gomock.Call {
+func (mr *MockTritonMockRecorder) ServerLiveRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerLiveRequest", reflect.TypeOf((*MockTriton)(nil).ServerLiveRequest))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerLiveRequest", reflect.TypeOf((*MockTriton)(nil).ServerLiveRequest), arg0)
 }
 
 // ServerReadyRequest mocks base method.
-func (m *MockTriton) ServerReadyRequest() *inferenceserver.ServerReadyResponse {
+func (m *MockTriton) ServerReadyRequest(arg0 context.Context) *inferenceserver.ServerReadyResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServerReadyRequest")
+	ret := m.ctrl.Call(m, "ServerReadyRequest", arg0)
 	ret0, _ := ret[0].(*inferenceserver.ServerReadyResponse)
 	return ret0
 }
 
 // ServerReadyRequest indicates an expected call of ServerReadyRequest.
-func (mr *MockTritonMockRecorder) ServerReadyRequest() *gomock.Call {
+func (mr *MockTritonMockRecorder) ServerReadyRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerReadyRequest", reflect.TypeOf((*MockTriton)(nil).ServerReadyRequest))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerReadyRequest", reflect.TypeOf((*MockTriton)(nil).ServerReadyRequest), arg0)
 }
 
 // UnloadModelRequest mocks base method.
-func (m *MockTriton) UnloadModelRequest(arg0 string) (*inferenceserver.RepositoryModelUnloadResponse, error) {
+func (m *MockTriton) UnloadModelRequest(arg0 context.Context, arg1 string) (*inferenceserver.RepositoryModelUnloadResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnloadModelRequest", arg0)
+	ret := m.ctrl.Call(m, "UnloadModelRequest", arg0, arg1)
 	ret0, _ := ret[0].(*inferenceserver.RepositoryModelUnloadResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnloadModelRequest indicates an expected call of UnloadModelRequest.
-func (mr *MockTritonMockRecorder) UnloadModelRequest(arg0 interface{}) *gomock.Call {
+func (mr *MockTritonMockRecorder) UnloadModelRequest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnloadModelRequest", reflect.TypeOf((*MockTriton)(nil).UnloadModelRequest), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnloadModelRequest", reflect.TypeOf((*MockTriton)(nil).UnloadModelRequest), arg0, arg1)
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -355,15 +355,15 @@ func TestModelInfer(t *testing.T) {
 		postResponse := []string{"1.0:dog:1"}
 		triton.
 			EXPECT().
-			ModelMetadataRequest(ensembleModel.Name, fmt.Sprint(ensembleModel.Version)).
+			ModelMetadataRequest(context.Background(), ensembleModel.Name, fmt.Sprint(ensembleModel.Version)).
 			Return(modelMetadataResponse)
 		triton.
 			EXPECT().
-			ModelConfigRequest(ensembleModel.Name, fmt.Sprint(ensembleModel.Version)).
+			ModelConfigRequest(context.Background(), ensembleModel.Name, fmt.Sprint(ensembleModel.Version)).
 			Return(modelConfigResponse)
 		triton.
 			EXPECT().
-			ModelInferRequest(modelPB.Model_TASK_CLASSIFICATION, [][]byte{}, ensembleModel.Name, fmt.Sprint(ensembleModel.Version), modelMetadataResponse, modelConfigResponse).
+			ModelInferRequest(context.Background(), modelPB.Model_TASK_CLASSIFICATION, [][]byte{}, ensembleModel.Name, fmt.Sprint(ensembleModel.Version), modelMetadataResponse, modelConfigResponse).
 			Return(modelInferResponse, nil)
 		triton.
 			EXPECT().

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -169,7 +169,7 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 		if tEnsembleModel.Name != "" && tEnsembleModel.Name == tModel.Name { // load ensemble model last.
 			continue
 		}
-		if _, err = w.triton.LoadModelRequest(tModel.Name); err == nil {
+		if _, err = w.triton.LoadModelRequest(ctx, tModel.Name); err == nil {
 			continue
 		}
 		updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{
@@ -182,7 +182,7 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 	}
 
 	if tEnsembleModel.Name != "" { // load ensemble model.
-		if _, err = w.triton.LoadModelRequest(tEnsembleModel.Name); err != nil {
+		if _, err = w.triton.LoadModelRequest(ctx, tEnsembleModel.Name); err != nil {
 			updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{
 				ModelState: modelPB.Model_STATE_ERROR,
 			}
@@ -257,7 +257,7 @@ func (w *worker) UnDeployModelActivity(ctx context.Context, param *ModelParams) 
 
 	for _, tm := range tritonModels {
 		// Unload all models composing the ensemble model
-		if _, err = w.triton.UnloadModelRequest(tm.Name); err != nil {
+		if _, err = w.triton.UnloadModelRequest(ctx, tm.Name); err != nil {
 			updateResourceReq.Resource.State = &controllerPB.Resource_ModelState{
 				ModelState: modelPB.Model_STATE_ERROR,
 			}


### PR DESCRIPTION
Because

- provide clearer view of span life cycle for observability

This commit

- add support for context propagation to temporal worker
