### PR TITLE
docs(contributing): update guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,18 +14,86 @@ Please refer to the [community contributing section](https://github.com/instill-
 
 Before delving into the details to come up with your first PR, please familiarise yourself with the project structure of [Instill Core](https://github.com/instill-ai/community#instill-core).
 
-### Prerequisites & Development
+### Prerequisites
 
-Please refer to [README](../README.md) for development setup.
+- [Instill Model](https://github.com/instill-ai/model)
 
-#### Pre-commit hooks
+### Pre-commit hooks
 
 check out `.pre-commit-config.yaml` for the set of hooks that we used
 
-#### Run test
+### Local development
+
+On the local machine, clone `model` repository in your workspace, move to the repository folder, and launch all dependent microservices:
 
 ```
-go test -race ./... -covermode=atomic
+$ cd <your-workspace>
+$ git clone https://github.com/instill-ai/model.git
+$ cd model
+$ make latest PROFILE=model
+```
+
+Clone `model-backend` repository in your workspace and move to the repository folder:
+
+```
+$ cd <your-workspace>
+$ git clone https://github.com/instill-ai/model-backend.git
+$ cd model-backend
+```
+
+### Build the dev image
+
+```bash
+$ make build
+```
+
+### Run the dev container
+
+```bash
+$ make dev
+```
+
+Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
+
+### Run the server
+
+```bash
+$ docker exec -it model-backend /bin/bash
+$ go run ./cmd/migration
+$ go run ./cmd/init
+$ CFG_SERVER_ITMODE_ENABLED=true go run ./cmd/main
+```
+
+### Run the Temporal worker
+
+```bash
+$ docker exec -it model-backend /bin/bash
+$ CFG_SERVER_ITMODE_ENABLED=true go run ./cmd/worker
+```
+
+### Run the unit test
+
+```
+$ make unit-test
+```
+
+### Run the integration test
+
+```bash
+$ docker exec -it model-backend /bin/bash
+$ make integration-test
+```
+
+#### Run with api-gateway mode
+
+```bash
+$ make integration-test API_GATEWAY_URL=localhost:8080
+```
+
+### Stop the dev container
+
+```bash
+$ make stop
 ```
 
 ### Sending PRs
@@ -42,6 +110,17 @@ Please take these general guidelines into consideration when you are sending a P
 5. **Open a Pull Request:** Initiate a pull request to our repository. Our team will review your changes and collaborate with you on any necessary refinements.
 
 When you are ready to send a PR, we recommend you to first open a `draft` one. This will trigger a bunch of `tests` [workflows](https://github.com/instill-ai/pipeline-backend/tree/main/.github/workflows) running a thorough test suite on multiple platforms. After the tests are done and passed, you can now mark the PR `open` to notify the codebase owners to review. We appreciate your endeavour to pass the integration test for your PR to make sure the sanity with respect to the entire scope of **Instill Core**.
+
+### CI/CD
+
+- **pull_request** to the `main` branch will trigger the **`Integration Test`** workflow running the integration test using the image built on the PR head branch.
+- **push** to the `main` branch will trigger
+  - the **`Integration Test`** workflow building and pushing the `:latest` image on the `main` branch, following by running the integration test, and
+  - the **`Release Please`** workflow, which will create and update a PR with respect to the up-to-date `main` branch using [release-please-action](https://github.com/google-github-actions/release-please-action).
+
+Once the release PR is merged to the `main` branch, the [release-please-action](https://github.com/google-github-actions/release-please-action) will tag and release a version correspondingly.
+
+The images are pushed to Docker Hub [repository](https://hub.docker.com/r/instill/model-backend).
 
 ## Last words
 

--- a/README.md
+++ b/README.md
@@ -4,88 +4,13 @@
 
 `model-backend` manages all model resources including model definitions and model instances within [Instill Model](https://github.com/instill-ai/model) to convert the unstructured data to meaningful data representations.
 
-## Local dev
-
-On the local machine, clone `model` repository in your workspace, move to the repository folder, and launch all dependent microservices:
-
-```
-$ cd <your-workspace>
-$ git clone https://github.com/instill-ai/model.git
-$ cd model
-$ make latest PROFILE=model
-```
-
-Clone `model-backend` repository in your workspace and move to the repository folder:
-
-```
-$ cd <your-workspace>
-$ git clone https://github.com/instill-ai/model-backend.git
-$ cd model-backend
-```
-
-### Build the dev image
-
-```bash
-$ make build
-```
-
-### Run the dev container
-
-```bash
-$ make dev
-```
-
-Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
-
-### Run the server
-
-```bash
-$ docker exec -it model-backend /bin/bash
-$ go run ./cmd/migration
-$ go run ./cmd/init
-$ CFG_SERVER_ITMODE_ENABLED=true go run ./cmd/main
-```
-
-### Run the Temporal worker
-
-```bash
-$ docker exec -it model-backend /bin/bash
-$ CFG_SERVER_ITMODE_ENABLED=true go run ./cmd/worker
-```
-
-### Run the integration test
-
-```bash
-$ docker exec -it model-backend /bin/bash
-$ make integration-test
-```
-
-#### Run with api-gateway mode
-
-```bash
-$ make integration-test API_GATEWAY_URL=localhost:8080
-```
-
-### Stop the dev container
-
-```bash
-$ make stop
-```
-
-### CI/CD
-
-- **pull_request** to the `main` branch will trigger the **`Integration Test`** workflow running the integration test using the image built on the PR head branch.
-- **push** to the `main` branch will trigger
-  - the **`Integration Test`** workflow building and pushing the `:latest` image on the `main` branch, following by running the integration test, and
-  - the **`Release Please`** workflow, which will create and update a PR with respect to the up-to-date `main` branch using [release-please-action](https://github.com/google-github-actions/release-please-action).
-
-Once the release PR is merged to the `main` branch, the [release-please-action](https://github.com/google-github-actions/release-please-action) will tag and release a version correspondingly.
-
-The images are pushed to Docker Hub [repository](https://hub.docker.com/r/instill/model-backend).
-
 ## Contributing
 
 Please refer to the [Contributing Guidelines](./.github/CONTRIBUTING.md) for more details.
+
+## Community
+
+Please refer to the [community](https://github.com/instill-ai/community) repository.
 
 ## License
 


### PR DESCRIPTION
Because

- we'd like to keep `README.md` succinct and put contributing guidelines in the repo `.github/CONTRIBUTING.md`

This commit

-  move the content of local development into the repo contributing guideline.
