### PR TITLE
chore: reclone and convert model structure if missing in model repo

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -312,6 +312,17 @@ func GetGitHubRepoInfo(repo string) (*GitHubInfo, error) {
 	return &githubRepoInfo, nil
 }
 
+func HasModelInModelRepository(modelRepositoryRoot string, namespace string, modelName string) bool {
+
+	path := fmt.Sprintf("%v/%v#%v#*", modelRepositoryRoot, namespace, modelName)
+
+	if matches, _ := filepath.Glob(path); matches == nil {
+		return false
+	}
+
+	return true
+}
+
 func RemoveModelRepository(modelRepositoryRoot string, namespace string, modelName string, instanceName string) {
 	path := fmt.Sprintf("%v/%v#%v#*#%v", modelRepositoryRoot, namespace, modelName, instanceName)
 	if err := ValidateFilePath(path); err != nil {


### PR DESCRIPTION
Because

- deploy model will fail if model-repository is empty but db has model records

This commit

- reclone and repopulate model-repository with model records in db
