### PR TITLE
feat(ray): use shared python executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,13 @@ ENV VENV=/opt/venv
 RUN python3 -m venv $VENV
 ENV PATH="$VENV/bin:$PATH"
 
-RUN pip install jsonschema pyyaml
+# RUN export PIP_DEFAULT_TIMEOUT=10000
 RUN pip install --upgrade pip setuptools wheel
-RUN pip install --no-cache-dir opencv-contrib-python-headless transformers pillow torch torchvision onnxruntime dvc[gs]==2.34.2
-RUN pip install --no-cache-dir ray[serve] scikit-image
-RUN pip install --no-cache-dir instill-sdk==0.3.2rc7
+RUN pip install dvc[gs]==2.34.2
+# RUN pip install jsonschema pyyaml
+# RUN pip install --no-cache-dir opencv-contrib-python-headless transformers pillow torch torchvision onnxruntime dvc[gs]==2.34.2
+# RUN pip install --no-cache-dir ray[serve] scikit-image
+# RUN pip install --no-cache-dir instill-sdk==0.3.2rc7
 
 # Need permission of /tmp folder for internal process such as store temporary files.
 RUN chown -R nobody:nogroup /tmp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -40,13 +40,13 @@ ENV VENV=/opt/venv
 RUN python3 -m venv $VENV
 ENV PATH="$VENV/bin:$PATH"
 
-RUN export PIP_DEFAULT_TIMEOUT=10000
-
-RUN pip install jsonschema pyyaml
+# RUN export PIP_DEFAULT_TIMEOUT=10000
 RUN pip install --upgrade pip setuptools wheel
-RUN pip install --no-cache-dir opencv-contrib-python-headless transformers pillow torch torchvision onnxruntime dvc[gs]==2.34.2
-RUN pip install --no-cache-dir ray[serve] scikit-image
-RUN pip install --no-cache-dir instill-sdk==0.3.2rc7
+RUN pip install dvc[gs]==2.34.2
+# RUN pip install jsonschema pyyaml
+# RUN pip install --no-cache-dir opencv-contrib-python-headless transformers pillow torch torchvision onnxruntime dvc[gs]==2.34.2
+# RUN pip install --no-cache-dir ray[serve] scikit-image
+# RUN pip install --no-cache-dir instill-sdk==0.3.2rc7
 
 # -- set up Go
 COPY go.mod go.sum ./

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ dev:							## Run dev container
 	@docker run -d --rm \
 		-v $(PWD):/${SERVICE_NAME} \
 		-v model-repository:/model-repository \
+		-v ray-conda:/ray-conda \
 		-v ~/.cache/instill:/.cache \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
 		--network instill-network \

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -373,7 +373,7 @@ func PostProcess(inferResponse *rayserver.ModelInferResponse, modelMetadata *ray
 
 func (r *ray) DeployModel(modelPath string) error {
 	modelPath = filepath.Join(config.Config.RayServer.ModelStore, modelPath)
-	cmd := exec.Command("python", "model.py",
+	cmd := exec.Command("/ray-conda/bin/python", "model.py",
 		"--func", "deploy",
 		"--model", modelPath,
 	)
@@ -390,7 +390,7 @@ func (r *ray) DeployModel(modelPath string) error {
 
 func (r *ray) UndeployModel(modelPath string) error {
 	modelPath = filepath.Join(config.Config.RayServer.ModelStore, modelPath)
-	cmd := exec.Command("python", "model.py",
+	cmd := exec.Command("/ray-conda/bin/python", "model.py",
 		"--func", "undeploy",
 		"--model", modelPath,
 	)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -609,7 +609,12 @@ func HuggingFaceExport(dir string, modelConfig datamodel.HuggingFaceModelConfigu
 		return err
 	}
 	// atol 0.001 mean that accept difference with 0.1%
-	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("python3 -m transformers.onnx --feature=image-classification --atol 0.001 --model=%s %s/%s-infer/1", modelConfig.RepoId, dir, modelID))
+	cmd := exec.Command("/ray-conda/bin/python",
+		"-m", "transformers.onnx",
+		"--feature=image-classification",
+		"--atol", "0.001",
+		fmt.Sprintf("--model=%s", modelConfig.RepoId),
+		fmt.Sprintf("%s/%s-infer/1", dir, modelID))
 	if err := cmd.Run(); err != nil {
 		return err
 	}
@@ -726,7 +731,10 @@ func UpdateModelConfig(modelRepository string, tritonModels []*datamodel.Inferen
 		return err
 	}
 
-	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("python3 assets/scripts/query_model_onnx.py -f %s", modelFilePath)).Output()
+	out, err := exec.Command("/ray-conda/bin/python",
+		"assets/scripts/query_model_onnx.py",
+		"-f", modelFilePath,
+	).Output()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Because

- avoid installing duplicate packages in `model-backend` container

This commit

- share python executable with `ray-server`
