### PR TITLE
chore(deps): remove air dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,9 +106,6 @@ model-backend
 
 # local protogen-go
 protogen-go
-
-# air related files and folders
-.air.toml
 tmp
 
 .DS_Store

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,9 +13,6 @@ COPY --from=docker:dind-rootless --chown=nobody:nogroup /usr/local/bin/docker /u
 
 ARG TARGETOS TARGETARCH K6_VERSION ARTIVC_VERSION
 
-# air
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/cosmtrek/air@v1.49
-
 # k6
 ARG K6_VERSION
 ADD https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-${TARGETARCH}.tar.gz k6-v${K6_VERSION}-linux-${TARGETARCH}.tar.gz


### PR DESCRIPTION
The `latest` version is incompatible with the current Go version and the tool is unused
