### PR TITLE
chore(model): undeploy faulty model in error state

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -885,7 +885,7 @@ func (s *service) DeleteUserModel(ctx context.Context, ns resource.Namespace, us
 		return err
 	}
 
-	for *state != modelPB.Model_STATE_OFFLINE && *state != modelPB.Model_STATE_ERROR {
+	for *state != modelPB.Model_STATE_OFFLINE {
 		state, err = s.GetResourceState(ctx, modelInDB.UID)
 		if err != nil {
 			return err

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -236,6 +236,8 @@ func (w *worker) UnDeployModelActivity(ctx context.Context, param *ModelParams) 
 		if err := w.ray.UndeployModel(name); err != nil {
 			logger.Error(fmt.Sprintf("ray model undeployment failed: %v", err))
 		}
+		// TODO: fix no return here by properly check in ray app is serving
+		// if not return nil even if workflow failed
 	}
 
 	logger.Info("UnDeployModelActivity completed")


### PR DESCRIPTION
Because

- properly delete app on ray serve even if resource state is in `STATE_ERROR`

This commit

- allow model deletion in `STATE_ERROR`
