### PR TITLE
chore(temporal): add max retry to prevent never ending workflows

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,8 +22,8 @@ type ServerConfig struct {
 		Cert string `koanf:"cert"`
 		Key  string `koanf:"key"`
 	}
-	Edition     string   `koanf:"edition"`
-	Usage       struct {
+	Edition string `koanf:"edition"`
+	Usage   struct {
 		Enabled    bool   `koanf:"enabled"`
 		TLSEnabled bool   `koanf:"tlsenabled"`
 		Host       string `koanf:"host"`
@@ -34,6 +34,11 @@ type ServerConfig struct {
 		Enabled bool `koanf:"enabled"`
 	}
 	MaxDataSize int `koanf:"maxdatasize"`
+	Workflow    struct {
+		MaxWorkflowTimeout int32 `koanf:"maxworkflowtimeout"`
+		MaxWorkflowRetry   int32 `koanf:"maxworkflowretry"`
+		MaxActivityRetry   int32 `koanf:"maxactivityretry"`
+	}
 }
 
 // DatabaseConfig related to database
@@ -124,16 +129,16 @@ type LogConfig struct {
 
 // AppConfig defines
 type AppConfig struct {
-	Server                 ServerConfig          `koanf:"server"`
-	Database               DatabaseConfig        `koanf:"database"`
-	TritonServer           TritonServerConfig    `koanf:"tritonserver"`
-	MgmtBackend            MgmtBackendConfig     `koanf:"mgmtbackend"`
-	Cache                  CacheConfig           `koanf:"cache"`
-	MaxBatchSizeLimitation MaxBatchSizeConfig    `koanf:"maxbatchsizelimitation"`
-	Temporal               TemporalConfig        `koanf:"temporal"`
-	Controller             ControllerConfig      `koanf:"controller"`
-	InitModel              InitModelConfig       `koanf:"initmodel"`
-	Log                    LogConfig             `koanf:"log"`
+	Server                 ServerConfig       `koanf:"server"`
+	Database               DatabaseConfig     `koanf:"database"`
+	TritonServer           TritonServerConfig `koanf:"tritonserver"`
+	MgmtBackend            MgmtBackendConfig  `koanf:"mgmtbackend"`
+	Cache                  CacheConfig        `koanf:"cache"`
+	MaxBatchSizeLimitation MaxBatchSizeConfig `koanf:"maxbatchsizelimitation"`
+	Temporal               TemporalConfig     `koanf:"temporal"`
+	Controller             ControllerConfig   `koanf:"controller"`
+	InitModel              InitModelConfig    `koanf:"initmodel"`
+	Log                    LogConfig          `koanf:"log"`
 }
 
 // Config - Global variable to export

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,10 @@ server:
   itmode:
     enabled: false
   maxdatasize: 12 # MB in unit
+  workflow:
+    maxworkflowtimeout: 3600 # in seconds
+    maxworkflowretry: 3
+    maxactivityretry: 1
 database:
   username: postgres
   password: password

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -3,16 +3,19 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"github.com/gofrs/uuid"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	workflowpb "go.temporal.io/api/workflow/v1"
 
+	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/pkg/datamodel"
 	"github.com/instill-ai/model-backend/pkg/logger"
 	"github.com/instill-ai/model-backend/pkg/worker"
@@ -24,8 +27,12 @@ func (s *service) DeployModelAsync(ctx context.Context, owner string, modelUID u
 	logger, _ := logger.GetZapLogger(ctx)
 	id, _ := uuid.NewV4()
 	workflowOptions := client.StartWorkflowOptions{
-		ID:        id.String(),
-		TaskQueue: worker.TaskQueue,
+		ID:                       id.String(),
+		TaskQueue:                worker.TaskQueue,
+		WorkflowExecutionTimeout: time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout) * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: config.Config.Server.Workflow.MaxWorkflowRetry,
+		},
 	}
 
 	model, err := s.repository.GetModelByUID(owner, modelUID, modelv1alpha.View_VIEW_BASIC)
@@ -55,8 +62,12 @@ func (s *service) UndeployModelAsync(ctx context.Context, owner string, modelUID
 	logger, _ := logger.GetZapLogger(ctx)
 	id, _ := uuid.NewV4()
 	workflowOptions := client.StartWorkflowOptions{
-		ID:        id.String(),
-		TaskQueue: worker.TaskQueue,
+		ID:                       id.String(),
+		TaskQueue:                worker.TaskQueue,
+		WorkflowExecutionTimeout: time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout) * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: config.Config.Server.Workflow.MaxWorkflowRetry,
+		},
 	}
 
 	model, err := s.repository.GetModelByUID(owner, modelUID, modelv1alpha.View_VIEW_BASIC)
@@ -132,8 +143,12 @@ func (s *service) CreateModelAsync(ctx context.Context, owner string, model *dat
 	logger, _ := logger.GetZapLogger(ctx)
 	id, _ := uuid.NewV4()
 	workflowOptions := client.StartWorkflowOptions{
-		ID:        id.String(),
-		TaskQueue: worker.TaskQueue,
+		ID:                       id.String(),
+		TaskQueue:                worker.TaskQueue,
+		WorkflowExecutionTimeout: time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout) * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: config.Config.Server.Workflow.MaxWorkflowRetry,
+		},
 	}
 
 	we, err := s.temporalClient.ExecuteWorkflow(

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/instill-ai/model-backend/config"
@@ -35,6 +36,9 @@ func (w *worker) DeployModelWorkflow(ctx workflow.Context, param *ModelParams) e
 	ao := workflow.ActivityOptions{
 		TaskQueue:           TaskQueue,
 		StartToCloseTimeout: 300 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: config.Config.Server.Workflow.MaxActivityRetry,
+		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
@@ -211,6 +215,9 @@ func (w *worker) UnDeployModelWorkflow(ctx workflow.Context, param *ModelParams)
 
 	ao := workflow.ActivityOptions{
 		StartToCloseTimeout: 2 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: config.Config.Server.Workflow.MaxActivityRetry,
+		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 


### PR DESCRIPTION
Because

- prevent errored workflow from running endlessly

This commit

- add max retry limit for workflow/activity
