### PR TITLE
fix(payload): fix incorrect conversion between integer types

### DIFF
--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -166,21 +166,21 @@ func parseTexToImageRequestInputs(req *modelPB.TriggerUserModelRequest) (textToI
 	}
 
 	for _, taskInput := range req.TaskInputs {
-		steps := int64(utils.TEXT_TO_IMAGE_STEPS)
+		steps := utils.TEXT_TO_IMAGE_STEPS
 		if taskInput.GetTextToImage().Steps != nil {
-			steps = int64(*taskInput.GetTextToImage().Steps)
+			steps = *taskInput.GetTextToImage().Steps
 		}
 		cfgScale := float32(utils.IMAGE_TO_TEXT_CFG_SCALE)
 		if taskInput.GetTextToImage().CfgScale != nil {
 			cfgScale = float32(*taskInput.GetTextToImage().CfgScale)
 		}
-		seed := int64(utils.IMAGE_TO_TEXT_SEED)
+		seed := utils.IMAGE_TO_TEXT_SEED
 		if taskInput.GetTextToImage().Seed != nil {
-			seed = int64(*taskInput.GetTextToImage().Seed)
+			seed = *taskInput.GetTextToImage().Seed
 		}
-		samples := int64(utils.IMAGE_TO_TEXT_SAMPLES)
+		samples := utils.IMAGE_TO_TEXT_SAMPLES
 		if taskInput.GetTextToImage().Samples != nil {
-			samples = int64(*taskInput.GetTextToImage().Samples)
+			samples = *taskInput.GetTextToImage().Samples
 		}
 		if samples > 1 {
 			return nil, fmt.Errorf("we only allow samples=1 for now and will improve to allow the generation of multiple samples in the future")
@@ -198,9 +198,9 @@ func parseTexToImageRequestInputs(req *modelPB.TriggerUserModelRequest) (textToI
 
 func parseTexGenerationRequestInputs(req *modelPB.TriggerUserModelRequest) (textGenerationInput *triton.TextGenerationInput, err error) {
 	for _, taskInput := range req.TaskInputs {
-		outputLen := int64(utils.TEXT_GENERATION_OUTPUT_LEN)
+		outputLen := utils.TEXT_GENERATION_OUTPUT_LEN
 		if taskInput.GetTextGeneration().OutputLen != nil {
-			outputLen = int64(*taskInput.GetTextGeneration().OutputLen)
+			outputLen = *taskInput.GetTextGeneration().OutputLen
 		}
 		badWordsList := string("")
 		if taskInput.GetTextGeneration().BadWordsList != nil {
@@ -210,13 +210,13 @@ func parseTexGenerationRequestInputs(req *modelPB.TriggerUserModelRequest) (text
 		if taskInput.GetTextGeneration().StopWordsList != nil {
 			stopWordsList = *taskInput.GetTextGeneration().BadWordsList
 		}
-		topK := int64(utils.TEXT_GENERATION_TOP_K)
+		topK := utils.TEXT_GENERATION_TOP_K
 		if taskInput.GetTextGeneration().Topk != nil {
-			topK = int64(*taskInput.GetTextGeneration().Topk)
+			topK = *taskInput.GetTextGeneration().Topk
 		}
-		seed := int64(utils.TEXT_GENERATION_SEED)
+		seed := utils.TEXT_GENERATION_SEED
 		if taskInput.GetTextGeneration().Seed != nil {
-			seed = int64(*taskInput.GetTextGeneration().Seed)
+			seed = *taskInput.GetTextGeneration().Seed
 		}
 		textGenerationInput = &triton.TextGenerationInput{
 			Prompt:        taskInput.GetTextGeneration().Prompt,
@@ -309,12 +309,13 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *t
 		return nil, fmt.Errorf("invalid samples input, only support a single samples")
 	}
 
-	step := int(utils.TEXT_TO_IMAGE_STEPS)
+	step := utils.TEXT_TO_IMAGE_STEPS
 	if len(stepStr) > 0 {
-		step, err = strconv.Atoi(stepStr[0])
+		parseStep, err := strconv.ParseInt(stepStr[0], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid step input %w", err)
 		}
+		step = int32(parseStep)
 	}
 
 	cfgScale := float64(utils.IMAGE_TO_TEXT_CFG_SCALE)
@@ -325,20 +326,22 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *t
 		}
 	}
 
-	seed := int(utils.IMAGE_TO_TEXT_SEED)
+	seed := utils.IMAGE_TO_TEXT_SEED
 	if len(seedStr) > 0 {
-		seed, err = strconv.Atoi(seedStr[0])
+		parseSeed, err := strconv.ParseInt(seedStr[0], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid seed input %w", err)
 		}
+		seed = int32(parseSeed)
 	}
 
-	samples := int(utils.IMAGE_TO_TEXT_SAMPLES)
+	samples := utils.IMAGE_TO_TEXT_SAMPLES
 	if len(samplesStr) > 0 {
-		samples, err = strconv.Atoi(samplesStr[0])
+		parseSamples, err := strconv.ParseInt(samplesStr[0], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid samples input %w", err)
 		}
+		samples = int32(parseSamples)
 	}
 
 	if samples > 1 {
@@ -347,10 +350,10 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *t
 
 	return &triton.TextToImageInput{
 		Prompt:   prompts[0],
-		Steps:    int64(step),
+		Steps:    step,
 		CfgScale: float32(cfgScale),
-		Seed:     int64(seed),
-		Samples:  int64(samples),
+		Seed:     seed,
+		Samples:  samples,
 	}, nil
 }
 
@@ -375,37 +378,40 @@ func parseTextFormDataTextGenerationInputs(req *http.Request) (textGeneration *t
 		stopWordsList = stopWordsListInput[0]
 	}
 
-	outputLen := int(utils.TEXT_GENERATION_OUTPUT_LEN)
+	outputLen := utils.TEXT_GENERATION_OUTPUT_LEN
 	if len(outputLenInput) > 0 {
-		outputLen, err = strconv.Atoi(outputLenInput[0])
+		parseOutputLen, err := strconv.ParseInt(outputLenInput[0], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid input %w", err)
 		}
+		outputLen = int32(parseOutputLen)
 	}
 
-	topK := int(utils.TEXT_GENERATION_TOP_K)
+	topK := utils.TEXT_GENERATION_TOP_K
 	if len(topKInput) > 0 {
-		topK, err = strconv.Atoi(topKInput[0])
+		parseTopK, err := strconv.ParseInt(topKInput[0], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid input %w", err)
 		}
+		topK = int32(parseTopK)
 	}
 
-	seed := int(utils.TEXT_GENERATION_SEED)
+	seed := utils.TEXT_GENERATION_SEED
 	if len(seedInput) > 0 {
-		seed, err = strconv.Atoi(seedInput[0])
+		parseSeed, err := strconv.ParseInt(seedInput[0], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid input %w", err)
 		}
+		seed = int32(parseSeed)
 	}
 
 	// TODO: add support for bad/stop words
 	return &triton.TextGenerationInput{
 		Prompt:        prompts[0],
-		OutputLen:     int64(outputLen),
+		OutputLen:     outputLen,
 		BadWordsList:  badWordsList,
 		StopWordsList: stopWordsList,
-		TopK:          int64(topK),
-		Seed:          int64(seed),
+		TopK:          topK,
+		Seed:          seed,
 	}, nil
 }

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -124,19 +124,19 @@ func savePredictInputsTriggerMode(stream modelPB.ModelPublicService_TriggerUserM
 			case *modelPB.TaskInputStream_TextToImage:
 				textToImageInput = &triton.TextToImageInput{
 					Prompt:   fileData.TaskInput.GetTextToImage().Prompt,
-					Steps:    int64(*fileData.TaskInput.GetTextToImage().Steps),
+					Steps:    *fileData.TaskInput.GetTextToImage().Steps,
 					CfgScale: *fileData.TaskInput.GetTextToImage().CfgScale,
-					Seed:     int64(*fileData.TaskInput.GetTextToImage().Seed),
-					Samples:  int64(*fileData.TaskInput.GetTextToImage().Samples),
+					Seed:     *fileData.TaskInput.GetTextToImage().Seed,
+					Samples:  *fileData.TaskInput.GetTextToImage().Samples,
 				}
 			case *modelPB.TaskInputStream_TextGeneration:
 				textGeneration = &triton.TextGenerationInput{
 					Prompt:        fileData.TaskInput.GetTextGeneration().Prompt,
-					OutputLen:     int64(*fileData.TaskInput.GetTextGeneration().OutputLen),
+					OutputLen:     *fileData.TaskInput.GetTextGeneration().OutputLen,
 					BadWordsList:  *fileData.TaskInput.GetTextGeneration().BadWordsList,
 					StopWordsList: *fileData.TaskInput.GetTextGeneration().StopWordsList,
-					TopK:          int64(*fileData.TaskInput.GetTextGeneration().Topk),
-					Seed:          int64(*fileData.TaskInput.GetTextGeneration().Seed),
+					TopK:          *fileData.TaskInput.GetTextGeneration().Topk,
+					Seed:          *fileData.TaskInput.GetTextGeneration().Seed,
 				}
 			default:
 				return nil, "", fmt.Errorf("unsupported task input type")
@@ -244,19 +244,19 @@ func savePredictInputsTestMode(stream modelPB.ModelPublicService_TestUserModelBi
 			case *modelPB.TaskInputStream_TextToImage:
 				textToImageInput = &triton.TextToImageInput{
 					Prompt:   fileData.TaskInput.GetTextToImage().Prompt,
-					Steps:    int64(*fileData.TaskInput.GetTextToImage().Steps),
+					Steps:    *fileData.TaskInput.GetTextToImage().Steps,
 					CfgScale: *fileData.TaskInput.GetTextToImage().CfgScale,
-					Seed:     int64(*fileData.TaskInput.GetTextToImage().Seed),
-					Samples:  int64(*fileData.TaskInput.GetTextToImage().Samples),
+					Seed:     *fileData.TaskInput.GetTextToImage().Seed,
+					Samples:  *fileData.TaskInput.GetTextToImage().Samples,
 				}
 			case *modelPB.TaskInputStream_TextGeneration:
 				textGeneration = &triton.TextGenerationInput{
 					Prompt:        fileData.TaskInput.GetTextGeneration().Prompt,
-					OutputLen:     int64(*fileData.TaskInput.GetTextGeneration().OutputLen),
+					OutputLen:     *fileData.TaskInput.GetTextGeneration().OutputLen,
 					BadWordsList:  *fileData.TaskInput.GetTextGeneration().BadWordsList,
 					StopWordsList: *fileData.TaskInput.GetTextGeneration().StopWordsList,
-					TopK:          int64(*fileData.TaskInput.GetTextGeneration().Topk),
-					Seed:          int64(*fileData.TaskInput.GetTextGeneration().Seed),
+					TopK:          *fileData.TaskInput.GetTextGeneration().Topk,
+					Seed:          *fileData.TaskInput.GetTextGeneration().Seed,
 				}
 			default:
 				return nil, "", fmt.Errorf("unsupported task input type")

--- a/pkg/triton/triton.go
+++ b/pkg/triton/triton.go
@@ -263,26 +263,16 @@ func (ts *triton) ModelInferRequest(ctx context.Context, task commonPB.Task, inf
 	switch task {
 	case commonPB.Task_TASK_TEXT_TO_IMAGE:
 		textToImageInput := inferInput.(*TextToImageInput)
-		// Correctly handle the conversion with an upper-bound check
 		samples := make([]byte, 4)
-		if textToImageInput.Samples > math.MaxUint32 {
-		    textToImageInput.Samples = math.MaxUint32
-		}
 		binary.LittleEndian.PutUint32(samples, uint32(textToImageInput.Samples))
 		steps := make([]byte, 4)
-		if textToImageInput.Steps > math.MaxUint32 {
-		    textToImageInput.Steps = math.MaxUint32
-		}
 		binary.LittleEndian.PutUint32(steps, uint32(textToImageInput.Steps))
 		guidanceScale := make([]byte, 4)
 		if textToImageInput.CfgScale > math.MaxFloat32 {
-		    textToImageInput.CfgScale = math.MaxFloat32
+			textToImageInput.CfgScale = math.MaxFloat32
 		}
 		binary.LittleEndian.PutUint32(guidanceScale, math.Float32bits(textToImageInput.CfgScale)) // Fixed value.
 		seed := make([]byte, 8)
-		if textToImageInput.Seed > math.MaxUint64 {
-		    textToImageInput.Seed = math.MaxUint64
-		}
 		binary.LittleEndian.PutUint64(seed, uint64(textToImageInput.Seed))
 		modelInferRequest.RawInputContents = append(modelInferRequest.RawInputContents, SerializeBytesTensor([][]byte{[]byte(textToImageInput.Prompt)}))
 		modelInferRequest.RawInputContents = append(modelInferRequest.RawInputContents, SerializeBytesTensor([][]byte{[]byte("NONE")}))
@@ -294,24 +284,10 @@ func (ts *triton) ModelInferRequest(ctx context.Context, task commonPB.Task, inf
 	case commonPB.Task_TASK_TEXT_GENERATION:
 		textGenerationInput := inferInput.(*TextGenerationInput)
 		outputLen := make([]byte, 4)
-		 if textGenerationInput.OutputLen > math.MaxUint32 {
-		textGenerationInput.OutputLen = math.MaxUint32
-	    	}
 		binary.LittleEndian.PutUint32(outputLen, uint32(textGenerationInput.OutputLen))
-		// Add an upper-bound check for TopK
-		const maxUint32 = math.MaxUint32
-		if textGenerationInput.TopK > maxUint32 {
-		    textGenerationInput.TopK = maxUint32
-		}
 		topK := make([]byte, 4)
-		if textGenerationInput.TopK > math.MaxUint32 {
-		textGenerationInput.TopK = math.MaxUint32
-	    	}
 		binary.LittleEndian.PutUint32(topK, uint32(textGenerationInput.TopK))
 		seed := make([]byte, 8)
-		if textGenerationInput.Seed > math.MaxUint64 {
-	        textGenerationInput.Seed = math.MaxUint64
-	    	}
 		binary.LittleEndian.PutUint64(seed, uint64(textGenerationInput.Seed))
 		modelInferRequest.RawInputContents = append(modelInferRequest.RawInputContents, SerializeBytesTensor([][]byte{[]byte(textGenerationInput.Prompt)}))
 		modelInferRequest.RawInputContents = append(modelInferRequest.RawInputContents, outputLen)

--- a/pkg/triton/triton.go
+++ b/pkg/triton/triton.go
@@ -28,19 +28,19 @@ type InferInput interface{}
 
 type TextToImageInput struct {
 	Prompt   string
-	Steps    int64
+	Steps    int32
 	CfgScale float32
-	Seed     int64
-	Samples  int64
+	Seed     int32
+	Samples  int32
 }
 
 type TextGenerationInput struct {
 	Prompt        string
-	OutputLen     int64
+	OutputLen     int32
 	BadWordsList  string
 	StopWordsList string
-	TopK          int64
-	Seed          int64
+	TopK          int32
+	Seed          int32
 }
 
 type ImageInput struct {

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -69,16 +69,16 @@ var UnmarshalOptions protojson.UnmarshalOptions = protojson.UnmarshalOptions{
 const DefaultPageSize = 10
 
 const (
-	TEXT_TO_IMAGE_STEPS     = int64(10)
+	TEXT_TO_IMAGE_STEPS     = int32(10)
 	IMAGE_TO_TEXT_CFG_SCALE = float32(7)
-	IMAGE_TO_TEXT_SEED      = int64(1024)
-	IMAGE_TO_TEXT_SAMPLES   = int64(1)
+	IMAGE_TO_TEXT_SEED      = int32(1024)
+	IMAGE_TO_TEXT_SAMPLES   = int32(1)
 )
 
 const (
-	TEXT_GENERATION_OUTPUT_LEN = int64(100)
-	TEXT_GENERATION_TOP_K      = int64(1)
-	TEXT_GENERATION_SEED       = int64(0)
+	TEXT_GENERATION_OUTPUT_LEN = int32(100)
+	TEXT_GENERATION_TOP_K      = int32(1)
+	TEXT_GENERATION_SEED       = int32(0)
 )
 
 const MODEL_CACHE_DIR = "/.cache/models"


### PR DESCRIPTION
Because

- avoid unbound int type conversion

This commit

- apply bound check and error handling by `ParseInt`
