### PR TITLE
chore(artifact): update artifact ports

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,8 +42,8 @@ mgmtbackend:
     key:
 artifactbackend:
   host: artifact-backend
-  publicport: 8085
-  privateport: 3085
+  publicport: 8082
+  privateport: 3082
   https:
     cert:
     key:


### PR DESCRIPTION
Because

- We have changed the public and private port of artifact backend

This commit

- adopt the latest artifact backend ports in config