### PR TITLE
chore(ray): remove cpu resource request for gpu model

### DIFF
--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -259,7 +259,6 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 			runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", EnvNumOfCPUs, 2))
 		} else {
 			runOptions = append(runOptions,
-				fmt.Sprintf("-e %s=%v", EnvNumOfCPUs, 1),
 				fmt.Sprintf("-e %s=%v", EnvNumOfGPUs, 0.5),
 				"--device nvidia.com/gpu=all",
 			)


### PR DESCRIPTION
Because

- we are removing available CPU resource on GPU node to prevent CPU model to schedule on GPU node

This commit

- remove cpu resource request for GPU model
