### PR TITLE
chore(main,constant): update predeploy model namespace

### DIFF
--- a/cmd/model/main.go
+++ b/cmd/model/main.go
@@ -175,7 +175,7 @@ func main() {
 					Configuration:   configuration,
 					Visibility:      modelPB.Model_VISIBILITY_PUBLIC,
 				},
-				Parent: "users/" + constant.DefaultUserID,
+				Parent: "users/" + constant.InstillUserID,
 			})
 			if err != nil {
 				logger.Info(fmt.Sprintf("Created model err: %v", err))
@@ -209,7 +209,7 @@ func main() {
 					return
 				} else {
 					_, err := modelPublicServiceClient.DeployUserModel(ctx, &modelPB.DeployUserModelRequest{
-						Name: fmt.Sprintf("users/%s/models/%s", constant.DefaultUserID, modelConfig.ID),
+						Name: fmt.Sprintf("users/%s/models/%s", constant.InstillUserID, modelConfig.ID),
 					})
 					if err != nil {
 						logger.Error(fmt.Sprintf("deploy model err: %v", err))

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -2,4 +2,5 @@ package constant
 
 // Constants for resource owner
 const DefaultUserID string = "admin"
+const InstillUserID string = "instill-ai"
 const HeaderUserUIDKey = "jwt-sub"


### PR DESCRIPTION
Because

- predeploy/public models should be owned by `instill-ai` instead of `admin`

This commit

- update predeploy model namespace
