### PR TITLE
chore(ray): adopt registry namespace format

### DIFF
--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -155,7 +155,7 @@ func (h *PrivateHandler) DeployModelAdmin(ctx context.Context, req *modelPB.Depl
 
 	}
 
-	wfID, err := h.service.DeployNamespaceModelAsyncAdmin(ctx, modelUID)
+	wfID, err := h.service.DeployNamespaceModelAsyncAdmin(ctx, ns.NsID, modelUID)
 	if err != nil {
 		st, e := sterr.CreateErrorResourceInfo(
 			codes.Internal,
@@ -198,7 +198,17 @@ func (h *PrivateHandler) UndeployModelAdmin(ctx context.Context, req *modelPB.Un
 		return &modelPB.UndeployModelAdminResponse{}, err
 	}
 
-	wfID, err := h.service.UndeployNamespaceModelAsyncAdmin(ctx, modelUID)
+	pbModel, err := h.service.GetModelByUIDAdmin(ctx, modelUID, modelPB.View_VIEW_FULL)
+	if err != nil {
+		return &modelPB.UndeployModelAdminResponse{}, err
+	}
+
+	ns, _, err := h.service.GetRscNamespaceAndNameID(pbModel.GetOwnerName())
+	if err != nil {
+		return nil, err
+	}
+
+	wfID, err := h.service.UndeployNamespaceModelAsyncAdmin(ctx, ns.NsID, modelUID)
 	if err != nil {
 		return &modelPB.UndeployModelAdminResponse{}, err
 	}

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -42,7 +42,7 @@ type Ray interface {
 	IsRayServerReady(ctx context.Context) bool
 	DeployModel(modelPath string) error
 	UndeployModel(modelPath string) error
-	UpdateContainerizedModel(modelPath string, imageName string, useGPU bool, isDeploy bool) error
+	UpdateContainerizedModel(modelPath string, userID string, imageName string, useGPU bool, isDeploy bool) error
 	Init()
 	Close()
 }
@@ -543,7 +543,7 @@ func (r *ray) UndeployModel(modelPath string) error {
 	return err
 }
 
-func (r *ray) UpdateContainerizedModel(modelPath string, imageName string, useGPU bool, isDeploy bool) error {
+func (r *ray) UpdateContainerizedModel(modelPath string, userID string, imageName string, useGPU bool, isDeploy bool) error {
 	absModelPath := filepath.Join(config.Config.RayServer.ModelStore, modelPath)
 	applicationName := strings.Join(strings.Split(absModelPath, "/")[3:], "_")
 
@@ -566,7 +566,7 @@ func (r *ray) UpdateContainerizedModel(modelPath string, imageName string, useGP
 		RoutePrefix: "/" + applicationName,
 		RuntimeEnv: RuntimeEnv{
 			Container: Container{
-				Image:      fmt.Sprintf("%s:%v/%s", config.Config.Registry.Host, config.Config.Registry.Port, imageName),
+				Image:      fmt.Sprintf("%s:%v/%s/%s", config.Config.Registry.Host, config.Config.Registry.Port, userID, imageName),
 				RunOptions: runOptions,
 			},
 		},

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -126,7 +126,7 @@ func (s *service) CreateNamespaceModelAsync(ctx context.Context, ns resource.Nam
 	return id.String(), nil
 }
 
-func (s *service) DeployNamespaceModelAsyncAdmin(ctx context.Context, modelUID uuid.UUID) (string, error) {
+func (s *service) DeployNamespaceModelAsyncAdmin(ctx context.Context, userID string, modelUID uuid.UUID) (string, error) {
 
 	logger, _ := custom_logger.GetZapLogger(ctx)
 	id, _ := uuid.NewV4()
@@ -149,7 +149,8 @@ func (s *service) DeployNamespaceModelAsyncAdmin(ctx context.Context, modelUID u
 		workflowOptions,
 		"DeployModelWorkflow",
 		&worker.ModelParams{
-			Model: model,
+			UserID: userID,
+			Model:  model,
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
@@ -161,7 +162,7 @@ func (s *service) DeployNamespaceModelAsyncAdmin(ctx context.Context, modelUID u
 	return id.String(), nil
 }
 
-func (s *service) UndeployNamespaceModelAsyncAdmin(ctx context.Context, modelUID uuid.UUID) (string, error) {
+func (s *service) UndeployNamespaceModelAsyncAdmin(ctx context.Context, userID string, modelUID uuid.UUID) (string, error) {
 
 	logger, _ := custom_logger.GetZapLogger(ctx)
 	id, _ := uuid.NewV4()
@@ -184,7 +185,8 @@ func (s *service) UndeployNamespaceModelAsyncAdmin(ctx context.Context, modelUID
 		workflowOptions,
 		"UnDeployModelWorkflow",
 		&worker.ModelParams{
-			Model: model,
+			UserID: userID,
+			Model:  model,
 		})
 
 	if err != nil {

--- a/pkg/worker/model.go
+++ b/pkg/worker/model.go
@@ -24,7 +24,8 @@ import (
 )
 
 type ModelParams struct {
-	Model *datamodel.Model
+	UserID string
+	Model  *datamodel.Model
 }
 
 var tracer = otel.Tracer("model-backend.temporal.tracer")
@@ -99,7 +100,7 @@ func (w *worker) DeployModelActivity(ctx context.Context, param *ModelParams) er
 			return err
 		}
 		name := filepath.Join(param.Model.Owner, param.Model.ID)
-		if err = w.ray.UpdateContainerizedModel(name, param.Model.ID, modelConfig.GPU, true); err != nil {
+		if err = w.ray.UpdateContainerizedModel(name, param.UserID, param.Model.ID, modelConfig.GPU, true); err != nil {
 			logger.Error(fmt.Sprintf("containerized ray model deployment failed: %v", err))
 			return err
 		}
@@ -208,7 +209,7 @@ func (w *worker) UnDeployModelActivity(ctx context.Context, param *ModelParams) 
 
 	if modelDef.ID == "container" {
 		name := filepath.Join(param.Model.Owner, param.Model.ID)
-		if err := w.ray.UpdateContainerizedModel(name, param.Model.ID, false, false); err != nil {
+		if err := w.ray.UpdateContainerizedModel(name, param.UserID, param.Model.ID, false, false); err != nil {
 			logger.Error(fmt.Sprintf("containerized ray model undeployment failed: %v", err))
 		}
 		logger.Info("UnDeployModelActivity completed")


### PR DESCRIPTION
Because

- We have decided to adopt the format of `{user-id}/{model-id}` for model repository name
- We are missing permission check for `DeployNamespaceModel`

This commit

- add `UserID` in repo name when pulling model iamge
- add permission check for `DeployNamespaceModel`

Resolves INS-3975