### PR TITLE
chore(utils): exclude json file from size check

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -722,7 +722,7 @@ func HasModelWeightFile(modelRepository string, inferenceModels []*datamodel.Inf
 		if len(modelFiles) > 0 {
 			for _, modelFile := range modelFiles {
 				fi, _ := os.Stat(modelFile)
-				if fi.Size() < 200 { // 200b
+				if !strings.HasSuffix(fi.Name(), ".json") && fi.Size() < 200 { // 200b
 					return false
 				}
 			}


### PR DESCRIPTION
Because

- json file might be smaller than 200b

This commit

- exclude json file from file size check. weight file check login will be refactored in the future
