### PR TITLE
chore(utils): fix has model weight

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -735,6 +735,22 @@ func HasModelWeightFile(modelRepository string, inferenceModels []*datamodel.Inf
 	return false
 }
 
+func HasDVCWeightFile(modelRepository string, inferenceModels []*datamodel.InferenceModel) bool {
+	for _, inferenceModel := range inferenceModels {
+		modelDir := fmt.Sprintf("%s/%s", modelRepository, inferenceModel.Name)
+		dvcFiles := findDVCPaths(modelDir)
+		if len(dvcFiles) > 0 {
+			for _, dvcFile := range dvcFiles {
+				if _, err := os.Stat(strings.TrimSuffix(dvcFile, ".dvc")); err != nil {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return false
+}
+
 func updateModelConfigModel(configFilePath string, oldStr string, newStr string) error {
 	if _, err := os.Stat(configFilePath); err != nil {
 		return err

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -82,7 +82,7 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 	modelSrcDir := fmt.Sprintf("/tmp/%s", rdid.String())
 	switch modelDef.ID {
 	case "github":
-		if !config.Config.Server.ItMode.Enabled && !utils.HasModelWeightFile(config.Config.TritonServer.ModelStore, inferenceModels) {
+		if !config.Config.Server.ItMode.Enabled && !utils.HasDVCWeightFile(config.Config.TritonServer.ModelStore, inferenceModels) {
 			var modelConfig datamodel.GitHubModelConfiguration
 			if err := json.Unmarshal(dbModel.Configuration, &modelConfig); err != nil {
 				return err


### PR DESCRIPTION
Because

- `hasModelWeight` is too generic and cause edge case errors

This commit

- add dedicated logic for dvc files
- has*Weight will be source specific in the future
