### PR TITLE
feat(model): Support for LLM-like models in TRITON Inference Server

### DIFF
--- a/pkg/triton/triton.go
+++ b/pkg/triton/triton.go
@@ -177,10 +177,17 @@ func (ts *triton) ModelInferRequest(ctx context.Context, task commonPB.Task, inf
 				Shape:    []int64{1},
 			})
 		case commonPB.Task_TASK_TEXT_GENERATION:
+			var inputShape []int64
+			if modelConfig.Config.MaxBatchSize > 0 {
+				inputShape = []int64{1, 1}
+			} else {
+				inputShape = []int64{1}
+			}
+
 			inferInputs = append(inferInputs, &inferenceserver.ModelInferRequest_InferInputTensor{
 				Name:     modelMetadata.Inputs[i].Name,
 				Datatype: modelMetadata.Inputs[i].Datatype,
-				Shape:    []int64{1, 1},
+				Shape:    inputShape,
 			})
 		case commonPB.Task_TASK_CLASSIFICATION,
 			commonPB.Task_TASK_DETECTION,


### PR DESCRIPTION
Because

- To enhance TRITON Inference Server's capabilities by supporting LLM-like models such as Llama through the vLLM and python operator.

This commit

- Enable support for module files with postfixes: model, json, and sagetensors.
- Introduce an improved filename parser. (Note: There's a TODO to develop a more generalized function for detecting file structure.)
