### PR TITLE
chore(redis): update model cache key

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -49,7 +49,7 @@ cache:
       addr: redis:6379
   model:
     enabled: false
-    cache_dir: /.cache/models
+    cache_dir: /model-repository/.cache/models
 maxbatchsizelimitation:
   unspecified: 2
   classification: 16

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -139,11 +139,11 @@ func GitHubClone(dir string, instanceConfig datamodel.GitHubModelConfiguration, 
 	defer cancel()
 
 	urlRepo := instanceConfig.Repository
-	modelRepo := fmt.Sprintf("%s_%s", instanceConfig.Repository, instanceConfig.Tag)
+	redisRepoKey := fmt.Sprintf("%s:%s", instanceConfig.Repository, instanceConfig.Tag)
 	// Check in the cache first.
 	if config.Config.Cache.Model.Enabled {
 		_ = os.MkdirAll(config.Config.Cache.Model.CacheDir, os.ModePerm)
-		if state, err := redisClient.Get(ctx, modelRepo).Result(); err != nil && err != redis.Nil {
+		if state, err := redisClient.Get(ctx, redisRepoKey).Result(); err != nil && err != redis.Nil {
 			return err
 		} else if err == nil {
 			if state == "done" {
@@ -183,11 +183,11 @@ func GitHubClone(dir string, instanceConfig datamodel.GitHubModelConfiguration, 
 			}
 		}
 		if config.Config.Cache.Model.Enabled {
-			redisClient.Set(ctx, modelRepo, "done", time.Duration(0))
+			redisClient.Set(ctx, redisRepoKey, "done", time.Duration(0))
 		}
 	} else {
 		if config.Config.Cache.Model.Enabled {
-			redisClient.Set(ctx, modelRepo, "without_large_file", time.Duration(0))
+			redisClient.Set(ctx, redisRepoKey, "without_large_file", time.Duration(0))
 		}
 	}
 


### PR DESCRIPTION
Because

- use redis key naming convention

This commit

- update model cache key
