### PR TITLE
fix(worker): fix temporal cloud namespace init

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -153,7 +153,10 @@ func main() {
 	}
 	defer tempClient.Close()
 
-	initTemporalNamespace(ctx, tempClient)
+	// for only local temporal cluster
+	if config.Config.Temporal.Ca == "" && config.Config.Temporal.Cert == "" && config.Config.Temporal.Key == "" {
+		initTemporalNamespace(ctx, tempClient)
+	}
 
 	fgaClient, err := openfgaClient.NewSdkClient(&openfgaClient.ClientConfiguration{
 		ApiScheme: "http",


### PR DESCRIPTION
Because

- we can't programmatically list namespace in Temporal Cloud (i.e., `tcld` is the current only way to pass the authentication) 

This commit

- bypass the initialisation of namespace for Temporal Cloud route
