### PR TITLE
test(model): convert test models to container format and add build workflow

### DIFF
--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -1,0 +1,59 @@
+name: Build and Push Test Images
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    paths:
+      - "assets/model-**"
+
+jobs:
+  docker-hub:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        model:
+          [
+            "dummy-cls",
+            "dummy-det",
+            "dummy-image-to-image",
+            "dummy-instance-segmentation",
+            "dummy-keypoint",
+            "dummy-semantic-segmentation",
+            "dummy-text-generation",
+            "dummy-text-generation-chat",
+            "dummy-text-to-image",
+            "dummy-visual-question-answering",
+          ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.botGitHubToken }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install Instill Python SDK
+        run: pip install --pre instill-sdk
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        id: builder
+        with:
+          driver-opts: image=moby/buildkit:master
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: dropletbot
+          password: ${{ secrets.botDockerHubPassword }}
+
+      - name: Build test models
+        working-directory: ./assets/model-${{ matrix.model }}
+        run: python -m instill.helpers.build
+
+      - name: Push test models
+        working-directory: ./assets/model-${{ matrix.model }}
+        run: python -m instill.helpers.push -u docker.io

--- a/assets/model-dummy-cls/instill.yaml
+++ b/assets/model-dummy-cls/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-cls
+tag: test

--- a/assets/model-dummy-cls/model.py
+++ b/assets/model-dummy-cls/model.py
@@ -38,10 +38,7 @@ class MobileNet:
         b_tensors = req.raw_input_contents[0]
         input_tensors = deserialize_bytes_tensor(b_tensors)
 
-        out = [
-            bytes("1:match", "utf-8")
-            for _ in range(len(input_tensors))
-        ]
+        out = [bytes("1:match", "utf-8") for _ in range(len(input_tensors))]
 
         out = serialize_byte_tensor(np.asarray(out))
         out = np.expand_dims(out, axis=0)
@@ -50,13 +47,13 @@ class MobileNet:
             req=req,
             outputs=[
                 Metadata(
-                name="output",
-                datatype=str(DataType.TYPE_STRING.name),
-                shape=[len(input_tensors), 1],
-            )
+                    name="output",
+                    datatype=str(DataType.TYPE_STRING.name),
+                    shape=[len(input_tensors), 1],
+                )
             ],
             raw_outputs=out,
         )
 
 
-deployable = InstillDeployable(MobileNet, "/", False)
+entrypoint = InstillDeployable(MobileNet).get_deployment_handle()

--- a/assets/model-dummy-det/instill.yaml
+++ b/assets/model-dummy-det/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-det
+tag: test

--- a/assets/model-dummy-det/model.py
+++ b/assets/model-dummy-det/model.py
@@ -73,4 +73,4 @@ class Det:
         )
 
 
-deployable = InstillDeployable(Det, "/", False)
+entrypoint = InstillDeployable(Det).get_deployment_handle()

--- a/assets/model-dummy-image-to-image/instill.yaml
+++ b/assets/model-dummy-image-to-image/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-image-to-image
+tag: test

--- a/assets/model-dummy-image-to-image/model.py
+++ b/assets/model-dummy-image-to-image/model.py
@@ -104,4 +104,4 @@ class ImageToImage:
         )
 
 
-deployable = InstillDeployable(ImageToImage, "/", False)
+entrypoint = InstillDeployable(ImageToImage).get_deployment_handle()

--- a/assets/model-dummy-instance-segmentation/instill.yaml
+++ b/assets/model-dummy-instance-segmentation/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-instance-segmentation
+tag: test

--- a/assets/model-dummy-instance-segmentation/model.py
+++ b/assets/model-dummy-instance-segmentation/model.py
@@ -10,7 +10,7 @@ from instill.helpers import (
 
 
 @instill_deployment
-class Det:
+class InstanceSegmentation:
     def __init__(self, _):
         pass
 
@@ -116,4 +116,4 @@ class Det:
         )
 
 
-deployable = InstillDeployable(Det, "/", False)
+entrypoint = InstillDeployable(InstanceSegmentation).get_deployment_handle()

--- a/assets/model-dummy-keypoint/instill.yaml
+++ b/assets/model-dummy-keypoint/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-keypoint
+tag: test

--- a/assets/model-dummy-keypoint/model.py
+++ b/assets/model-dummy-keypoint/model.py
@@ -10,7 +10,7 @@ from instill.helpers import (
 
 
 @instill_deployment
-class Det:
+class Keypoint:
     def __init__(self, _):
         pass
 
@@ -93,4 +93,4 @@ class Det:
         )
 
 
-deployable = InstillDeployable(Det, "/", False)
+entrypoint = InstillDeployable(Keypoint).get_deployment_handle()

--- a/assets/model-dummy-semantic-segmentation/instill.yaml
+++ b/assets/model-dummy-semantic-segmentation/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-semantic-segmentation
+tag: test

--- a/assets/model-dummy-semantic-segmentation/model.py
+++ b/assets/model-dummy-semantic-segmentation/model.py
@@ -89,4 +89,4 @@ class SemanticSegmentation:
         )
 
 
-deployable = InstillDeployable(SemanticSegmentation, "/", False)
+entrypoint = InstillDeployable(SemanticSegmentation).get_deployment_handle()

--- a/assets/model-dummy-text-generation-chat/instill.yaml
+++ b/assets/model-dummy-text-generation-chat/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-text-generation-chat
+tag: test

--- a/assets/model-dummy-text-generation-chat/model.py
+++ b/assets/model-dummy-text-generation-chat/model.py
@@ -62,4 +62,4 @@ class TextGenerationChat:
         )
 
 
-deployable = InstillDeployable(TextGenerationChat, "/", False)
+entrypoint = InstillDeployable(TextGenerationChat).get_deployment_handle()

--- a/assets/model-dummy-text-generation/instill.yaml
+++ b/assets/model-dummy-text-generation/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-text-generation
+tag: test

--- a/assets/model-dummy-text-generation/model.py
+++ b/assets/model-dummy-text-generation/model.py
@@ -62,4 +62,4 @@ class TextGeneration:
         )
 
 
-deployable = InstillDeployable(TextGeneration, "/", False)
+entrypoint = InstillDeployable(TextGeneration).get_deployment_handle()

--- a/assets/model-dummy-text-to-image/instill.yaml
+++ b/assets/model-dummy-text-to-image/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-text-to-image
+tag: test

--- a/assets/model-dummy-text-to-image/model.py
+++ b/assets/model-dummy-text-to-image/model.py
@@ -104,4 +104,4 @@ class TextToImage:
         )
 
 
-deployable = InstillDeployable(TextToImage, "/", False)
+entrypoint = InstillDeployable(TextToImage).get_deployment_handle()

--- a/assets/model-dummy-visual-question-answering/instill.yaml
+++ b/assets/model-dummy-visual-question-answering/instill.yaml
@@ -1,0 +1,6 @@
+build:
+  gpu: false
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+repo: instill/dummy-visual-question-answering
+tag: test

--- a/assets/model-dummy-visual-question-answering/model.py
+++ b/assets/model-dummy-visual-question-answering/model.py
@@ -62,4 +62,4 @@ class VisualQuestionAnswering:
         )
 
 
-deployable = InstillDeployable(VisualQuestionAnswering, "/", False)
+entrypoint = InstillDeployable(VisualQuestionAnswering).get_deployment_handle()

--- a/config/config.go
+++ b/config/config.go
@@ -30,8 +30,8 @@ type ServerConfig struct {
 		Host               string `koanf:"host"`
 		Port               int    `koanf:"port"`
 	}
-	Debug  bool `koanf:"debug"`
-	MaxDataSize int `koanf:"maxdatasize"`
+	Debug       bool `koanf:"debug"`
+	MaxDataSize int  `koanf:"maxdatasize"`
 	Workflow    struct {
 		MaxWorkflowTimeout int32 `koanf:"maxworkflowtimeout"`
 		MaxWorkflowRetry   int32 `koanf:"maxworkflowretry"`

--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,6 @@ type ServerConfig struct {
 		Port               int    `koanf:"port"`
 	}
 	Debug  bool `koanf:"debug"`
-	ItMode struct {
-		Enabled bool `koanf:"enabled"`
-	}
 	MaxDataSize int `koanf:"maxdatasize"`
 	Workflow    struct {
 		MaxWorkflowTimeout int32 `koanf:"maxworkflowtimeout"`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,8 +12,6 @@ server:
     host: usage.instill.tech
     port: 443
   debug: true
-  itmode:
-    enabled: false
   maxdatasize: 100 # MB in unit
   workflow:
     maxworkflowtimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- We need to convert all existing test models into container format for integration-tests

This commit

- retire `ItMode` config
- converts test models into container format
- add test model build workflow
