### PR TITLE
refactor(cmd): support org namespace with predeploy models

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,9 +110,10 @@ type ControllerConfig struct {
 }
 
 type InitModelConfig struct {
-	OwnerID string `koanf:"ownerid"`
-	Path    string `koanf:"path"`
-	Enabled bool   `koanf:"enabled"`
+	OwnerType string `koanf:"ownertype"`
+	OwnerID   string `koanf:"ownerid"`
+	Path      string `koanf:"path"`
+	Enabled   bool   `koanf:"enabled"`
 }
 
 // MaxBatchSizeConfig defines the maximum size of the batch of a AI task

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -79,6 +79,7 @@ controller:
     cert:
     key:
 initmodel:
+  ownertype: users
   ownerid: admin
   enabled: false
   path: https://raw.githubusercontent.com/instill-ai/model/main/model-hub/model_hub_cpu.json

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	custom_logger "github.com/instill-ai/model-backend/pkg/logger"
-	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
 
 func HTTPResponseModifier(ctx context.Context, w http.ResponseWriter, p proto.Message) error {
@@ -174,7 +173,11 @@ func CustomMatcher(key string) (string, bool) {
 	}
 }
 
-func InjectOwnerToContext(ctx context.Context, owner *mgmtPB.User) context.Context {
+type Owner interface {
+	GetUid() string
+}
+
+func InjectOwnerToContext(ctx context.Context, owner Owner) context.Context {
 	ctx = metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", owner.GetUid())
 	return ctx
 }


### PR DESCRIPTION
Because

- we now support creating and deploying models under org namespace

This commit

- support hosting predeploy models under org namespace
