### PR TITLE
fix(Dockerfile): fix Python 3.11 using Debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,20 +29,31 @@ RUN mkdir /vdp
 RUN mkdir /model-repository
 RUN mkdir /.cache
 
-FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_VERSION}
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION}
 
-RUN apt update && apt install -y \
-    bash \
-    build-essential \
+ENV DEBIAN_FRONTEND noninteractive
+
+# tools to work with versatile model import
+RUN apt-get update && apt-get install -y \
     python3 \
     python3-setuptools \
     python3-pip \
+    python3-jsonschema \
+    python3-yaml \
+    python3-wheel \
+    python3-pil \
+    python3-pil.imagetk \
+    pipx \
     git \
     git-lfs \
     curl \
     && rm -rf /var/lib/apt/lists/*
-RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install --no-cache-dir transformers==4.21.0 pillow torch==1.12.1 torchvision==0.13.1 onnxruntime==1.11.1 dvc[gs]==2.34.2
+
+RUN pipx install torch
+RUN pipx install torchvision --include-deps
+RUN pipx install onnxruntime
+RUN pipx install dvc[gs]
+RUN git clone https://github.com/huggingface/transformers.git && cd transformers && pipx install -e .
 
 # Need permission of /tmp folder for internal process such as store temporary files.
 RUN chown -R nobody:nogroup /tmp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,14 +30,22 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-setuptools \
     python3-pip \
+    python3-jsonschema \
+    python3-yaml \
+    python3-wheel \
+    python3-pil \
+    python3-pil.imagetk \
+    pipx \
     git \
     git-lfs \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install jsonschema pyyaml
-RUN pip install --upgrade pip setuptools wheel
-RUN pip3 install --no-cache-dir transformers==4.21.0 pillow torch==1.12.1 torchvision==0.13.1 onnxruntime==1.11.1 dvc[gs]==2.34.2
+RUN pipx install torch
+RUN pipx install torchvision --include-deps
+RUN pipx install onnxruntime
+RUN pipx install dvc[gs]
+RUN git clone https://github.com/huggingface/transformers.git && cd transformers && pipx install -e .
 
 # -- set up Go
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -46,12 +46,10 @@ require (
 )
 
 require (
+	github.com/instill-ai/mgmt-backend v0.6.1-alpha.0.20231019224100-43a72b7eb664 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	google.golang.org/genproto v0.0.0-20230725213213-b022f6e96895 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230725213213-b022f6e96895 // indirect
-)
-
-require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -60,9 +58,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.16.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
-)
-
-require (
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/catalinc/hashcash v0.0.0-20220723060415-5e3ec3e24f67 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1309,6 +1309,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/instill-ai/mgmt-backend v0.6.1-alpha.0.20231019224100-43a72b7eb664 h1:Upd54LPRR/Lr8eRHNQ31YzXakpdpY/oY2JhCkky53Vc=
+github.com/instill-ai/mgmt-backend v0.6.1-alpha.0.20231019224100-43a72b7eb664/go.mod h1:22VmpkGSgMZd9xxw4l9mTmxqmTKj1dncVMPdswJ5oIU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f h1:hweU93u6qsg8GH/YSogOfa+wOZEnkilGsijcy1xKX7E=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061 h1:lOp2fORCj76/gfPuLqB3TEN2cvFRJHUQOxwFSl4qxEw=


### PR DESCRIPTION
Because

- Go 1.21 base image uses Python 3.11, which breaks the previous build

This commit

- update Dockerfiles
