### PR TITLE
chore(model): remove large package from test model

### DIFF
--- a/assets/model-dummy-image-to-image/instill.yaml
+++ b/assets/model-dummy-image-to-image/instill.yaml
@@ -2,6 +2,5 @@ build:
   gpu: false
   python_version: "3.11"  # support only 3.11
   python_packages:
-    - torch==2.2.1
 repo: instill/dummy-image-to-image
 tag: test

--- a/assets/model-dummy-image-to-image/model.py
+++ b/assets/model-dummy-image-to-image/model.py
@@ -6,7 +6,7 @@ from instill.helpers import (
     Metadata,
 )
 
-import torch
+import numpy as np
 
 
 @instill_deployment
@@ -78,15 +78,8 @@ class ImageToImage:
         resp_outputs = []
         resp_raw_outputs = []
         for _ in req.raw_input_contents:
-            generator = torch.Generator(device="cpu").manual_seed(0)
-            image: torch.Tensor = torch.randn(
-                (1, 3, 5, 5), generator=generator, device="cpu"
-            )
-            image = image.type(dtype=torch.float32)
-            image = (image / 2 + 0.5).clamp(0, 1)
-            image = image.cpu().permute(0, 2, 3, 1).numpy().tobytes()
+            image = np.zeros([1, 5, 5, 3], dtype=np.float32).tobytes()
 
-            # rles
             resp_outputs.append(
                 Metadata(
                     name="images",

--- a/assets/model-dummy-text-to-image/instill.yaml
+++ b/assets/model-dummy-text-to-image/instill.yaml
@@ -2,6 +2,5 @@ build:
   gpu: false
   python_version: "3.11"  # support only 3.11
   python_packages:
-    - torch==2.2.1
 repo: instill/dummy-text-to-image
 tag: test

--- a/assets/model-dummy-text-to-image/model.py
+++ b/assets/model-dummy-text-to-image/model.py
@@ -6,7 +6,7 @@ from instill.helpers import (
     Metadata,
 )
 
-import torch
+import numpy as np
 
 
 @instill_deployment
@@ -78,15 +78,8 @@ class TextToImage:
         resp_outputs = []
         resp_raw_outputs = []
         for _ in req.raw_input_contents:
-            generator = torch.Generator(device="cpu").manual_seed(0)
-            image: torch.Tensor = torch.randn(
-                (1, 3, 5, 5), generator=generator, device="cpu"
-            )
-            image = image.type(dtype=torch.float32)
-            image = (image / 2 + 0.5).clamp(0, 1)
-            image = image.cpu().permute(0, 2, 3, 1).numpy().tobytes()
+            image = np.zeros([1, 5, 5, 3], dtype=np.float32).tobytes()
 
-            # rles
             resp_outputs.append(
                 Metadata(
                     name="images",


### PR DESCRIPTION
Because

- some test model image has `torch` installed and is making them unreasonably large

This commit

- remove `torch` from test models
