### PR TITLE
chore(usage): fix redis cache datatype

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -40,7 +40,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/service"
 	"github.com/instill-ai/model-backend/pkg/triton"
 	"github.com/instill-ai/model-backend/pkg/usage"
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 	"github.com/instill-ai/x/temporal"
 	"github.com/instill-ai/x/zapadapter"
 
@@ -213,8 +213,8 @@ func main() {
 		runtime.WithErrorHandler(middleware.ErrorHandler),
 		runtime.WithIncomingHeaderMatcher(middleware.CustomMatcher),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
-			MarshalOptions:   util.MarshalOptions,
-			UnmarshalOptions: util.UnmarshalOptions,
+			MarshalOptions:   utils.MarshalOptions,
+			UnmarshalOptions: utils.UnmarshalOptions,
 		}),
 	)
 
@@ -223,8 +223,8 @@ func main() {
 		runtime.WithErrorHandler(middleware.ErrorHandler),
 		runtime.WithIncomingHeaderMatcher(middleware.CustomMatcher),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
-			MarshalOptions:   util.MarshalOptions,
-			UnmarshalOptions: util.UnmarshalOptions,
+			MarshalOptions:   utils.MarshalOptions,
+			UnmarshalOptions: utils.UnmarshalOptions,
 		}),
 	)
 

--- a/cmd/model/main.go
+++ b/cmd/model/main.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/pkg/logger"
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 
 	custom_otel "github.com/instill-ai/model-backend/pkg/logger/otel"
 	commonPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
@@ -104,7 +104,7 @@ func main() {
 	}
 
 	var modelConfigs []ModelConfig
-	err := util.GetJSON(config.Config.InitModel.Path, &modelConfigs)
+	err := utils.GetJSON(config.Config.InitModel.Path, &modelConfigs)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}
@@ -130,7 +130,7 @@ func main() {
 				Model: &modelPB.Model{
 					Id:              modelConfig.ID,
 					Description:     &modelConfig.Description,
-					Task:            commonPB.Task(util.Tasks[strings.ToUpper(modelConfig.Task)]),
+					Task:            commonPB.Task(utils.Tasks[strings.ToUpper(modelConfig.Task)]),
 					ModelDefinition: modelConfig.ModelDefinition,
 					Configuration:   configuration,
 					Visibility:      modelPB.Model_VISIBILITY_PUBLIC,

--- a/pkg/handler/mock_service_test.go
+++ b/pkg/handler/mock_service_test.go
@@ -15,7 +15,7 @@ import (
 	datamodel "github.com/instill-ai/model-backend/pkg/datamodel"
 	repository "github.com/instill-ai/model-backend/pkg/repository"
 	service "github.com/instill-ai/model-backend/pkg/service"
-	util "github.com/instill-ai/model-backend/pkg/util"
+	util "github.com/instill-ai/model-backend/pkg/utils"
 	mgmtv1alpha "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 	taskv1alpha "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	modelv1alpha "github.com/instill-ai/protogen-go/model/model/v1alpha"

--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -16,7 +16,7 @@ import (
 	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/pkg/logger"
 	"github.com/instill-ai/model-backend/pkg/triton"
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
@@ -39,11 +39,11 @@ func parseImageFromURL(ctx context.Context, url string) (*image.Image, error) {
 		return nil, fmt.Errorf("unable to read content body from image at %v", url)
 	}
 
-	if numBytes > int64(config.Config.Server.MaxDataSize*util.MB) {
+	if numBytes > int64(config.Config.Server.MaxDataSize*utils.MB) {
 		return nil, fmt.Errorf(
 			"image size must be smaller than %vMB. Got %vMB",
 			config.Config.Server.MaxDataSize,
-			float32(numBytes)/float32(util.MB),
+			float32(numBytes)/float32(utils.MB),
 		)
 	}
 
@@ -66,11 +66,11 @@ func parseImageFromBase64(ctx context.Context, encoded string) (*image.Image, er
 		return nil, fmt.Errorf("unable to decode base64 image")
 	}
 	numBytes := len(decoded)
-	if numBytes > config.Config.Server.MaxDataSize*util.MB {
+	if numBytes > config.Config.Server.MaxDataSize*utils.MB {
 		return nil, fmt.Errorf(
 			"image size must be smaller than %vMB. Got %vMB",
 			config.Config.Server.MaxDataSize,
-			float32(numBytes)/float32(util.MB),
+			float32(numBytes)/float32(utils.MB),
 		)
 	}
 	img, _, err := image.Decode(bytes.NewReader(decoded))
@@ -166,19 +166,19 @@ func parseTexToImageRequestInputs(req *modelPB.TriggerModelRequest) (textToImage
 	}
 
 	for _, taskInput := range req.TaskInputs {
-		steps := int64(util.TEXT_TO_IMAGE_STEPS)
+		steps := int64(utils.TEXT_TO_IMAGE_STEPS)
 		if taskInput.GetTextToImage().Steps != nil {
 			steps = int64(*taskInput.GetTextToImage().Steps)
 		}
-		cfgScale := float32(util.IMAGE_TO_TEXT_CFG_SCALE)
+		cfgScale := float32(utils.IMAGE_TO_TEXT_CFG_SCALE)
 		if taskInput.GetTextToImage().CfgScale != nil {
 			cfgScale = float32(*taskInput.GetTextToImage().CfgScale)
 		}
-		seed := int64(util.IMAGE_TO_TEXT_SEED)
+		seed := int64(utils.IMAGE_TO_TEXT_SEED)
 		if taskInput.GetTextToImage().Seed != nil {
 			seed = int64(*taskInput.GetTextToImage().Seed)
 		}
-		samples := int64(util.IMAGE_TO_TEXT_SAMPLES)
+		samples := int64(utils.IMAGE_TO_TEXT_SAMPLES)
 		if taskInput.GetTextToImage().Samples != nil {
 			samples = int64(*taskInput.GetTextToImage().Samples)
 		}
@@ -198,7 +198,7 @@ func parseTexToImageRequestInputs(req *modelPB.TriggerModelRequest) (textToImage
 
 func parseTexGenerationRequestInputs(req *modelPB.TriggerModelRequest) (textGenerationInput *triton.TextGenerationInput, err error) {
 	for _, taskInput := range req.TaskInputs {
-		outputLen := int64(util.TEXT_GENERATION_OUTPUT_LEN)
+		outputLen := int64(utils.TEXT_GENERATION_OUTPUT_LEN)
 		if taskInput.GetTextGeneration().OutputLen != nil {
 			outputLen = int64(*taskInput.GetTextGeneration().OutputLen)
 		}
@@ -210,11 +210,11 @@ func parseTexGenerationRequestInputs(req *modelPB.TriggerModelRequest) (textGene
 		if taskInput.GetTextGeneration().StopWordsList != nil {
 			stopWordsList = *taskInput.GetTextGeneration().BadWordsList
 		}
-		topK := int64(util.TEXT_GENERATION_TOP_K)
+		topK := int64(utils.TEXT_GENERATION_TOP_K)
 		if taskInput.GetTextGeneration().Topk != nil {
 			topK = int64(*taskInput.GetTextGeneration().Topk)
 		}
-		seed := int64(util.TEXT_GENERATION_SEED)
+		seed := int64(utils.TEXT_GENERATION_SEED)
 		if taskInput.GetTextGeneration().Seed != nil {
 			seed = int64(*taskInput.GetTextGeneration().Seed)
 		}
@@ -253,11 +253,11 @@ func parseImageFormDataInputsToBytes(req *http.Request) (imgsBytes [][]byte, err
 			return nil, fmt.Errorf("unable to read content body from image")
 		}
 
-		if numBytes > int64(config.Config.Server.MaxDataSize*util.MB) {
+		if numBytes > int64(config.Config.Server.MaxDataSize*utils.MB) {
 			return nil, fmt.Errorf(
 				"image size must be smaller than %vMB. Got %vMB from image %v",
 				config.Config.Server.MaxDataSize,
-				float32(numBytes)/float32(util.MB),
+				float32(numBytes)/float32(utils.MB),
 				content.Filename,
 			)
 		}
@@ -309,7 +309,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *t
 		return nil, fmt.Errorf("invalid samples input, only support a single samples")
 	}
 
-	step := int(util.TEXT_TO_IMAGE_STEPS)
+	step := int(utils.TEXT_TO_IMAGE_STEPS)
 	if len(stepStr) > 0 {
 		step, err = strconv.Atoi(stepStr[0])
 		if err != nil {
@@ -317,7 +317,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *t
 		}
 	}
 
-	cfgScale := float64(util.IMAGE_TO_TEXT_CFG_SCALE)
+	cfgScale := float64(utils.IMAGE_TO_TEXT_CFG_SCALE)
 	if len(cfgScaleStr) > 0 {
 		cfgScale, err = strconv.ParseFloat(cfgScaleStr[0], 32)
 		if err != nil {
@@ -325,7 +325,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *t
 		}
 	}
 
-	seed := int(util.IMAGE_TO_TEXT_SEED)
+	seed := int(utils.IMAGE_TO_TEXT_SEED)
 	if len(seedStr) > 0 {
 		seed, err = strconv.Atoi(seedStr[0])
 		if err != nil {
@@ -333,7 +333,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *t
 		}
 	}
 
-	samples := int(util.IMAGE_TO_TEXT_SAMPLES)
+	samples := int(utils.IMAGE_TO_TEXT_SAMPLES)
 	if len(samplesStr) > 0 {
 		samples, err = strconv.Atoi(samplesStr[0])
 		if err != nil {
@@ -375,7 +375,7 @@ func parseTextFormDataTextGenerationInputs(req *http.Request) (textGeneration *t
 		stopWordsList = stopWordsListInput[0]
 	}
 
-	outputLen := int(util.TEXT_GENERATION_OUTPUT_LEN)
+	outputLen := int(utils.TEXT_GENERATION_OUTPUT_LEN)
 	if len(outputLenInput) > 0 {
 		outputLen, err = strconv.Atoi(outputLenInput[0])
 		if err != nil {
@@ -383,7 +383,7 @@ func parseTextFormDataTextGenerationInputs(req *http.Request) (textGeneration *t
 		}
 	}
 
-	topK := int(util.TEXT_GENERATION_TOP_K)
+	topK := int(utils.TEXT_GENERATION_TOP_K)
 	if len(topKInput) > 0 {
 		topK, err = strconv.Atoi(topKInput[0])
 		if err != nil {
@@ -391,7 +391,7 @@ func parseTextFormDataTextGenerationInputs(req *http.Request) (textGeneration *t
 		}
 	}
 
-	seed := int(util.TEXT_GENERATION_SEED)
+	seed := int(utils.TEXT_GENERATION_SEED)
 	if len(seedInput) > 0 {
 		seed, err = strconv.Atoi(seedInput[0])
 		if err != nil {

--- a/pkg/handler/private_handler.go
+++ b/pkg/handler/private_handler.go
@@ -17,7 +17,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/datamodel"
 	"github.com/instill-ai/model-backend/pkg/service"
 	"github.com/instill-ai/model-backend/pkg/triton"
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 	"github.com/instill-ai/x/sterr"
 
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
@@ -130,7 +130,7 @@ func (h *PrivateHandler) DeployModelAdmin(ctx context.Context, req *modelPB.Depl
 		return &modelPB.DeployModelAdminResponse{}, err
 	}
 
-	if !util.HasModelInModelRepository(config.Config.TritonServer.ModelStore, dbModel.Owner, dbModel.ID) {
+	if !utils.HasModelInModelRepository(config.Config.TritonServer.ModelStore, dbModel.Owner, dbModel.ID) {
 
 		modelDefinition, err := h.service.GetModelDefinitionByUID(ctx, dbModel.ModelDefinitionUid)
 		if err != nil {

--- a/pkg/logger/otel/const.go
+++ b/pkg/logger/otel/const.go
@@ -5,7 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 
 	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 )
@@ -106,13 +106,13 @@ func NewLogMessage(
 		EventResult   interface{} "json:\"eventResult\""
 		EventMessage  string      "json:\"eventMessage\""
 	}{
-		IsAuditEvent: util.IsAuditEvent(eventName),
+		IsAuditEvent: utils.IsAuditEvent(eventName),
 		EventInfo: struct {
 			EventName string "json:\"eventName\""
 			Billable  bool   "json:\"billable\""
 		}{
 			EventName: eventName,
-			Billable:  util.IsBillableEvent(eventName),
+			Billable:  utils.IsBillableEvent(eventName),
 		},
 	}
 

--- a/pkg/service/collect.go
+++ b/pkg/service/collect.go
@@ -5,17 +5,21 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/pkg/utils"
 )
 
 func (s *service) WriteNewDataPoint(ctx context.Context, data utils.UsageMetricData) error {
 
-	bData, err := json.Marshal(data)
-	if err != nil {
-		return err
-	}
+	if config.Config.Server.Usage.Enabled {
 
-	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:model.trigger_data", data.OwnerUID), string(bData))
+		bData, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+
+		s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:model.trigger_data", data.OwnerUID), string(bData))
+	}
 
 	return nil
 }

--- a/pkg/service/collect.go
+++ b/pkg/service/collect.go
@@ -2,17 +2,20 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"time"
 
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 )
 
-func (s *service) WriteNewDataPoint(ctx context.Context, data util.UsageMetricData) {
-	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:trigger.trigger_time", data.OwnerUID), data.TriggerTime.Format(time.RFC3339Nano))
-	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:trigger.trigger_uid", data.OwnerUID), data.TriggerUID)
-	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:trigger.model_uid", data.OwnerUID), data.ModelUID)
-	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:trigger.model_definition_uid", data.OwnerUID), data.ModelDefinitionUID)
-	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:trigger.model_task", data.OwnerUID), data.ModelTask.String())
-	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:trigger.status", data.OwnerUID), data.Status)
+func (s *service) WriteNewDataPoint(ctx context.Context, data utils.UsageMetricData) error {
+
+	bData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	s.redisClient.RPush(ctx, fmt.Sprintf("user:%s:model.trigger_data", data.OwnerUID), string(bData))
+
+	return nil
 }

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -4,13 +4,13 @@ import (
 	"context"
 
 	"github.com/gofrs/uuid"
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 	controllerPB "github.com/instill-ai/protogen-go/model/controller/v1alpha"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
 func (s *service) GetResourceState(ctx context.Context, modelUID uuid.UUID) (*modelPB.Model_State, error) {
-	resourcePermalink := util.ConvertModelToResourcePermalink(modelUID.String())
+	resourcePermalink := utils.ConvertModelToResourcePermalink(modelUID.String())
 
 	resp, err := s.controllerClient.GetResource(ctx, &controllerPB.GetResourceRequest{
 		ResourcePermalink: resourcePermalink,
@@ -24,7 +24,7 @@ func (s *service) GetResourceState(ctx context.Context, modelUID uuid.UUID) (*mo
 }
 
 func (s *service) UpdateResourceState(ctx context.Context, modelUID uuid.UUID, state modelPB.Model_State, progress *int32, workflowId *string) error {
-	resourcePermalink := util.ConvertModelToResourcePermalink(modelUID.String())
+	resourcePermalink := utils.ConvertModelToResourcePermalink(modelUID.String())
 
 	if _, err := s.controllerClient.UpdateResource(ctx, &controllerPB.UpdateResourceRequest{
 		Resource: &controllerPB.Resource{
@@ -43,7 +43,7 @@ func (s *service) UpdateResourceState(ctx context.Context, modelUID uuid.UUID, s
 }
 
 func (s *service) DeleteResourceState(ctx context.Context, modelUID uuid.UUID) error {
-	resourcePermalink := util.ConvertModelToResourcePermalink(modelUID.String())
+	resourcePermalink := utils.ConvertModelToResourcePermalink(modelUID.String())
 
 	if _, err := s.controllerClient.DeleteResource(ctx, &controllerPB.DeleteResourceRequest{
 		ResourcePermalink: resourcePermalink,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -25,7 +25,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/logger"
 	"github.com/instill-ai/model-backend/pkg/repository"
 	"github.com/instill-ai/model-backend/pkg/triton"
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 	"github.com/instill-ai/x/sterr"
 
 	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
@@ -79,7 +79,7 @@ type Service interface {
 	DeleteResourceState(ctx context.Context, modelUID uuid.UUID) error
 
 	// Usage collection
-	WriteNewDataPoint(ctx context.Context, data util.UsageMetricData)
+	WriteNewDataPoint(ctx context.Context, data utils.UsageMetricData) error
 }
 
 type service struct {
@@ -626,7 +626,7 @@ func (s *service) ModelInfer(ctx context.Context, modelUID uuid.UUID, inferInput
 				if err := json.Unmarshal(b, &mapOutput); err != nil {
 					return nil, err
 				}
-				util.ConvertAllJSONKeySnakeCase(mapOutput)
+				utils.ConvertAllJSONKeySnakeCase(mapOutput)
 
 				b, err = json.Marshal(mapOutput)
 				if err != nil {

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -1,4 +1,4 @@
-package util
+package utils
 
 import (
 	"google.golang.org/protobuf/encoding/protojson"

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -1,4 +1,4 @@
-package util
+package utils
 
 import (
 	"archive/zip"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,4 +1,4 @@
-package util
+package utils
 
 import (
 	"bufio"
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/gernest/front"
 	"github.com/gofrs/uuid"
@@ -870,6 +869,6 @@ type UsageMetricData struct {
 	Status             mgmtPB.Status
 	TriggerUID         string
 	ModelDefinitionUID string
-	TriggerTime        time.Time
+	TriggerTime        string
 	ModelTask          commonPB.Task
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,4 +1,4 @@
-package util
+package utils
 
 import (
 	"fmt"

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/pkg/datamodel"
-	"github.com/instill-ai/model-backend/pkg/util"
+	"github.com/instill-ai/model-backend/pkg/utils"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
@@ -71,7 +71,7 @@ var preDeployModelMap = map[string]map[string]string{
 
 func GetPreDeployGitHubModelUUID(model datamodel.Model) (*datamodel.PreDeployModel, error) {
 	var preDeployModelConfigs []PreModelConfig
-	err := util.GetJSON(config.Config.InitModel.Path, &preDeployModelConfigs)
+	err := utils.GetJSON(config.Config.InitModel.Path, &preDeployModelConfigs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because

- avoid error-prone implementation of redis cache datatype

This commit

- update redis cache datatype
- add usage enabled check before write into redis
- fix `util` package naming
