### PR TITLE
chore(service): remove unsafe user_id injection

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -104,11 +104,10 @@ type service struct {
 	mgmtPrivateServiceClient mgmtPB.MgmtPrivateServiceClient
 	temporalClient           client.Client
 	controllerClient         controllerPB.ControllerPrivateServiceClient
-	defaultUserUid           uuid.UUID
 }
 
 // NewService returns a new service instance
-func NewService(r repository.Repository, t triton.Triton, m mgmtPB.MgmtPrivateServiceClient, rc *redis.Client, tc client.Client, cs controllerPB.ControllerPrivateServiceClient, defaultUserUid uuid.UUID) Service {
+func NewService(r repository.Repository, t triton.Triton, m mgmtPB.MgmtPrivateServiceClient, rc *redis.Client, tc client.Client, cs controllerPB.ControllerPrivateServiceClient) Service {
 	return &service{
 		repository:               r,
 		triton:                   t,
@@ -116,7 +115,6 @@ func NewService(r repository.Repository, t triton.Triton, m mgmtPB.MgmtPrivateSe
 		redisClient:              rc,
 		temporalClient:           tc,
 		controllerClient:         cs,
-		defaultUserUid:           defaultUserUid,
 	}
 }
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -456,7 +456,7 @@ func TestGetModelDefinition(t *testing.T) {
 			GetModelDefinition("github").
 			Return(&datamodel.ModelDefinition{}, nil).
 			Times(1)
-		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, uuid.Nil)
+		s := service.NewService(mockRepository, nil, nil, nil, nil, nil)
 
 		_, err := s.GetModelDefinition(context.Background(), "github")
 		assert.NoError(t, err)
@@ -473,7 +473,7 @@ func TestListModelDefinitions(t *testing.T) {
 			ListModelDefinitions(modelPB.View_VIEW_FULL, int(100), "").
 			Return([]*datamodel.ModelDefinition{}, "", int64(100), nil).
 			Times(1)
-		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, uuid.Nil)
+		s := service.NewService(mockRepository, nil, nil, nil, nil, nil)
 
 		_, _, _, err := s.ListModelDefinitions(context.Background(), modelPB.View_VIEW_FULL, 100, "")
 		assert.NoError(t, err)


### PR DESCRIPTION
Because

- the `user_id` injection in backend is unsafe

This commit

- remove `user_id` injection