### PR TITLE
chore(utils): update model cache redis key prefix

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -139,7 +139,7 @@ func GitHubClone(dir string, instanceConfig datamodel.GitHubModelConfiguration, 
 	defer cancel()
 
 	urlRepo := instanceConfig.Repository
-	redisRepoKey := fmt.Sprintf("%s:%s", instanceConfig.Repository, instanceConfig.Tag)
+	redisRepoKey := fmt.Sprintf("model_cache:%s:%s", instanceConfig.Repository, instanceConfig.Tag)
 	// Check in the cache first.
 	if config.Config.Cache.Model.Enabled {
 		_ = os.MkdirAll(config.Config.Cache.Model.CacheDir, os.ModePerm)


### PR DESCRIPTION
Because

- make model cache redis key prefix consistent

This commit

- update model cache redis key prefix
