### PR TITLE
refactor(auth): replace `Jwt-Sub` with `Instill-User-Uid`

### DIFF
--- a/integration-test/rest_create_model_with_jwt.js
+++ b/integration-test/rest_create_model_with_jwt.js
@@ -34,23 +34,23 @@ export function CreateModelFromLocal(header) {
     fd_cls.append("model_definition", "model-definitions/local");
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
-    group(`Model Backend API: CreateModelFromLocal [with random "jwt-sub" header]`, function () {
+    group(`Model Backend API: CreateModelFromLocal [with random "Instill-User-Uid" header]`, function () {
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeaderWithRandomAuth(`multipart/form-data; boundary=${fd_cls.boundary}`, uuidv4()),
       })
 
       check(createClsModelRes, {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/multipart task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/multipart task cls response status 401`]: (r) =>
           r.status === 401,
       });
     });
 
-    group(`Model Backend API: CreateModelFromLocal [with default user "jwt-sub" header]`, function () {
+    group(`Model Backend API: CreateModelFromLocal [with default user "Instill-User-Uid" header]`, function () {
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
       })
       check(createClsModelRes, {
-        [`[with default user "jwt-sub" header] POST /v1alpha/models/multipart task cls response status 201`]: (r) =>
+        [`[with default user "Instill-User-Uid" header] POST /v1alpha/models/multipart task cls response status 201`]: (r) =>
           r.status === 201,
       });
 
@@ -81,12 +81,12 @@ export function CreateModelFromLocal(header) {
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] DELETE /v1alpha/models/${model_id} status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] DELETE /v1alpha/models/${model_id} status 401`]: (r) =>
           r.status === 401
       });
 
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
           r.status === 204
       });
     });
@@ -109,21 +109,21 @@ export function CreateModelFromGitHub(header) {
       }
     })
 
-    group(`Model Backend API: Upload a model by GitHub [with random "jwt-sub" header]`, function () {
+    group(`Model Backend API: Upload a model by GitHub [with random "Instill-User-Uid" header]`, function () {
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, payload, {
         headers: genHeaderWithRandomAuth("application/json", uuidv4()),
       })
 
       check(createClsModelRes, {
-        [`[with random "jwt-sub" header] POST /v1alpha/models task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models task cls response status 401`]: (r) =>
           r.status === 401,
       });
     });
 
-    group(`Model Backend API: Upload a model by GitHub [with default user "jwt-sub" header]`, function () {
+    group(`Model Backend API: Upload a model by GitHub [with default user "Instill-User-Uid" header]`, function () {
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, payload, header)
       check(createClsModelRes, {
-        [`[with default user "jwt-sub" header] POST /v1alpha/models task cls response status 201`]: (r) =>
+        [`[with default user "Instill-User-Uid" header] POST /v1alpha/models task cls response status 201`]: (r) =>
           r.status === 201,
       });
 
@@ -131,7 +131,7 @@ export function CreateModelFromGitHub(header) {
       check(http.request("GET", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/watch`, null, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id}/watch status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models/${model_id}/watch status 401`]: (r) =>
           r.status === 401
       });
 
@@ -161,12 +161,12 @@ export function CreateModelFromGitHub(header) {
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] DELETE /v1alpha/models/${model_id} status not 204`]: (r) =>
+        [`[with random "Instill-User-Uid" header] DELETE /v1alpha/models/${model_id} status not 204`]: (r) =>
           r.status !== 204
       });
 
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
           r.status === 204
       });
     });

--- a/integration-test/rest_deploy_model_with_jwt.js
+++ b/integration-test/rest_deploy_model_with_jwt.js
@@ -26,7 +26,7 @@ export function DeployUndeployModel(header) {
   let userUid = resp.json().user.uid
 
   {
-    group(`Model Backend API: Load model online [with random "jwt-sub" header]`, function () {
+    group(`Model Backend API: Load model online [with random "Instill-User-Uid" header]`, function () {
       let fd_cls = new FormData();
       let model_id = randomString(10)
       fd_cls.append("id", model_id);
@@ -55,12 +55,12 @@ export function DeployUndeployModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/deploy`, {}, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/deploy online task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/deploy online task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/deploy`, {}, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/deploy online task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/deploy online task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -78,12 +78,12 @@ export function DeployUndeployModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/undeploy`, {}, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/undeploy online task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/undeploy online task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/undeploy`, {}, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/undeploy online task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/undeploy online task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -100,7 +100,7 @@ export function DeployUndeployModel(header) {
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE clean up response status`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE clean up response status`]: (r) =>
           r.status === 204
       });
     });

--- a/integration-test/rest_infer_model_with_jwt.js
+++ b/integration-test/rest_infer_model_with_jwt.js
@@ -38,7 +38,7 @@ export function TestModel(header) {
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
   {
-    group(`Model Backend API: Predict Model with classification model [with random "jwt-sub" header]`, function () {
+    group(`Model Backend API: Predict Model with classification model [with random "Instill-User-Uid" header]`, function () {
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
       })
@@ -80,12 +80,12 @@ export function TestModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test url cls status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test url cls status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -106,11 +106,11 @@ export function TestModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls multiple images status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test url cls multiple images status 401`]: (r) =>
           r.status === 401,
       });
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/test url cls multiple images status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test url cls multiple images status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -126,12 +126,12 @@ export function TestModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test base64 cls status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test base64 cls status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -153,12 +153,12 @@ export function TestModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls multiple images status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test base64 cls multiple images status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test`, payload, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/test base64 cls multiple images status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test base64 cls multiple images status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -169,14 +169,14 @@ export function TestModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test-multipart`, fd.body(), {
         headers: genHeaderWithRandomAuth(`multipart/form-data; boundary=${fd.boundary}`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test-multipart cls status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
       }), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test-multipart cls status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -189,20 +189,20 @@ export function TestModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test-multipart`, fd.body(), {
         headers: genHeaderWithRandomAuth(`multipart/form-data; boundary=${fd.boundary}`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls multiple images status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test-multipart cls multiple images status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/test-multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
       }), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/test-multipart cls multiple images status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/test-multipart cls multiple images status 200`]: (r) =>
           r.status === 200,
       });
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE clean up response status 204`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE clean up response status 204`]: (r) =>
           r.status === 204
       });
 

--- a/integration-test/rest_model_card_with_jwt.js
+++ b/integration-test/rest_model_card_with_jwt.js
@@ -50,16 +50,16 @@ export function GetModelCard(header) {
       currentTime = new Date().getTime();
     }
 
-    group(`Model Backend API: Get model card [with "jwt-sub" header]`, function () {
+    group(`Model Backend API: Get model card [with "Instill-User-Uid" header]`, function () {
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/readme`, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id}/readme response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models/${model_id}/readme response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/readme`, header), {
-        [`[with default "jwt-sub" header] GET /v1alpha/models/${model_id}/readme response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models/${model_id}/readme response status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -76,7 +76,7 @@ export function GetModelCard(header) {
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE clean up response status 204`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE clean up response status 204`]: (r) =>
           r.status === 204
       });
     });

--- a/integration-test/rest_publish_model_with_jwt.js
+++ b/integration-test/rest_publish_model_with_jwt.js
@@ -32,7 +32,7 @@ export function PublishUnpublishModel(header) {
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
   {
-    group(`Model Backend API: PublishModel [with "jwt-sub" header]`, function () {
+    group(`Model Backend API: PublishModel [with "Instill-User-Uid" header]`, function () {
 
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -53,24 +53,24 @@ export function PublishUnpublishModel(header) {
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/publish`, null, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/publish task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/publish task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/unpublish`, null, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] POST /v1alpha/models/${model_id}/unpublish task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/unpublish task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/publish`, null, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/publish task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/publish task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/unpublish`, null, header), {
-        [`[with default "jwt-sub" header] POST /v1alpha/models/${model_id}/unpublish task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] POST /v1alpha/models/${model_id}/unpublish task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -87,7 +87,7 @@ export function PublishUnpublishModel(header) {
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with random "jwt-sub" header] DELETE clean up response status 204`]: (r) =>
+        [`[with random "Instill-User-Uid" header] DELETE clean up response status 204`]: (r) =>
           r.status === 204
       });
     });

--- a/integration-test/rest_query_model_with_jwt.js
+++ b/integration-test/rest_query_model_with_jwt.js
@@ -47,28 +47,28 @@ export function GetModel(header) {
       currentTime = new Date().getTime();
     }
 
-    group(`Model Backend API: Get model info [with "jwt-sub" header]`, function () {
+    group(`Model Backend API: Get model info [with "Instill-User-Uid" header]`, function () {
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}?view=VIEW_FULL`, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, header), {
-        [`[with default "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models/${model_id} task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}?view=VIEW_FULL`, header), {
-        [`[with default "jwt-sub" header] GET /v1alpha/models/${model_id} task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models/${model_id} task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -85,7 +85,7 @@ export function GetModel(header) {
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
           r.status === 204
       });
     });
@@ -98,35 +98,35 @@ export function ListModels(header) {
   let userUid = resp.json().user.uid
 
   {
-    group(`Model Backend API: Get model list [with "jwt-sub" header]`, function () {
+    group(`Model Backend API: Get model list [with "Instill-User-Uid" header]`, function () {
       let resp = http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models?page_size=1`, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       })
       check(resp, {
-        [`[with random "jwt-sub" header] GET /v1alpha/models task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models?view=VIEW_FULL`, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models?view=VIEW_FULL task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models?view=VIEW_FULL task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       resp = http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models?page_size=1`, header)
       check(resp, {
-        [`[with default "jwt-sub" header] GET /v1alpha/models task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models?page_size=1&page_token=${resp.json().next_page_token}`, header), {
-        [`[with default "jwt-sub" header] GET /v1alpha/models task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models?view=VIEW_FULL`, header), {
-        [`[with default "jwt-sub" header] GET /v1alpha/models?view=VIEW_FULL task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models?view=VIEW_FULL task cls response status 200`]: (r) =>
           r.status === 200,
       });
     });
@@ -166,28 +166,28 @@ export function LookupModel(header) {
     resp = http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, header)
     let modelUid = resp.json().model.uid
 
-    group(`Model Backend API: Look up model [with "jwt-sub" header]`, function () {
+    group(`Model Backend API: Look up model [with "Instill-User-Uid" header]`, function () {
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelUid}/lookUp`, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models/${modelUid}/lookUp task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL`, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4()),
       }), {
-        [`[with random "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] GET /v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelUid}/lookUp`, header), {
-        [`[with default "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models/${modelUid}/lookUp task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL`, header), {
-        [`[with default "jwt-sub" header] GET /v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] GET /v1alpha/models/${modelUid}/lookUp?view=VIEW_FULL task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -204,7 +204,7 @@ export function LookupModel(header) {
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE /v1alpha/models/${model_id} status 204`]: (r) =>
           r.status === 204
       });
     });

--- a/integration-test/rest_update_model_with_jwt.js
+++ b/integration-test/rest_update_model_with_jwt.js
@@ -34,7 +34,7 @@ export function UpdateModel(header) {
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
   {
-    group(`Model Backend API: Update model [with "jwt-sub" header]`, function () {
+    group(`Model Backend API: Update model [with "Instill-User-Uid" header]`, function () {
 
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -59,12 +59,12 @@ export function UpdateModel(header) {
       check(http.patch(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, payload, {
         headers: genHeaderWithRandomAuth(`application/json`, uuidv4())
       }), {
-        [`[with random "jwt-sub" header] PATCH /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
+        [`[with random "Instill-User-Uid" header] PATCH /v1alpha/models/${model_id} task cls response status 401`]: (r) =>
           r.status === 401,
       });
 
       check(http.patch(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, payload, header), {
-        [`[with default "jwt-sub" header] PATCH /v1alpha/models/${model_id} task cls response status 200`]: (r) =>
+        [`[with default "Instill-User-Uid" header] PATCH /v1alpha/models/${model_id} task cls response status 200`]: (r) =>
           r.status === 200,
       });
 
@@ -81,7 +81,7 @@ export function UpdateModel(header) {
 
       // clean up
       check(http.request("DELETE", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}`, null, header), {
-        [`[with default "jwt-sub" header] DELETE clean up response status 204`]: (r) =>
+        [`[with default "Instill-User-Uid" header] DELETE clean up response status 204`]: (r) =>
           r.status === 204
       });
     });

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -3,4 +3,4 @@ package constant
 // Constants for resource owner
 const DefaultUserID string = "admin"
 const InstillUserID string = "instill-ai"
-const HeaderUserUIDKey = "jwt-sub"
+const HeaderUserUIDKey = "Instill-User-Uid"

--- a/pkg/handler/public_handler.go
+++ b/pkg/handler/public_handler.go
@@ -415,8 +415,8 @@ func HandleCreateModelByMultiPartFormData(s service.Service, w http.ResponseWrit
 			span.SetStatus(1, "User not found")
 			return
 		default:
-			makeJSONResponse(w, 401, "Unauthorized", "Required parameter 'jwt-sub' or 'owner-id' not found in your header")
-			span.SetStatus(1, "Required parameter 'jwt-sub' or 'owner-id' not found in your header")
+			makeJSONResponse(w, 401, "Unauthorized", "Required parameter 'Instill-User-Uid' or 'owner-id' not found in your header")
+			span.SetStatus(1, "Required parameter 'Instill-User-Uid' or 'owner-id' not found in your header")
 			return
 		}
 	}
@@ -3013,8 +3013,8 @@ func inferModelByUpload(s service.Service, w http.ResponseWriter, req *http.Requ
 			span.SetStatus(1, "User not found")
 			return
 		default:
-			makeJSONResponse(w, 401, "Unauthorized", "Required parameter 'jwt-sub' or 'owner-id' not found in your header")
-			span.SetStatus(1, "Required parameter 'jwt-sub' or 'owner-id' not found in your header")
+			makeJSONResponse(w, 401, "Unauthorized", "Required parameter 'Instill-User-Uid' or 'owner-id' not found in your header")
+			span.SetStatus(1, "Required parameter 'Instill-User-Uid' or 'owner-id' not found in your header")
 			return
 		}
 	}

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -161,6 +161,9 @@ func CustomMatcher(key string) (string, bool) {
 	if strings.HasPrefix(strings.ToLower(key), "jwt-") {
 		return key, true
 	}
+	if strings.HasPrefix(strings.ToLower(key), "instill-") {
+		return key, true
+	}
 
 	switch key {
 	case "request-id":

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -173,6 +173,6 @@ func CustomMatcher(key string) (string, bool) {
 }
 
 func InjectOwnerToContext(ctx context.Context, owner *mgmtPB.User) context.Context {
-	ctx = metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", owner.GetUid())
+	ctx = metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", owner.GetUid())
 	return ctx
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -138,7 +138,7 @@ func (s *service) GetMgmtPrivateServiceClient() mgmtPB.MgmtPrivateServiceClient 
 // GetUser returns the api user
 func (s *service) GetUser(ctx context.Context) (string, uuid.UUID, error) {
 
-	// Verify if "jwt-sub" is in the header
+	// Verify if "Instill-User-Uid" is in the header
 	headerUserUId := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
 	if headerUserUId != "" {
 		_, err := uuid.FromString(headerUserUId)


### PR DESCRIPTION
Because

- We need to standardize the naming convention of customized headers

This commit

- replace `Jwt-Sub` with `Instill-User-Uid`
