### PR TITLE
chore(ray): add timeout for infer calls

### DIFF
--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -173,7 +173,9 @@ func (r *ray) ModelInferRequest(ctx context.Context, task commonPB.Task, inferIn
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	ctx = metadata.AppendToOutgoingContext(ctx, "application", applicationMetadatValue)
+	defer cancel()
 
 	// Create request input tensors
 	var inferInputs []*rayserver.InferTensor


### PR DESCRIPTION
Because

- allow up to 10 minutes for infer request

This commit

- add timeout for infer calls
