### PR TITLE
fix(service): fix fail model deletion in state error

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -119,6 +119,7 @@ jobs:
           EDITION=local-ce:test \
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          RAY_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           EDITION=local-ce:test \

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -886,7 +886,7 @@ func (s *service) DeleteUserModel(ctx context.Context, ns resource.Namespace, us
 		return err
 	}
 
-	for *state != modelPB.Model_STATE_OFFLINE {
+	for *state != modelPB.Model_STATE_OFFLINE && *state != modelPB.Model_STATE_ERROR {
 		state, err = s.GetResourceState(ctx, modelInDB.UID)
 		if err != nil {
 			return err


### PR DESCRIPTION
Because

- unable to delete model when model is in `STATE_ERROR`

This commit

- allow deletion when model no online or under longrunning operation
