### PR TITLE
chore(main): fix jwt header uid

### DIFF
--- a/cmd/model/main.go
+++ b/cmd/model/main.go
@@ -137,7 +137,7 @@ func main() {
 	}
 
 	resp, err := mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{
-		Name: fmt.Sprintf("users/%v", constant.DefaultUserID),
+		Name: fmt.Sprintf("users/%v", constant.InstillUserID),
 	})
 	if err != nil {
 		logger.Fatal(err.Error())


### PR DESCRIPTION
Because

- namespace mismatched between header and request body

This commit

- fix jwt header uid
