### PR TITLE
chore(config,ray): add gpu vram info when deploying

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,10 @@ type TritonServerConfig struct {
 type RayServerConfig struct {
 	GrpcURI    string `koanf:"grpcuri"`
 	ModelStore string `koanf:"modelstore"`
+	GPU        struct {
+		Enabled bool   `koanf:"enabled"`
+		Vram    string `koanf:"vram"`
+	}
 }
 
 // MgmtBackendConfig related to mgmt-backend

--- a/config/config.go
+++ b/config/config.go
@@ -74,10 +74,7 @@ type TritonServerConfig struct {
 type RayServerConfig struct {
 	GrpcURI    string `koanf:"grpcuri"`
 	ModelStore string `koanf:"modelstore"`
-	GPU        struct {
-		Enabled bool   `koanf:"enabled"`
-		Vram    string `koanf:"vram"`
-	}
+	Vram       string `koanf:"vram"`
 }
 
 // MgmtBackendConfig related to mgmt-backend

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,6 +41,9 @@ tritonserver:
 rayserver:
   grpcuri: ray-server:9000
   modelstore: /model-repository
+  gpu:
+    enabled: false
+    vram: "8"
 mgmtbackend:
   host: mgmt-backend
   privateport: 3084

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,9 +41,7 @@ tritonserver:
 rayserver:
   grpcuri: ray-server:9000
   modelstore: /model-repository
-  gpu:
-    enabled: false
-    vram: "8"
+  vram:
 mgmtbackend:
   host: mgmt-backend
   privateport: 3084

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -453,7 +453,7 @@ func PostProcess(inferResponse *rayserver.RayServiceCallResponse, modelMetadata 
 
 func (r *ray) DeployModel(modelPath string) error {
 	modelPath = filepath.Join(config.Config.RayServer.ModelStore, modelPath)
-	cmd := exec.Command("/ray-conda/bin/python", "-c", fmt.Sprintf("from model import deployable; deployable.deploy(\"%s\", \"%s\")", modelPath, config.Config.RayServer.GrpcURI))
+	cmd := exec.Command("/ray-conda/bin/python", "-c", fmt.Sprintf("from model import deployable; deployable.deploy(\"%s\", \"%s\", \"%s\")", modelPath, config.Config.RayServer.GrpcURI, config.Config.RayServer.GPU.Vram))
 	cmd.Dir = modelPath
 
 	cmd.Stdin = os.Stdin

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -453,7 +453,7 @@ func PostProcess(inferResponse *rayserver.RayServiceCallResponse, modelMetadata 
 
 func (r *ray) DeployModel(modelPath string) error {
 	modelPath = filepath.Join(config.Config.RayServer.ModelStore, modelPath)
-	cmd := exec.Command("/ray-conda/bin/python", "-c", fmt.Sprintf("from model import deployable; deployable.deploy(\"%s\", \"%s\", \"%s\")", modelPath, config.Config.RayServer.GrpcURI, config.Config.RayServer.GPU.Vram))
+	cmd := exec.Command("/ray-conda/bin/python", "-c", fmt.Sprintf("from model import deployable; deployable.deploy(\"%s\", \"%s\", \"%s\")", modelPath, config.Config.RayServer.GrpcURI, config.Config.RayServer.Vram))
 	cmd.Dir = modelPath
 
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
Because

- python-sdk now require deploy calls to include `vram` info to dynamically adjust `num_of_gpus` value

This commit

- add vram in config and `DeployModel` method
