### PR TITLE
chore: remove api-token validation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1308,8 +1308,6 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829050804-7cbee906e52d h1:LpzcaqduRTxGjOQgncCgLQxpH7TAsLmpbxROdVDJxDM=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829050804-7cbee906e52d/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
-github.com/instill-ai/usage-client v0.2.4-alpha h1:mYXd62eZsmGKBlzwMcdEgTBgn8zlbagYUHro6+p50c8=
-github.com/instill-ai/usage-client v0.2.4-alpha/go.mod h1:BMxgyr02sqH6SeITXSV4M1ewwvfklzXIc5yzIqaN0c8=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -3,5 +3,3 @@ package constant
 // Constants for resource owner
 const DefaultUserID string = "instill-ai"
 const HeaderUserUIDKey = "jwt-sub"
-const HeaderAuthorization = "Authorization"
-const AccessTokenKeyFormat = "access_token:%s:owner_permalink"


### PR DESCRIPTION
Because

- centralize api_token validation in api-gateway

This commit

- remove api_token validation