### PR TITLE
chore(ray): add model resource config envs

### DIFF
--- a/pkg/ray/const.go
+++ b/pkg/ray/const.go
@@ -212,11 +212,11 @@ var SupportedAcceleratorTypeMemory = map[string]int{
 }
 
 const (
-	ENV_MEMORY               = "RAY_MEMORY"
-	ENV_TOTAL_VRAM           = "RAY_TOTAL_VRAM"
-	ENV_RAY_ACCELERATOR_TYPE = "RAY_ACCELERATOR_TYPE"
-	ENV_NUM_OF_GPUS          = "RAY_NUM_OF_GPUS"
-	ENV_NUM_OF_CPUS          = "RAY_NUM_OF_CPUS"
-	ENV_NUM_OF_MIN_REPLICAS  = "RAY_NUM_OF_MIN_REPLICAS"
-	ENV_NUM_OF_MAX_REPLICAS  = "RAY_NUM_OF_MAX_REPLICAS"
+	EnvMemory             = "RAY_MEMORY"
+	EnvTotalVRAM          = "RAY_TOTAL_VRAM"
+	EnvRayAcceleratorType = "RAY_ACCELERATOR_TYPE"
+	EnvNumOfGPUs          = "RAY_NUM_OF_GPUS"
+	EnvNumOfCPUs          = "RAY_NUM_OF_CPUS"
+	EnvNumOfMinReplicas   = "RAY_NUM_OF_MIN_REPLICAS"
+	EnvNumOfMaxReplicas   = "RAY_NUM_OF_MAX_REPLICAS"
 )

--- a/pkg/ray/const.go
+++ b/pkg/ray/const.go
@@ -183,3 +183,40 @@ var SupportedAcceleratorType = map[string]string{
 	"NVIDIA_A100_40G":           "A100-40G",
 	"NVIDIA_A100_80G":           "A100-80G",
 }
+
+var SupportedAcceleratorTypeMemory = map[string]int{
+	"NVIDIA_TESLA_V100":         16,
+	"NVIDIA_TESLA_P100":         16,
+	"NVIDIA_TESLA_T4":           16,
+	"NVIDIA_TESLA_P4":           8,
+	"NVIDIA_TESLA_K80":          24,
+	"NVIDIA_TESLA_A10G":         24,
+	"NVIDIA_L4":                 24,
+	"NVIDIA_A100":               40,
+	"INTEL_MAX_1550":            128,
+	"INTEL_MAX_1100":            48,
+	"INTEL_GAUDI":               128,
+	"AMD_INSTINCT_MI100":        32,
+	"AMD_INSTINCT_MI250X":       128,
+	"AMD_INSTINCT_MI250":        128,
+	"AMD_INSTINCT_MI210":        64,
+	"AMD_INSTINCT_MI300X":       192,
+	"AMD_RADEON_R9_200_HD_7900": 3,
+	"AMD_RADEON_HD_7900":        3,
+	"AWS_NEURON_CORE":           32,
+	"GOOGLE_TPU_V2":             8,
+	"GOOGLE_TPU_V3":             16,
+	"GOOGLE_TPU_V4":             32,
+	"NVIDIA_A100_40G":           40,
+	"NVIDIA_A100_80G":           80,
+}
+
+const (
+	ENV_MEMORY               = "RAY_MEMORY"
+	ENV_TOTAL_VRAM           = "RAY_TOTAL_VRAM"
+	ENV_RAY_ACCELERATOR_TYPE = "RAY_ACCELERATOR_TYPE"
+	ENV_NUM_OF_GPUS          = "RAY_NUM_OF_GPUS"
+	ENV_NUM_OF_CPUS          = "RAY_NUM_OF_CPUS"
+	ENV_NUM_OF_MIN_REPLICAS  = "RAY_NUM_OF_MIN_REPLICAS"
+	ENV_NUM_OF_MAX_REPLICAS  = "RAY_NUM_OF_MAX_REPLICAS"
+)

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -256,21 +256,27 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 		}
 
 		if val == SupportedAcceleratorType["CPU"] {
-			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_CPUS, 2))
+			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", EnvNumOfCPUs, 2))
 		} else {
-			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_CPUS, 1))
-			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_GPUS, 0.5))
-			runOptions = append(runOptions, "--device nvidia.com/gpu=all")
+			runOptions = append(runOptions,
+				fmt.Sprintf("-e %s=%v", EnvNumOfCPUs, 1),
+				fmt.Sprintf("-e %s=%v", EnvNumOfGPUs, 0.5),
+				"--device nvidia.com/gpu=all",
+			)
 			if val != SupportedAcceleratorType["GPU"] {
-				runOptions = append(runOptions, fmt.Sprintf("-e %s=%s", ENV_RAY_ACCELERATOR_TYPE, val))
-				runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_TOTAL_VRAM, SupportedAcceleratorTypeMemory[val]))
+				runOptions = append(runOptions,
+					fmt.Sprintf("-e %s=%s", EnvRayAcceleratorType, val),
+					fmt.Sprintf("-e %s=%v", EnvTotalVRAM, SupportedAcceleratorTypeMemory[val]),
+				)
 			}
 		}
 	}
 
 	// TODO: Support custom resource configs for deployment in the future
-	runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_MIN_REPLICAS, 0))
-	runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_MAX_REPLICAS, 5))
+	runOptions = append(runOptions,
+		fmt.Sprintf("-e %s=%v", EnvNumOfMinReplicas, 0),
+		fmt.Sprintf("-e %s=%v", EnvNumOfMaxReplicas, 5),
+	)
 
 	applicationConfig := Application{
 		Name:        applicationMetadatValue,

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -255,13 +255,22 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 			return fmt.Errorf("accelerator type(hardware) not supported")
 		}
 
-		if val != SupportedAcceleratorType["CPU"] {
+		if val == SupportedAcceleratorType["CPU"] {
+			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_CPUS, 2))
+		} else {
+			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_CPUS, 1))
+			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_GPUS, 0.5))
 			runOptions = append(runOptions, "--device nvidia.com/gpu=all")
 			if val != SupportedAcceleratorType["GPU"] {
-				runOptions = append(runOptions, fmt.Sprintf("-e RAY_ACCELERATOR_TYPE=%s", val))
+				runOptions = append(runOptions, fmt.Sprintf("-e %s=%s", ENV_RAY_ACCELERATOR_TYPE, val))
+				runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_TOTAL_VRAM, SupportedAcceleratorTypeMemory[val]))
 			}
 		}
 	}
+
+	// TODO: Support custom resource configs for deployment in the future
+	runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_MIN_REPLICAS, 0))
+	runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", ENV_NUM_OF_MAX_REPLICAS, 5))
 
 	applicationConfig := Application{
 		Name:        applicationMetadatValue,


### PR DESCRIPTION
Because

- we will only allow model resource configuration from model-backend

This commit

- support model resource config env variables passthrough to ray
- lay the foundation for future customizable model deployment
