### PR TITLE
refactor(logging): reduce unnecessary log emission

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -95,7 +95,9 @@ func main() {
 		// can't handle the error due to https://github.com/uber-go/zap/issues/880
 		_ = logger.Sync()
 	}()
-	grpc_zap.ReplaceGrpcLoggerV2(logger)
+
+	// verbosity 3 will avoid [transport] from emitting
+	grpc_zap.ReplaceGrpcLoggerV2WithVerbosity(logger, 3)
 
 	db := database.GetConnection()
 	defer database.Close(db)
@@ -116,6 +118,9 @@ func main() {
 			// will not log gRPC calls if it was a call to liveness or readiness and no error was raised
 			if err == nil {
 				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPublicService/.*ness$", fullMethodName); match {
+					return false
+					// stop logging successful private function calls
+				} else if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
 					return false
 				}
 			}

--- a/go.sum
+++ b/go.sum
@@ -1306,8 +1306,6 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc h1:RGrUkr9dnUxQs74/x1lWdLhIODnr6m6dZ/6UY+n08qw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230926065719-21b2e1fe684c h1:FIP3cWEOxYNfwdxZsD+wgv4l3xaaBF4O4XAgI+K0Jt0=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230926065719-21b2e1fe684c/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -37,7 +37,7 @@ export function setup() {
   }))
 
   check(loginResp, {
-    [`POST ${constant.mgmtPublicHost}/v1alpha//auth/login response status is 200`]: (
+    [`POST ${constant.mgmtPublicHost}/v1alpha/auth/login response status is 200`]: (
       r
     ) => r.status === 200,
   });

--- a/pkg/triton/triton.go
+++ b/pkg/triton/triton.go
@@ -124,9 +124,10 @@ func (ts *triton) ModelReadyRequest(ctx context.Context, modelName string, model
 		Name:    modelName,
 		Version: modelInstance,
 	}
+
 	// Submit modelReady request to server
 	modelReadyResponse, err := ts.tritonClient.ModelReady(ctx, &modelReadyRequest)
-	logger.Debug(fmt.Sprintf("ModelReadyResponse: %v %v", modelReadyResponse, err))
+
 	if err != nil {
 		logger.Error(err.Error())
 	}


### PR DESCRIPTION
Because

- Currently backends in Instill Base Instill VDP and Instill Model will emit a huge amount of logs with level Info, which can overwhelm stdout

This commit

- Refactor grpc logger `verbosity` and bypass successful private function calls

closes instill-ai/community#436