### PR TITLE
refactor(controller): remove most dependencies from controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230818082151-fe5c9357e125
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1305,8 +1305,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc h1:1akaOOUCsVU2yzFIb5KwVw5GRy7v+hyNmNmJD+2x+l8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230818082151-fe5c9357e125 h1:T8ey9xcT9gSkd675d1XdOgC5KEFB/TxW/dMbVUHqMEk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230818082151-fe5c9357e125/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/go.sum
+++ b/go.sum
@@ -1307,8 +1307,6 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc h1:1akaOOUCsVU2yzFIb5KwVw5GRy7v+hyNmNmJD+2x+l8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
-github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814113533-6727d46291c1 h1:iaPGRShOA7aTNJBke9IoM6zzgjxYxbo3UCcCndiMWSQ=
-github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814113533-6727d46291c1/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -54,7 +54,8 @@ export default () => {
     queryModelPrivate.ListModels()
     queryModelPrivate.LookUpModel()
     deployModelPrivate.CheckModel()
-    deployModelPrivate.DeployUndeployModel()
+    // private deploy will be triggered by public deploy
+    // deployModelPrivate.DeployUndeployModel()
   }
 
   // Create model API

--- a/integration-test/grpc_create_model.js
+++ b/integration-test/grpc_create_model.js
@@ -71,9 +71,7 @@ export function CreateModel() {
     }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeployModel', req, {}), {
       'DeployModel status': (r) => r && r.status === grpc.StatusOK,
-      'DeployModel operation name': (r) => r && r.message.operation.name !== undefined,
-      'DeployModel operation metadata': (r) => r && r.message.operation.metadata === null,
-      'DeployModel operation done': (r) => r && r.message.operation.done === false,
+      'DeployModel model name': (r) => r && r.message.modelId === model_id
     });
 
     // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)

--- a/integration-test/grpc_deploy_model.js
+++ b/integration-test/grpc_deploy_model.js
@@ -68,9 +68,7 @@ export function DeployUndeployModel() {
     }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeployModel', req, {}), {
       'DeployModel status': (r) => r && r.status === grpc.StatusOK,
-      'DeployModel operation name': (r) => r && r.message.operation.name !== undefined,
-      'DeployModel operation metadata': (r) => r && r.message.operation.metadata === null,
-      'DeployModel operation done': (r) => r && r.message.operation.done === false,
+      'DeployModel model name': (r) => r && r.message.modelId === model_id
     });
 
     // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)

--- a/integration-test/grpc_deploy_model_private.js
+++ b/integration-test/grpc_deploy_model_private.js
@@ -93,7 +93,7 @@ export function CheckModel() {
     currentTime = new Date().getTime();
     timeoutTime = new Date().getTime() + 120000;
     while (timeoutTime > currentTime) {
-      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+      let res = publicClient.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
         name: `models/${model_id}`
       }, {})
       if (res.message.state !== "STATE_UNSPECIFIED") {

--- a/integration-test/grpc_deploy_model_private.js
+++ b/integration-test/grpc_deploy_model_private.js
@@ -90,6 +90,18 @@ export function CheckModel() {
     }, {}), {
       'CheckModelAdmin uuid length is invalid': (r) => r && r.status === grpc.StatusInvalidArgument,
     });
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(publicClient.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {

--- a/integration-test/grpc_infer_model.js
+++ b/integration-test/grpc_infer_model.js
@@ -69,9 +69,7 @@ export function InferModel() {
     }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeployModel', req, {}), {
       'DeployModel status': (r) => r && r.status === grpc.StatusOK,
-      'DeployModel operation name': (r) => r && r.message.operation.name !== undefined,
-      'DeployModel operation metadata': (r) => r && r.message.operation.metadata === null,
-      'DeployModel operation done': (r) => r && r.message.operation.done === false,
+      'DeployModel model name': (r) => r && r.message.modelId === model_id
     });
 
     // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -181,9 +179,7 @@ export function InferModel() {
     }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeployModel', req, {}), {
       'DeployModel status': (r) => r && r.status === grpc.StatusOK,
-      'DeployModel operation name': (r) => r && r.message.operation.name !== undefined,
-      'DeployModel operation metadata': (r) => r && r.message.operation.metadata === null,
-      'DeployModel operation done': (r) => r && r.message.operation.done === false,
+      'DeployModel model name': (r) => r && r.message.modelId === model_id
     });
 
     // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)

--- a/integration-test/grpc_publish_model.js
+++ b/integration-test/grpc_publish_model.js
@@ -110,7 +110,18 @@ export function PublishUnPublishModel() {
     }), {
       "UnpublishModel response not found status": (r) => r.status === grpc.StatusNotFound,
     });
-
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {

--- a/integration-test/grpc_query_model.js
+++ b/integration-test/grpc_query_model.js
@@ -85,7 +85,18 @@ export function GetModel() {
     }, {}), {
       'GetModel non-existed model status not found': (r) => r && r.status === grpc.StatusNotFound,
     });
-
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {
@@ -149,7 +160,18 @@ export function ListModels() {
       "ListModels response models[0].create_time": (r) => r.message.models[0].createTime !== undefined,
       "ListModels response models[0].update_time": (r) => r.message.models[0].updateTime !== undefined,
     });
-
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {
@@ -221,6 +243,18 @@ export function LookupModel() {
     }, {}), {
       'LookUpModel non-existed model status not found': (r) => r && r.status === grpc.StatusInvalidArgument,
     });
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {

--- a/integration-test/grpc_query_model_private.js
+++ b/integration-test/grpc_query_model_private.js
@@ -91,7 +91,7 @@ export function ListModels() {
     currentTime = new Date().getTime();
     timeoutTime = new Date().getTime() + 120000;
     while (timeoutTime > currentTime) {
-      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+      let res = publicClient.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
         name: `models/${model_id}`
       }, {})
       if (res.message.state !== "STATE_UNSPECIFIED") {
@@ -181,7 +181,7 @@ export function LookUpModel() {
     currentTime = new Date().getTime();
     timeoutTime = new Date().getTime() + 120000;
     while (timeoutTime > currentTime) {
-      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+      let res = publicClient.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
         name: `models/${model_id}`
       }, {})
       if (res.message.state !== "STATE_UNSPECIFIED") {

--- a/integration-test/grpc_query_model_private.js
+++ b/integration-test/grpc_query_model_private.js
@@ -88,7 +88,18 @@ export function ListModels() {
       "ListModelsAdmin response models[0].create_time": (r) => r.message.models[0].createTime !== undefined,
       "ListModelsAdmin response models[0].update_time": (r) => r.message.models[0].updateTime !== undefined,
     });
-
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(publicClient.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {
@@ -167,6 +178,18 @@ export function LookUpModel() {
     }, {}), {
       'LookUpModelAdmin non-existed model status not found': (r) => r && r.status === grpc.StatusInvalidArgument,
     });
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(publicClient.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {

--- a/integration-test/grpc_update_model.js
+++ b/integration-test/grpc_update_model.js
@@ -84,7 +84,18 @@ export function UpdateModel() {
       "UpdateModel response model.create_time": (r) => r.message.model.createTime !== undefined,
       "UpdateModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
     });
-
+    currentTime = new Date().getTime();
+    timeoutTime = new Date().getTime() + 120000;
+    while (timeoutTime > currentTime) {
+      let res = client.invoke('model.model.v1alpha.ModelPublicService/WatchModel', {
+        name: `models/${model_id}`
+      }, {})
+      if (res.message.state !== "STATE_UNSPECIFIED") {
+        break
+      }
+      sleep(1)
+      currentTime = new Date().getTime();
+    }
     check(client.invoke('model.model.v1alpha.ModelPublicService/DeleteModel', {
       name: "models/" + model_id
     }), {

--- a/integration-test/proto/model/model/v1alpha/model.proto
+++ b/integration-test/proto/model/model/v1alpha/model.proto
@@ -340,8 +340,9 @@ message DeployModelRequest {
 
 // DeployModelResponse represents a response for a deployed model
 message DeployModelResponse {
-  // Deploy operation message
-  google.longrunning.Operation operation = 1;
+  // Deployed model's id
+  // Format: models/{model}
+  string model_id = 1;
 }
 
 // UndeployModelRequest represents a request to undeploy a model to offline
@@ -357,8 +358,9 @@ message UndeployModelRequest {
 
 // UndeployModelResponse represents a response for a undeployed model
 message UndeployModelResponse {
-  // Undeploy operation message
-  google.longrunning.Operation operation = 1;
+  // Undeployed model's id
+  // Format: models/{model}
+  string model_id = 1;
 }
 
 // GetModelCardRequest represents a request to query a model's README card

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -50,7 +50,8 @@ export default function (data) {
   if (!constant.apiGatewayMode) {
     queryModelPrivate.ListModelsAdmin()
     queryModelPrivate.LookupModelAdmin()
-    deployModelPrivate.DeployUndeployModel()
+    // private deploy will be trigger by public deploy
+    // deployModelPrivate.DeployUndeployModel()
   }
 
   // Infer Model API

--- a/integration-test/rest_create_model.js
+++ b/integration-test/rest_create_model.js
@@ -169,6 +169,31 @@ export function CreateModelFromLocal() {
           r.status === 409,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res_cls = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_cls}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_det = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_det}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_keypoint = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_keypoint}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_unspecified = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_unspecified}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res_cls.json().state !== "STATE_UNSPECIFIED" &&
+          res_det.json().state !== "STATE_UNSPECIFIED" &&
+          res_keypoint.json().state !== "STATE_UNSPECIFIED" &&
+          res_unspecified.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id_cls}`, null, {
         headers: genHeader(`application/json`),
@@ -281,6 +306,31 @@ export function CreateModelFromLocal() {
           r.status === 400,
       });
 
+      let currentTime = new Date().getTime();
+      let timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res_cls = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_cls}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_det = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_det}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_keypoint = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_keypoint}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_unspecified = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_unspecified}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res_cls.json().state !== "STATE_UNSPECIFIED" &&
+          res_det.json().state !== "STATE_UNSPECIFIED" &&
+          res_keypoint.json().state !== "STATE_UNSPECIFIED" &&
+          res_unspecified.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id_cls}`, null, {
         headers: genHeader(`application/json`),
@@ -387,6 +437,19 @@ export function CreateModelFromGitHub() {
         "POST /v1alpha/models by github missing github_url status": (r) =>
           r.status === 400,
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {

--- a/integration-test/rest_create_model_with_jwt.js
+++ b/integration-test/rest_create_model_with_jwt.js
@@ -70,6 +70,19 @@ export function CreateModelFromLocal() {
         currentTime = new Date().getTime();
       }
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeaderwithJwtSub(`application/json`, uuidv4()),
@@ -141,6 +154,19 @@ export function CreateModelFromGitHub() {
           headers: genHeader(`application/json`),
         })
         if (res.json().operation.done === true) {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
           break
         }
         sleep(1)

--- a/integration-test/rest_deploy_model.js
+++ b/integration-test/rest_deploy_model.js
@@ -78,6 +78,19 @@ export function DeployUndeployModel() {
           r.json().model.state === "STATE_ONLINE",
       })
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state === "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
         headers: genHeader(`application/json`),
       }), {
@@ -161,6 +174,19 @@ export function DeployUndeployModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.response`]: (r) =>
           r.json().operation.response !== undefined,
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state === "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
         headers: genHeader(`application/json`),

--- a/integration-test/rest_deploy_model.js
+++ b/integration-test/rest_deploy_model.js
@@ -59,14 +59,8 @@ export function DeployUndeployModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/deploy online task cls response status`]: (r) =>
           r.status === 200,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+        [`POST /v1alpha/models/${model_id}/deploy online task cls response mode ID`]: (r) =>
+          r.json().model_id === model_id
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}`, {
@@ -128,13 +122,7 @@ export function DeployUndeployModel() {
         [`POST /v1alpha/models/${model_id}/undeploy online task cls response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/undeploy online task cls response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/undeploy online task cls response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/undeploy online task cls response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/undeploy online task cls response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}`, {
@@ -165,14 +153,8 @@ export function DeployUndeployModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/deploy online task cls response status`]: (r) =>
           r.status === 200,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+        [`POST /v1alpha/models/${model_id}/deploy online task cls response model ID`]: (r) =>
+          r.json().model_id === model_id
       });
 
       currentTime = new Date().getTime();

--- a/integration-test/rest_infer_github_model.js
+++ b/integration-test/rest_infer_github_model.js
@@ -64,13 +64,7 @@ export function InferGitHubModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task cls response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model instance state being updated in 1 hours. Some GitHub models is huge.
@@ -333,13 +327,7 @@ export function InferGitHubModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task cls response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model instance state being updated in 1 hours. Some GitHub models is huge.
@@ -602,13 +590,7 @@ export function InferGitHubModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task det response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task det response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model instance state being updated in 1 hour
@@ -1010,13 +992,7 @@ export function InferGitHubModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task det response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task det response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model instance state being updated in 1 hour
@@ -1418,13 +1394,7 @@ export function InferGitHubModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task keypoint response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model instance state being updated in 1 hours. Some GitHub models is huge.

--- a/integration-test/rest_infer_model.js
+++ b/integration-test/rest_infer_model.js
@@ -62,13 +62,7 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task cls response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -331,13 +325,7 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task det response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task det response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task det response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -740,13 +728,7 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task unspecified response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task unspecified response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task unspecified response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task unspecified response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task unspecified response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -1066,13 +1048,7 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task keypoint response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task keypoint response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -1442,13 +1418,7 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task det empty response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task det empty response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task det empty response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task det empty response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task det empty response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -1814,13 +1784,7 @@ export function InferModel() {
         [`POST /v1alpha/models/${model_id}/deploy online task semantic response status`]: (r) =>
           r.status === 200,
         [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -2107,16 +2071,10 @@ export function InferModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/deploy`, {}, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /v1alpha/models/${model_id}/deploy online task response status`]: (r) =>
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response status`]: (r) =>
           r.status === 200,
-        [`POST /v1alpha/models/${model_id}/deploy online task response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.name`]: (r) =>
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -2539,16 +2497,10 @@ export function InferModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/deploy`, {}, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /v1alpha/models/${model_id}/deploy online task text to image response status`]: (r) =>
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response status`]: (r) =>
           r.status === 200,
-        [`POST /v1alpha/models/${model_id}/deploy online task text to image response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task text to image response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task text to image response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task text to image response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.name`]: (r) =>
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)
@@ -2775,16 +2727,10 @@ export function InferModel() {
       check(http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/deploy`, {}, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /v1alpha/models/${model_id}/deploy online task text generation response status`]: (r) =>
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response status`]: (r) =>
           r.status === 200,
-        [`POST /v1alpha/models/${model_id}/deploy online task text generation response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task text generation response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task text generation response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task text generation response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.name`]: (r) =>
+          r.json().model_id === model_id
       });
 
       // Check the model state being updated in 120 secs (in integration test, model is dummy model without download time but in real use case, time will be longer)

--- a/integration-test/rest_longrunning_operation.js
+++ b/integration-test/rest_longrunning_operation.js
@@ -60,16 +60,10 @@ export function GetLongRunningOperation() {
         headers: genHeader(`application/json`),
       })
       check(operationRes, {
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response status`]: (r) =>
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response status`]: (r) =>
           r.status === 200,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.done`]: (r) =>
-          r.json().operation.done === false,
-        [`POST /v1alpha/models/${model_id}/deploy online task cls response operation.response`]: (r) =>
-          r.json().operation.response !== undefined,
+        [`POST /v1alpha/models/${model_id}/deploy online task semantic response operation.name`]: (r) =>
+          r.json().model_id === model_id
       });
 
       sleep(1) // take time to execute in Temporal

--- a/integration-test/rest_longrunning_operation.js
+++ b/integration-test/rest_longrunning_operation.js
@@ -54,6 +54,8 @@ export function GetLongRunningOperation() {
         currentTime = new Date().getTime();
       }
 
+      // TODO: public endpoint of deploy/undeploy is not longrunning anymore, need test revise
+
       let operationRes = http.post(`${constant.apiPublicHost}/v1alpha/models/${model_id}/deploy`, {}, {
         headers: genHeader(`application/json`),
       })
@@ -71,24 +73,11 @@ export function GetLongRunningOperation() {
       });
 
       sleep(1) // take time to execute in Temporal
-      check(http.get(`${constant.apiPublicHost}/v1alpha/${operationRes.json().operation.name}`, {}, {
-        headers: genHeader(`application/json`),
-      }), {
-        [`GET v1alpha/${operationRes.json().operation.name} response status`]: (r) =>
-          r.status === 200,
-        [`GET v1alpha/${operationRes.json().operation.name} response operation.name`]: (r) =>
-          r.json().operation.name !== undefined,
-        [`GET v1alpha/${operationRes.json().operation.name} response operation.metadata`]: (r) =>
-          r.json().operation.metadata === null,
-        [`GET v1alpha/${operationRes.json().operation.name} response operation.done`]: (r) =>
-          r.json().operation.done !== undefined,
-      });
 
-      // Check the model state being updated in 120 secs
       currentTime = new Date().getTime();
       timeoutTime = new Date().getTime() + 120000;
       while (timeoutTime > currentTime) {
-        var res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
           headers: genHeader(`application/json`),
         })
         if (res.json().state === "STATE_UNSPECIFIED") {
@@ -97,6 +86,19 @@ export function GetLongRunningOperation() {
         sleep(1)
         currentTime = new Date().getTime();
       }
+
+      // check(http.get(`${constant.apiPublicHost}/v1alpha/${operationRes.json().operation.name}`, {}, {
+      //   headers: genHeader(`application/json`),
+      // }), {
+      //   [`GET v1alpha/${operationRes.json().operation.name} response status`]: (r) =>
+      //     r.status === 200,
+      //   [`GET v1alpha/${operationRes.json().operation.name} response operation.name`]: (r) =>
+      //     r.json().operation.name !== undefined,
+      //   [`GET v1alpha/${operationRes.json().operation.name} response operation.metadata`]: (r) =>
+      //     r.json().operation.metadata === null,
+      //   [`GET v1alpha/${operationRes.json().operation.name} response operation.done`]: (r) =>
+      //     r.json().operation.done !== undefined,
+      // });
 
       // model can only be deleted after operation done
       while (timeoutTime > currentTime) {

--- a/integration-test/rest_model_card.js
+++ b/integration-test/rest_model_card.js
@@ -70,6 +70,19 @@ export function GetModelCard() {
           r.json().readme.content !== undefined,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeader(`application/json`),
@@ -127,6 +140,19 @@ export function GetModelCard() {
         [`GET /v1alpha/models/${model_id}/readme no readme response readme.content`]: (r) =>
           r.json().readme.content === "",
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {

--- a/integration-test/rest_model_card_with_jwt.js
+++ b/integration-test/rest_model_card_with_jwt.js
@@ -69,6 +69,19 @@ export function GetModelCard() {
           r.status === 200,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeaderwithJwtSub(`application/json`, userUid),

--- a/integration-test/rest_publish_model.js
+++ b/integration-test/rest_publish_model.js
@@ -120,6 +120,20 @@ export function PublishUnpublishModel() {
       }), {
         [`POST /v1alpha/models/${model_id}/unpublish task cls response not found status`]: (r) => r.status === 404,
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeader(`application/json`),

--- a/integration-test/rest_publish_model_with_jwt.js
+++ b/integration-test/rest_publish_model_with_jwt.js
@@ -82,6 +82,19 @@ export function PublishUnpublishModel() {
           r.status === 200,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeaderwithJwtSub(`application/json`, userUid),

--- a/integration-test/rest_query_model.js
+++ b/integration-test/rest_query_model.js
@@ -117,6 +117,19 @@ export function GetModel() {
           r.json().model.update_time !== undefined,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeader(`application/json`),
@@ -339,6 +352,22 @@ export function ListModels() {
           r.json().models[1].update_time !== undefined,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res_1 = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_1}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_2 = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_2}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res_1.json().state !== "STATE_UNSPECIFIED" && res_2.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id_1}`, null, {
         headers: genHeader(`application/json`),
@@ -454,6 +483,19 @@ export function LookupModel() {
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.update_time`]: (r) =>
           r.json().model.update_time !== undefined,
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {

--- a/integration-test/rest_query_model_private.js
+++ b/integration-test/rest_query_model_private.js
@@ -347,6 +347,19 @@ export function LookupModelAdmin() {
           r.json().model.update_time !== undefined,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeader(`application/json`),

--- a/integration-test/rest_query_model_private.js
+++ b/integration-test/rest_query_model_private.js
@@ -228,6 +228,22 @@ export function ListModelsAdmin() {
           r.json().models[1].update_time !== undefined,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res_1 = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_1}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        let res_2 = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id_2}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res_1.json().state !== "STATE_UNSPECIFIED" && res_2.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id_1}`, null, {
         headers: genHeader(`application/json`),
@@ -346,6 +362,19 @@ export function LookupModelAdmin() {
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.update_time`]: (r) =>
           r.json().model.update_time !== undefined,
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
 
       currentTime = new Date().getTime();
       timeoutTime = new Date().getTime() + 120000;

--- a/integration-test/rest_query_model_with_jwt.js
+++ b/integration-test/rest_query_model_with_jwt.js
@@ -80,6 +80,19 @@ export function GetModel() {
           r.status === 200,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeaderwithJwtSub(`application/json`, userUid),
@@ -214,6 +227,19 @@ export function LookupModel() {
         [`[with default "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL task cls response status 200`]: (r) =>
           r.status === 200,
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {

--- a/integration-test/rest_update_model.js
+++ b/integration-test/rest_update_model.js
@@ -123,6 +123,20 @@ export function UpdateModel() {
         [`PATCH /v1alpha/models/${model_id} task cls description empty response model.update_time`]: (r) =>
           r.json().model.update_time !== undefined,
       });
+
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeader(`application/json`),

--- a/integration-test/rest_update_model_with_jwt.js
+++ b/integration-test/rest_update_model_with_jwt.js
@@ -74,6 +74,19 @@ export function UpdateModel() {
           r.status === 200,
       });
 
+      currentTime = new Date().getTime();
+      timeoutTime = new Date().getTime() + 120000;
+      while (timeoutTime > currentTime) {
+        let res = http.get(`${constant.apiPublicHost}/v1alpha/models/${model_id}/watch`, {
+          headers: genHeader(`application/json`),
+        })
+        if (res.json().state !== "STATE_UNSPECIFIED") {
+          break
+        }
+        sleep(1)
+        currentTime = new Date().getTime();
+      }
+
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/models/${model_id}`, null, {
         headers: genHeaderwithJwtSub(`application/json`, userUid),

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -2035,7 +2035,7 @@ func (h *PublicHandler) DeployModel(ctx context.Context, req *modelPB.DeployMode
 	eventName := "DeployModel"
 
 	// block for controller to update the state
-	ctx, cancel := context.WithTimeout(ctx, 4 * time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
 
 	ctx, span := tracer.Start(ctx, eventName,
@@ -2081,10 +2081,11 @@ func (h *PublicHandler) DeployModel(ctx context.Context, req *modelPB.DeployMode
 	}
 
 	state := modelPB.Model_STATE_OFFLINE.Enum()
-	for state == modelPB.Model_STATE_OFFLINE.Enum() {
+	for state.String() == modelPB.Model_STATE_OFFLINE.String() {
 		if state, err = h.service.GetResourceState(ctx, dbModel.UID); err != nil {
 			return &modelPB.DeployModelResponse{}, err
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
@@ -2104,7 +2105,7 @@ func (h *PublicHandler) UndeployModel(ctx context.Context, req *modelPB.Undeploy
 	eventName := "UndeployModel"
 
 	// block for controller to update the state
-	ctx, cancel := context.WithTimeout(ctx, 4 * time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
 
 	ctx, span := tracer.Start(ctx, eventName,
@@ -2149,11 +2150,12 @@ func (h *PublicHandler) UndeployModel(ctx context.Context, req *modelPB.Undeploy
 		return &modelPB.UndeployModelResponse{}, err
 	}
 
-	state := modelPB.Model_STATE_OFFLINE.Enum()
-	for state == modelPB.Model_STATE_OFFLINE.Enum() {
+	state := modelPB.Model_STATE_ONLINE.Enum()
+	for state.String() == modelPB.Model_STATE_ONLINE.String() {
 		if state, err = h.service.GetResourceState(ctx, dbModel.UID); err != nil {
 			return &modelPB.UndeployModelResponse{}, err
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"github.com/go-redis/redis/v9"
@@ -704,6 +705,13 @@ func (s *service) DeleteModel(ctx context.Context, owner string, modelID string)
 			modelDir := filepath.Join(config.Config.TritonServer.ModelStore, tritonModels[i].Name)
 			_ = os.RemoveAll(modelDir)
 		}
+	}
+
+	for state.String() == modelPB.Model_STATE_ONLINE.String() {
+		if state, err = s.GetResourceState(ctx, modelInDB.UID); err != nil {
+			return err
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	if err := s.DeleteResourceState(ctx, modelInDB.UID); err != nil {


### PR DESCRIPTION
Because

- reduce dependency cycle between `controller-model` and `model-backend`

This commit

- remove resource updating from `model-backend` to `controller-model` to avoid api calls cycle
- update public deploy/undeploy methods to change the desire state only, and let `controller-model` handle the actual deployment request
- update integration-test regarding to the deploy/undeploy public methods
