### PR TITLE
feat(ray): support custom accelerator type

### DIFF
--- a/pkg/ray/const.go
+++ b/pkg/ray/const.go
@@ -215,6 +215,7 @@ const (
 	EnvMemory             = "RAY_MEMORY"
 	EnvTotalVRAM          = "RAY_TOTAL_VRAM"
 	EnvRayAcceleratorType = "RAY_ACCELERATOR_TYPE"
+	EnvRayCustomResource  = "RAY_CUSTOM_RESOURCE"
 	EnvNumOfGPUs          = "RAY_NUM_OF_GPUS"
 	EnvNumOfCPUs          = "RAY_NUM_OF_CPUS"
 	EnvNumOfMinReplicas   = "RAY_NUM_OF_MIN_REPLICAS"


### PR DESCRIPTION
Because

- We need to support GPU types other than the official accelerator type supported by [ray](https://docs.ray.io/en/latest/ray-core/accelerator-types.html)

This commit

- support custom accelerator type env
