### PR TITLE
fix(model): fix missing field in ray while serving img2img task

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,7 +14,7 @@ server:
   debug: true
   itmode:
     enabled: false
-  maxdatasize: 32 # MB in unit
+  maxdatasize: 100 # MB in unit
   workflow:
     maxworkflowtimeout: 7200 # in seconds
     maxworkflowretry: 3


### PR DESCRIPTION
Because

we are transitioning the majority of our models to be served via Ray, moving away from Triton.

This commit

**Models Transitioned to Ray Serving:**
- LLaMA2-7B
- LLaMA2-7B-Chat
- LLaVA-7B
- Zephyr-7B
- Stable Diffusion XL
- ControlNet-Canny

**Models Remaining on Triton:**
- YOLOv7-Pose
- Stomata-Mask R-CNN


- Fix Missing field on ray serve and enlarge grpc maxdatasize