### PR TITLE
refactor(handler): adopt 32bit int type in request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1306,8 +1306,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193 h1:b2ye7vXuatGosIQ+65rkboubrQ+y6gX5xutyKcerZiQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc h1:RGrUkr9dnUxQs74/x1lWdLhIODnr6m6dZ/6UY+n08qw=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/private_handler.go
+++ b/pkg/handler/private_handler.go
@@ -47,7 +47,7 @@ func (h *PrivateHandler) ListModelsAdmin(ctx context.Context, req *modelPB.ListM
 	resp := modelPB.ListModelsAdminResponse{
 		Models:        pbModels,
 		NextPageToken: nextPageToken,
-		TotalSize:     totalSize,
+		TotalSize:     int32(totalSize),
 	}
 
 	return &resp, nil

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -79,7 +79,7 @@ func savePredictInputsTriggerMode(stream modelPB.ModelPublicService_TriggerUserM
 	var fileData *modelPB.TriggerUserModelBinaryFileUploadRequest
 
 	var allContentFiles []byte
-	var fileLengths []uint64
+	var fileLengths []uint32
 
 	var textToImageInput *triton.TextToImageInput
 	var textGeneration *triton.TextGenerationInput
@@ -124,19 +124,19 @@ func savePredictInputsTriggerMode(stream modelPB.ModelPublicService_TriggerUserM
 			case *modelPB.TaskInputStream_TextToImage:
 				textToImageInput = &triton.TextToImageInput{
 					Prompt:   fileData.TaskInput.GetTextToImage().Prompt,
-					Steps:    *fileData.TaskInput.GetTextToImage().Steps,
+					Steps:    int64(*fileData.TaskInput.GetTextToImage().Steps),
 					CfgScale: *fileData.TaskInput.GetTextToImage().CfgScale,
-					Seed:     *fileData.TaskInput.GetTextToImage().Seed,
-					Samples:  *fileData.TaskInput.GetTextToImage().Samples,
+					Seed:     int64(*fileData.TaskInput.GetTextToImage().Seed),
+					Samples:  int64(*fileData.TaskInput.GetTextToImage().Samples),
 				}
 			case *modelPB.TaskInputStream_TextGeneration:
 				textGeneration = &triton.TextGenerationInput{
 					Prompt:        fileData.TaskInput.GetTextGeneration().Prompt,
-					OutputLen:     *fileData.TaskInput.GetTextGeneration().OutputLen,
+					OutputLen:     int64(*fileData.TaskInput.GetTextGeneration().OutputLen),
 					BadWordsList:  *fileData.TaskInput.GetTextGeneration().BadWordsList,
 					StopWordsList: *fileData.TaskInput.GetTextGeneration().StopWordsList,
-					TopK:          *fileData.TaskInput.GetTextGeneration().Topk,
-					Seed:          *fileData.TaskInput.GetTextGeneration().Seed,
+					TopK:          int64(*fileData.TaskInput.GetTextGeneration().Topk),
+					Seed:          int64(*fileData.TaskInput.GetTextGeneration().Seed),
 				}
 			default:
 				return nil, "", fmt.Errorf("unsupported task input type")
@@ -172,7 +172,7 @@ func savePredictInputsTriggerMode(stream modelPB.ModelPublicService_TriggerUserM
 			return nil, "", fmt.Errorf("wrong parameter length of files")
 		}
 		imageBytes := make([][]byte, len(fileLengths))
-		start := uint64(0)
+		start := uint32(0)
 		for i := 0; i < len(fileLengths); i++ {
 			buff := new(bytes.Buffer)
 			img, _, err := image.Decode(bytes.NewReader(allContentFiles[start : start+fileLengths[i]]))
@@ -203,7 +203,7 @@ func savePredictInputsTestMode(stream modelPB.ModelPublicService_TestUserModelBi
 	var textGeneration *triton.TextGenerationInput
 
 	var allContentFiles []byte
-	var fileLengths []uint64
+	var fileLengths []uint32
 	for {
 		fileData, err = stream.Recv() //ignoring the data  TO-Do save files received
 		if err != nil {
@@ -244,19 +244,19 @@ func savePredictInputsTestMode(stream modelPB.ModelPublicService_TestUserModelBi
 			case *modelPB.TaskInputStream_TextToImage:
 				textToImageInput = &triton.TextToImageInput{
 					Prompt:   fileData.TaskInput.GetTextToImage().Prompt,
-					Steps:    *fileData.TaskInput.GetTextToImage().Steps,
+					Steps:    int64(*fileData.TaskInput.GetTextToImage().Steps),
 					CfgScale: *fileData.TaskInput.GetTextToImage().CfgScale,
-					Seed:     *fileData.TaskInput.GetTextToImage().Seed,
-					Samples:  *fileData.TaskInput.GetTextToImage().Samples,
+					Seed:     int64(*fileData.TaskInput.GetTextToImage().Seed),
+					Samples:  int64(*fileData.TaskInput.GetTextToImage().Samples),
 				}
 			case *modelPB.TaskInputStream_TextGeneration:
 				textGeneration = &triton.TextGenerationInput{
 					Prompt:        fileData.TaskInput.GetTextGeneration().Prompt,
-					OutputLen:     *fileData.TaskInput.GetTextGeneration().OutputLen,
+					OutputLen:     int64(*fileData.TaskInput.GetTextGeneration().OutputLen),
 					BadWordsList:  *fileData.TaskInput.GetTextGeneration().BadWordsList,
 					StopWordsList: *fileData.TaskInput.GetTextGeneration().StopWordsList,
-					TopK:          *fileData.TaskInput.GetTextGeneration().Topk,
-					Seed:          *fileData.TaskInput.GetTextGeneration().Seed,
+					TopK:          int64(*fileData.TaskInput.GetTextGeneration().Topk),
+					Seed:          int64(*fileData.TaskInput.GetTextGeneration().Seed),
 				}
 			default:
 				return nil, "", fmt.Errorf("unsupported task input type")
@@ -291,7 +291,7 @@ func savePredictInputsTestMode(stream modelPB.ModelPublicService_TestUserModelBi
 			return nil, "", fmt.Errorf("wrong parameter length of files")
 		}
 		imageBytes := make([][]byte, len(fileLengths))
-		start := uint64(0)
+		start := uint32(0)
 		for i := 0; i < len(fileLengths); i++ {
 			buff := new(bytes.Buffer)
 			img, _, err := image.Decode(bytes.NewReader(allContentFiles[start : start+fileLengths[i]]))
@@ -1589,7 +1589,7 @@ func (h *PublicHandler) ListModels(ctx context.Context, req *modelPB.ListModelsR
 	resp := modelPB.ListModelsResponse{
 		Models:        pbModels,
 		NextPageToken: nextPageToken,
-		TotalSize:     totalSize,
+		TotalSize:     int32(totalSize),
 	}
 
 	return &resp, nil
@@ -1729,7 +1729,7 @@ func (h *PublicHandler) ListUserModels(ctx context.Context, req *modelPB.ListUse
 	resp := modelPB.ListUserModelsResponse{
 		Models:        pbModels,
 		NextPageToken: nextPageToken,
-		TotalSize:     totalSize,
+		TotalSize:     int32(totalSize),
 	}
 
 	return &resp, nil
@@ -3157,7 +3157,7 @@ func (h *PublicHandler) ListModelDefinitions(ctx context.Context, req *modelPB.L
 	resp := modelPB.ListModelDefinitionsResponse{
 		ModelDefinitions: pbModelDefinitions,
 		NextPageToken:    nextPageToken,
-		TotalSize:        totalSize,
+		TotalSize:        int32(totalSize),
 	}
 
 	return &resp, nil

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -80,7 +80,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 
 	// Roll over all users and update the metrics with the cached uuid
 	userPageToken := ""
-	userPageSizeMax := int64(repository.MaxPageSize)
+	userPageSizeMax := int32(repository.MaxPageSize)
 	for {
 		userResp, err := u.mgmtPrivateServiceClient.ListUsersAdmin(ctx, &mgmtPB.ListUsersAdminRequest{
 			PageSize:  &userPageSizeMax,


### PR DESCRIPTION
Because

- the grpc-gateway will convert `int64` to `string`

This commit

- use `int32` for `page_size`, `total_size` and `file_length` to avoid this problem
