### PR TITLE
chore(usage): adopt latest protobuf to add user/owner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206133622-82ac47daf479
-	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97
+	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4
 	github.com/mennanov/fieldmask-utils v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206042803-5ace80a1eafe
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206133622-82ac47daf479
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1315,6 +1315,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206133622-82ac47daf479 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206133622-82ac47daf479/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97 h1:WycXqzJP1ihjJwrkxlNP2TQc1DSUxUtfl/PtCpLBa3Y=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97/go.mod h1:Da8RdKakfxy1iNdvI5FSTcL1lSDtda+b9jOgOEEO68E=
+github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b h1:YwXracXgTWxaPfIsbC3uaZFjGO0E2y1e3hK9ZUq7ipE=
+github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b/go.mod h1:4uTzVtcC+UVKhRaNvJc2+LFLcr/fv3vsYE5QCWu6TQ0=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=
 github.com/instill-ai/x v0.3.0-alpha/go.mod h1:YVYjkbqc5FKatJ+jZa1S/8e4xHkQ8j9V3RYboqBpoR0=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/go.sum
+++ b/go.sum
@@ -1311,6 +1311,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206042803-5ace80a1eafe h1:8x6a2zzX858AgXd5Cuq+/xkf3kYmcgHbOkzgg1K61VU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206042803-5ace80a1eafe/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206133622-82ac47daf479 h1:WBFc3acf5eya1VKLA9aQ5YK9q+28hFa4DMcasbPabrY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206133622-82ac47daf479/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97 h1:WycXqzJP1ihjJwrkxlNP2TQc1DSUxUtfl/PtCpLBa3Y=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97/go.mod h1:Da8RdKakfxy1iNdvI5FSTcL1lSDtda+b9jOgOEEO68E=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -2483,7 +2483,10 @@ func (h *PublicHandler) TriggerUserModelBinaryFileUpload(stream modelPB.ModelPub
 	}
 
 	usageData := utils.UsageMetricData{
-		OwnerUID:           userUID.String(),
+		OwnerUID:           ns.NsUid.String(),
+		OwnerType:          mgmtPB.OwnerType_OWNER_TYPE_USER,
+		UserUID:            userUID.String(),
+		UserType:           mgmtPB.OwnerType_OWNER_TYPE_USER,
 		ModelUID:           pbModel.Uid,
 		TriggerUID:         logUUID.String(),
 		TriggerTime:        startTime.Format(time.RFC3339Nano),
@@ -2620,7 +2623,10 @@ func (h *PublicHandler) TriggerUserModel(ctx context.Context, req *modelPB.Trigg
 	}
 
 	usageData := utils.UsageMetricData{
-		OwnerUID:           userUID.String(),
+		OwnerUID:           ns.NsUid.String(),
+		OwnerType:          mgmtPB.OwnerType_OWNER_TYPE_USER,
+		UserUID:            userUID.String(),
+		UserType:           mgmtPB.OwnerType_OWNER_TYPE_USER,
 		ModelUID:           pbModel.Uid,
 		TriggerUID:         logUUID.String(),
 		TriggerTime:        startTime.Format(time.RFC3339Nano),
@@ -3026,7 +3032,10 @@ func inferModelByUpload(s service.Service, w http.ResponseWriter, req *http.Requ
 	}
 
 	usageData := utils.UsageMetricData{
-		OwnerUID:           userUID.String(),
+		OwnerUID:           ns.NsUid.String(),
+		OwnerType:          mgmtPB.OwnerType_OWNER_TYPE_USER,
+		UserUID:            userUID.String(),
+		UserType:           mgmtPB.OwnerType_OWNER_TYPE_USER,
 		ModelUID:           pbModel.Uid,
 		TriggerUID:         logUUID.String(),
 		TriggerTime:        startTime.Format(time.RFC3339Nano),

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -119,13 +119,16 @@ func (u *usage) RetrieveUsageData() interface{} {
 							ModelDefinitionUid: triggerData.ModelDefinitionUID,
 							ModelTask:          triggerData.ModelTask,
 							Status:             triggerData.Status,
+							UserUid:            triggerData.UserUID,
+							UserType:           triggerData.UserType,
 						},
 					)
 				}
 			}
 
 			pbModelUsageData = append(pbModelUsageData, &usagePB.ModelUsageData_UserUsageData{
-				UserUid:          user.GetUid(),
+				OwnerUid:         user.GetUid(),
+				OwnerType:        mgmtPB.OwnerType_OWNER_TYPE_USER,
 				ModelTriggerData: triggerDataList,
 			})
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -909,6 +909,9 @@ func IsBillableEvent(eventName string) bool {
 
 type UsageMetricData struct {
 	OwnerUID           string
+	OwnerType          mgmtPB.OwnerType
+	UserUID            string
+	UserType           mgmtPB.OwnerType
 	ModelUID           string
 	Status             mgmtPB.Status
 	TriggerUID         string


### PR DESCRIPTION
Because

- adopt org and acl data collection for usage

This commit

- add `owner` and `user` data in each trigger and support user type
