### PR TITLE
feat(redis): use redis for model state caching

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/worker"
 
+	"github.com/go-redis/redis/v9"
 	"github.com/instill-ai/model-backend/config"
 	"github.com/instill-ai/model-backend/pkg/external"
 	"github.com/instill-ai/model-backend/pkg/logger"
@@ -65,7 +66,10 @@ func main() {
 	rayService := ray.NewRay()
 	defer rayService.Close()
 
-	cw := modelWorker.NewWorker(repository.NewRepository(db), triton, controllerClient, rayService)
+	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
+	defer redisClient.Close()
+
+	cw := modelWorker.NewWorker(repository.NewRepository(db), redisClient, triton, controllerClient, rayService)
 
 	temporalTracingInterceptor, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
 		Tracer:            otel.Tracer("temporal-tracer"),

--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,10 @@ type CacheConfig struct {
 	Redis struct {
 		RedisOptions redis.Options `koanf:"redisoptions"`
 	}
-	Model bool `koanf:"model"`
+	Model struct {
+		Enabled   bool   `koanf:"enabled"`
+		CacheDir  string `koanf:"cache_dir"`
+	}
 }
 
 // ControllerConfig related to controller

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -47,7 +47,9 @@ cache:
   redis:
     redisoptions:
       addr: redis:6379
-  model: false
+  model:
+    enabled: false
+    cache_dir: /.cache/models
 maxbatchsizelimitation:
   unspecified: 2
   classification: 16

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -961,7 +961,7 @@ func createGitHubModel(service service.Service, ctx context.Context, req *modelP
 	rdid, _ := uuid.NewV4()
 	modelSrcDir := fmt.Sprintf("/tmp/%v", rdid.String()) + ""
 	if config.Config.Cache.Model.Enabled { // cache model into ~/.cache/instill/models
-		modelSrcDir = config.Config.Cache.Model.CacheDir + "/" + fmt.Sprintf("%s:%s", modelConfig.Repository, modelConfig.Tag)
+		modelSrcDir = config.Config.Cache.Model.CacheDir + "/" + fmt.Sprintf("%s/%s", modelConfig.Repository, modelConfig.Tag)
 	}
 
 	if config.Config.Server.ItMode.Enabled { // use local model for testing to remove internet connection issue while testing

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -91,6 +91,3 @@ const (
 	TEXT_GENERATION_TOP_K          = int32(10)
 	TEXT_GENERATION_SEED           = int32(0)
 )
-
-const MODEL_CACHE_DIR = "/.cache/models"
-const MODEL_CACHE_FILE = "cached_models.json"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -139,7 +139,7 @@ func GitHubClone(dir string, instanceConfig datamodel.GitHubModelConfiguration, 
 	defer cancel()
 
 	urlRepo := instanceConfig.Repository
-	modelRepo := fmt.Sprintf("%s:%s", instanceConfig.Repository, instanceConfig.Tag)
+	modelRepo := fmt.Sprintf("%s/%s", instanceConfig.Repository, instanceConfig.Tag)
 	// Check in the cache first.
 	if config.Config.Cache.Model.Enabled {
 		_ = os.MkdirAll(config.Config.Cache.Model.CacheDir, os.ModePerm)

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -89,7 +89,7 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 			}
 
 			if config.Config.Cache.Model.Enabled { // cache model into ~/.cache/instill/models
-				modelSrcDir = config.Config.Cache.Model.CacheDir + "/" + fmt.Sprintf("%s:%s", modelConfig.Repository, modelConfig.Tag)
+				modelSrcDir = config.Config.Cache.Model.CacheDir + "/" + fmt.Sprintf("%s/%s", modelConfig.Repository, modelConfig.Tag)
 			}
 
 			if err := utils.GitHubClone(modelSrcDir, modelConfig, true, w.redisClient); err != nil {

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -88,11 +88,11 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 				return err
 			}
 
-			if config.Config.Cache.Model { // cache model into ~/.cache/instill/models
-				modelSrcDir = utils.MODEL_CACHE_DIR + "/" + modelConfig.Repository + modelConfig.Tag
+			if config.Config.Cache.Model.Enabled { // cache model into ~/.cache/instill/models
+				modelSrcDir = config.Config.Cache.Model.CacheDir + "/" + fmt.Sprintf("%s:%s", modelConfig.Repository, modelConfig.Tag)
 			}
 
-			if err := utils.GitHubClone(modelSrcDir, modelConfig, true); err != nil {
+			if err := utils.GitHubClone(modelSrcDir, modelConfig, true, w.redisClient); err != nil {
 				_ = os.RemoveAll(modelSrcDir)
 				return err
 			}
@@ -108,8 +108,8 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 				return err
 			}
 
-			if config.Config.Cache.Model { // cache model into ~/.cache/instill/models
-				modelSrcDir = utils.MODEL_CACHE_DIR + "/" + modelConfig.RepoId
+			if config.Config.Cache.Model.Enabled { // cache model into ~/.cache/instill/models
+				modelSrcDir = config.Config.Cache.Model.CacheDir + "/" + modelConfig.RepoId
 			}
 
 			if config.Config.Server.ItMode.Enabled { // use local model to remove internet connection issue while integration testing
@@ -155,7 +155,7 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 		}
 	}
 
-	if !config.Config.Cache.Model {
+	if !config.Config.Cache.Model.Enabled {
 		_ = os.RemoveAll(modelSrcDir)
 	}
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -2,9 +2,8 @@ package worker
 
 import (
 	"context"
-	"time"
 
-	"github.com/allegro/bigcache"
+	"github.com/go-redis/redis/v9"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/instill-ai/model-backend/pkg/ray"
@@ -31,7 +30,7 @@ type Worker interface {
 
 // worker represents resources required to run Temporal workflow and activity
 type worker struct {
-	cache            *bigcache.BigCache
+	redisClient      *redis.Client
 	repository       repository.Repository
 	ray              ray.Ray
 	triton           triton.Triton
@@ -39,12 +38,11 @@ type worker struct {
 }
 
 // NewWorker initiates a temporal worker for workflow and activity definition
-func NewWorker(r repository.Repository, t triton.Triton, c controllerPB.ControllerPrivateServiceClient, ra ray.Ray) Worker {
-	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(60 * time.Minute))
+func NewWorker(r repository.Repository, rc *redis.Client, t triton.Triton, c controllerPB.ControllerPrivateServiceClient, ra ray.Ray) Worker {
 
 	return &worker{
-		cache:            cache,
 		repository:       r,
+		redisClient:      rc,
 		ray:              ra,
 		triton:           t,
 		controllerClient: c,


### PR DESCRIPTION
Because

- json file as model cache state introduces race condition when multiple models are deploying

This commit

- use redis to cache model files state

fixes ins-2909