### PR TITLE
ci(workflows): use min triton image

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
   schedule:
     - cron: "0 0 * * 0"
 
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+          check-latest: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -119,6 +119,8 @@ jobs:
           EDITION=local-ce:test \
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          TRITON_SERVER_IMAGE=nvcr.io/nvidia/tritonserver \
+          TRITON_SERVER_VERSION=23.04-pyt-python-py3 \
           RAY_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ ADD https://github.com/InfuseAI/ArtiVC/releases/download/v${ARTIVC_VERSION}/Arti
 RUN tar -xf ArtiVC-v${ARTIVC_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local/bin
 
 # Mounting points
-RUN mkdir /etc/vdp
-RUN mkdir /vdp
 RUN mkdir /model-repository
 RUN mkdir /.cache
 
@@ -81,7 +79,5 @@ COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-worker ./
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-init-model ./
 COPY --from=build --chown=nobody:nogroup /usr/local/bin/avc /usr/local/bin/avc
 
-COPY --from=build --chown=nobody:nogroup /etc/vdp /etc/vdp
-COPY --from=build --chown=nobody:nogroup /vdp /vdp
 COPY --from=build --chown=nobody:nogroup /model-repository /model-repository
 COPY --from=build --chown=nobody:nogroup /.cache /.cache


### PR DESCRIPTION
Because

- PR head integration-test will run out of disk space

This commit

- use min triton image to reduce disk size usage
