### PR TITLE
chore(controller): fix predeploy and private create parent path

### DIFF
--- a/cmd/model/main.go
+++ b/cmd/model/main.go
@@ -20,6 +20,7 @@ import (
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 
 	"github.com/instill-ai/model-backend/config"
+	"github.com/instill-ai/model-backend/pkg/constant"
 	"github.com/instill-ai/model-backend/pkg/logger"
 	"github.com/instill-ai/model-backend/pkg/utils"
 
@@ -135,6 +136,7 @@ func main() {
 					Configuration:   configuration,
 					Visibility:      modelPB.Model_VISIBILITY_PUBLIC,
 				},
+				Parent: "users/" + constant.DefaultUserID,
 			})
 			if err != nil {
 				logger.Info(fmt.Sprintf("Created model err: %v", err))

--- a/pkg/handler/private_handler.go
+++ b/pkg/handler/private_handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/internal/resource"
+	"github.com/instill-ai/model-backend/pkg/constant"
 	"github.com/instill-ai/model-backend/pkg/datamodel"
 	"github.com/instill-ai/model-backend/pkg/service"
 	"github.com/instill-ai/model-backend/pkg/triton"
@@ -134,6 +135,7 @@ func (h *PrivateHandler) DeployModelAdmin(ctx context.Context, req *modelPB.Depl
 
 		createReq := &modelPB.CreateUserModelRequest{
 			Model: pbModel,
+			Parent: "users/" + constant.DefaultUserID,
 		}
 
 		var resp *modelPB.CreateUserModelResponse


### PR DESCRIPTION
Because

- missing parent path in predeploy and private model create request

This commit

- add `parent` param
