### PR TITLE
chore(ray): add nvidia CDI gpu flag

### DIFF
--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -557,6 +557,7 @@ func (r *ray) UpdateContainerizedModel(modelPath string, imageName string, isDep
 				RunOptions: []string{
 					"--tls-verify=false",
 					"--pull=always",
+					"--device nvidia.com/gpu=all",
 					"--rm",
 					"-v /home/ray/ray_pb2.py:/home/ray/ray_pb2.py",
 					"-v /home/ray/ray_pb2.pyi:/home/ray/ray_pb2.pyi",


### PR DESCRIPTION
Because

- We now use nvidia CDI to access gpu instead of runtime hook injection

This commit

- specify CDI devices with `podman run` command
