### PR TITLE
chore(worker): create temporal namespace at launch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -132,6 +132,7 @@ type MaxBatchSizeConfig struct {
 type TemporalConfig struct {
 	HostPort   string `koanf:"hostport"`
 	Namespace  string `koanf:"namespace"`
+	Retention  string `koanf:"retention"`
 	Ca         string `koanf:"ca"`
 	Cert       string `koanf:"cert"`
 	Key        string `koanf:"key"`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -68,6 +68,7 @@ maxbatchsizelimitation:
 temporal:
   hostport: temporal:7233
   namespace: model-backend
+  retention: 1d
   ca:
   cert:
   key:


### PR DESCRIPTION
Because

- make temporal namespace programmatically created to remove the `temporal-admin-tools` container at launch

This commit

- add initialisation temporal namespace logic in the worker `main.go`
- the implementation will skip the namespace creation if it already exists