### PR TITLE
chore(service): remove unsafe user_id injection and update default_user_id

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -1,5 +1,5 @@
 package constant
 
 // Constants for resource owner
-const DefaultUserID string = "instill-ai"
+const DefaultUserID string = "admin"
 const HeaderUserUIDKey = "jwt-sub"

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -152,7 +152,7 @@ func (s *service) GetUser(ctx context.Context) (string, uuid.UUID, error) {
 		return resp.User.Id, uuid.FromStringOrNil(headerUserUId), nil
 	}
 
-	return constant.DefaultUserID, s.defaultUserUid, nil
+	return "", uuid.Nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
 }
 
 func (s *service) ConvertOwnerPermalinkToName(permalink string) (string, error) {


### PR DESCRIPTION
Because

- the `user_id` injection in backend is unsafe
- we are going to change the default_user_id to `admin`

This commit

- remove `user_id` injection
- change the default_user_id to `admin`
