### PR TITLE
chore(model): update predeploy model logic

### DIFF
--- a/cmd/model/main.go
+++ b/cmd/model/main.go
@@ -26,8 +26,8 @@ import (
 	"github.com/instill-ai/model-backend/pkg/utils"
 
 	custom_otel "github.com/instill-ai/model-backend/pkg/logger/otel"
-	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
 	commonPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
@@ -137,7 +137,9 @@ func main() {
 	}
 
 	var userID string
-	if !strings.HasPrefix(config.Config.Server.Edition, "cloud") || strings.HasSuffix(config.Config.Server.Edition, "test"){
+	if !strings.HasPrefix(config.Config.Server.Edition, "cloud") ||
+		strings.HasSuffix(config.Config.Server.Edition, "test") ||
+		strings.HasSuffix(config.Config.Server.Edition, "dev") {
 		userID = fmt.Sprintf("users/%s", constant.DefaultUserID)
 	} else {
 		userID = fmt.Sprintf("users/%s", constant.InstillUserID)

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -75,6 +75,10 @@ func GetPreDeployGitHubModelUUID(model *datamodel.Model) (*datamodel.PreDeployMo
 		return nil, nil
 	}
 
+	if _, found := preDeployModelMap[model.ID]; !found {
+		return nil, nil
+	}
+
 	var preDeployModelConfigs []PreModelConfig
 	err := utils.GetJSON(config.Config.InitModel.Path, &preDeployModelConfigs)
 	if err != nil {
@@ -88,10 +92,6 @@ func GetPreDeployGitHubModelUUID(model *datamodel.Model) (*datamodel.PreDeployMo
 	}
 
 	var githubModel *datamodel.PreDeployModel
-
-	if _, found := preDeployModelMap[model.ID]; !found {
-		return githubModel, nil
-	}
 
 	for _, preDeployModelConfigs := range preDeployModelConfigs {
 		if modelConfig.Repository == preDeployModelConfigs.Configuration["repository"] &&


### PR DESCRIPTION
Because

- bypass predeploy model list

This commit

- bypass predeploy model list
