### PR TITLE
refactor(pkg): fix file close without error handling

### DIFF
--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -581,7 +581,9 @@ func parseImageFormDataInputsToBytes(req *http.Request) (imgsBytes [][]byte, err
 		file, err := content.Open()
 
 		if err != nil {
-			file.Close()
+			if err := file.Close(); err != nil {
+				return nil, err
+			}
 			logger.Error(fmt.Sprintf("Unable to open file for image %v", err))
 			return nil, fmt.Errorf("unable to open file for image")
 		}
@@ -589,11 +591,15 @@ func parseImageFormDataInputsToBytes(req *http.Request) (imgsBytes [][]byte, err
 		buff := new(bytes.Buffer) // pointer
 		numBytes, err := buff.ReadFrom(file)
 		if err != nil {
-			file.Close()
+			if err := file.Close(); err != nil {
+				return nil, err
+			}
 			logger.Error(fmt.Sprintf("Unable to read content body from image %v", err))
 			return nil, fmt.Errorf("unable to read content body from image")
 		}
-		file.Close()
+		if err := file.Close(); err != nil {
+			return nil, err
+		}
 
 		if numBytes > int64(config.Config.Server.MaxDataSize*constant.MB) {
 			return nil, fmt.Errorf(

--- a/pkg/handler/public.go
+++ b/pkg/handler/public.go
@@ -168,15 +168,16 @@ func HandleCreateModelByMultiPartFormData(s service.Service, w http.ResponseWrit
 	count := 0
 	for {
 		if count, err = reader.Read(part); err != nil {
+			if !errors.Is(err, io.EOF) {
+				makeJSONResponse(w, 400, "File Error", "Error reading input file")
+				span.SetStatus(1, "Error reading input file")
+				return
+			}
 			break
 		}
 		buf.Write(part[:count])
 	}
-	if errors.Is(err, io.EOF) {
-		makeJSONResponse(w, 400, "File Error", "Error reading input file")
-		span.SetStatus(1, "Error reading input file")
-		return
-	}
+
 	rdid, _ := uuid.NewV4()
 	tmpFile := path.Join("/tmp", rdid.String())
 	fp, err := os.Create(tmpFile)

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -134,7 +134,9 @@ func checkIsEnsembleProject(fPath string) (bool, error) {
 					result = false
 					return err
 				}
-				f.Close()
+				if err := f.Close(); err != nil {
+					return err
+				}
 			}
 			result = false
 			return nil
@@ -166,7 +168,9 @@ func checkIsEnsembleProject(fPath string) (bool, error) {
 			if err := scanner.Err(); err != nil {
 				return false, err
 			}
-			f.Close()
+			if err := f.Close(); err != nil {
+				return false, err
+			}
 		}
 	}
 
@@ -281,8 +285,13 @@ func Unzip(fPath string, dstDir string, owner string, uploadedModel *datamodel.M
 			return "", "", err
 		}
 
-		dstFile.Close()
-		fileInArchive.Close()
+		if err := dstFile.Close(); err != nil {
+			return "", "", err
+		}
+		if err := fileInArchive.Close(); err != nil {
+			return "", "", err
+		}
+
 		// Update ModelName in config.pbtxt
 		fileExtension := filepath.Ext(fPath)
 		if fileExtension == ".pbtxt" {


### PR DESCRIPTION
Because

- file close without error handling

This commit

- add error handling while closing file
