### PR TITLE
feat(model): embed sample input/output in model proto message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240503204658-d98e786cb9e6
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240505184837-87fec8c772eb
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1310,8 +1310,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240503204658-d98e786cb9e6 h1:60o/ugui7RbrnhkUxNTIgzUuIBNNVhzD4kRkuDsqjxM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240503204658-d98e786cb9e6/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240505184837-87fec8c772eb h1:8J1lSVWhZ3igyzxjN6R2L5exMOvr1Jp/uPZa5CeccKI=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240505184837-87fec8c772eb/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -225,19 +225,19 @@ func parseTexToImageRequestInputs(ctx context.Context, req TriggerNamespaceModel
 	}
 	pargedImages, parsedImageErr := parseImageRequestInputsToBytes(ctx, req)
 	for idx, taskInput := range req.GetTaskInputs() {
-		steps := utils.TextToImageSteps
+		steps := utils.ToImageSteps
 		if taskInput.GetTextToImage().Steps != nil {
 			steps = *taskInput.GetTextToImage().Steps
 		}
-		cfgScale := utils.ImageToTextCFGScale
+		cfgScale := utils.ToImageCFGScale
 		if taskInput.GetTextToImage().CfgScale != nil {
 			cfgScale = *taskInput.GetTextToImage().CfgScale
 		}
-		seed := utils.ImageToTextSeed
+		seed := utils.ToImageSeed
 		if taskInput.GetTextToImage().Seed != nil {
 			seed = *taskInput.GetTextToImage().Seed
 		}
-		samples := utils.ImageToTextSamples
+		samples := utils.ToImageSamples
 		if taskInput.GetTextToImage().Samples != nil {
 			samples = *taskInput.GetTextToImage().Samples
 		}
@@ -279,19 +279,19 @@ func parseImageToImageRequestInputs(ctx context.Context, req TriggerNamespaceMod
 	}
 	pargedImages, parsedImageErr := parseImageRequestInputsToBytes(ctx, req)
 	for idx, taskInput := range req.GetTaskInputs() {
-		steps := utils.TextToImageSteps
+		steps := utils.ToImageSteps
 		if taskInput.GetImageToImage().Steps != nil {
 			steps = *taskInput.GetImageToImage().Steps
 		}
-		cfgScale := utils.ImageToTextCFGScale
+		cfgScale := utils.ToImageCFGScale
 		if taskInput.GetImageToImage().CfgScale != nil {
 			cfgScale = *taskInput.GetImageToImage().CfgScale
 		}
-		seed := utils.ImageToTextSeed
+		seed := utils.ToImageSeed
 		if taskInput.GetImageToImage().Seed != nil {
 			seed = *taskInput.GetImageToImage().Seed
 		}
-		samples := utils.ImageToTextSamples
+		samples := utils.ToImageSamples
 		if taskInput.GetImageToImage().Samples != nil {
 			samples = *taskInput.GetImageToImage().Samples
 		}
@@ -658,7 +658,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *r
 		return nil, fmt.Errorf("invalid samples input, only support a single samples")
 	}
 
-	step := utils.TextToImageSteps
+	step := utils.ToImageSteps
 	if len(stepStr) > 0 {
 		parseStep, err := strconv.ParseInt(stepStr[0], 10, 32)
 		if err != nil {
@@ -667,7 +667,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *r
 		step = int32(parseStep)
 	}
 
-	cfgScale := float64(utils.ImageToTextCFGScale)
+	cfgScale := float64(utils.ToImageCFGScale)
 	if len(cfgScaleStr) > 0 {
 		cfgScale, err = strconv.ParseFloat(cfgScaleStr[0], 32)
 		if err != nil {
@@ -675,7 +675,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *r
 		}
 	}
 
-	seed := utils.ImageToTextSeed
+	seed := utils.ToImageSeed
 	if len(seedStr) > 0 {
 		parseSeed, err := strconv.ParseInt(seedStr[0], 10, 32)
 		if err != nil {
@@ -684,7 +684,7 @@ func parseImageFormDataTextToImageInputs(req *http.Request) (textToImageInput *r
 		seed = int32(parseSeed)
 	}
 
-	samples := utils.ImageToTextSamples
+	samples := utils.ToImageSamples
 	if len(samplesStr) > 0 {
 		parseSamples, err := strconv.ParseInt(samplesStr[0], 10, 32)
 		if err != nil {
@@ -746,7 +746,7 @@ func parseImageFormDataImageToImageInputs(req *http.Request) (imageToImageInput 
 		return nil, fmt.Errorf("invalid samples input, only support a single samples")
 	}
 
-	step := utils.TextToImageSteps
+	step := utils.ToImageSteps
 	if len(stepStr) > 0 {
 		parseStep, err := strconv.ParseInt(stepStr[0], 10, 32)
 		if err != nil {
@@ -755,7 +755,7 @@ func parseImageFormDataImageToImageInputs(req *http.Request) (imageToImageInput 
 		step = int32(parseStep)
 	}
 
-	cfgScale := float64(utils.ImageToTextCFGScale)
+	cfgScale := float64(utils.ToImageCFGScale)
 	if len(cfgScaleStr) > 0 {
 		cfgScale, err = strconv.ParseFloat(cfgScaleStr[0], 32)
 		if err != nil {
@@ -763,7 +763,7 @@ func parseImageFormDataImageToImageInputs(req *http.Request) (imageToImageInput 
 		}
 	}
 
-	seed := utils.ImageToTextSeed
+	seed := utils.ToImageSeed
 	if len(seedStr) > 0 {
 		parseSeed, err := strconv.ParseInt(seedStr[0], 10, 32)
 		if err != nil {
@@ -772,7 +772,7 @@ func parseImageFormDataImageToImageInputs(req *http.Request) (imageToImageInput 
 		seed = int32(parseSeed)
 	}
 
-	samples := utils.ImageToTextSamples
+	samples := utils.ToImageSamples
 	if len(samplesStr) > 0 {
 		parseSamples, err := strconv.ParseInt(samplesStr[0], 10, 32)
 		if err != nil {

--- a/pkg/ray/const.go
+++ b/pkg/ray/const.go
@@ -12,6 +12,16 @@ type TextToImageInput struct {
 	ExtraParams string
 }
 
+func NewTextToImageInput() *TextToImageInput {
+	return &TextToImageInput{
+		Prompt:   "A cute cat, sleeping.",
+		Steps:    10,
+		CfgScale: 7,
+		Seed:     1024,
+		Samples:  1,
+	}
+}
+
 type ImageToImageInput struct {
 	Prompt      string
 	PromptImage string
@@ -20,6 +30,17 @@ type ImageToImageInput struct {
 	Seed        int32
 	Samples     int32
 	ExtraParams string
+}
+
+func NewImageToImageInput() *ImageToImageInput {
+	return &ImageToImageInput{
+		Prompt:      "cute dog",
+		PromptImage: "https://artifacts.instill.tech/imgs/dog.jpg",
+		Steps:       10,
+		CfgScale:    7,
+		Seed:        1024,
+		Samples:     1,
+	}
 }
 
 type TextGenerationInput struct {
@@ -34,6 +55,17 @@ type TextGenerationInput struct {
 	ExtraParams   string
 }
 
+func NewTextGenerationInput() *TextGenerationInput {
+	return &TextGenerationInput{
+		Prompt:        "Simply put, the theory of relativity states that",
+		SystemMessage: "You are a helpful assistant.",
+		MaxNewTokens:  50,
+		TopK:          10,
+		Temperature:   0.7,
+		Seed:          1024,
+	}
+}
+
 type TextGenerationChatInput struct {
 	Prompt        string
 	PromptImages  string
@@ -44,6 +76,17 @@ type TextGenerationChatInput struct {
 	TopK          int32
 	Seed          int32
 	ExtraParams   string
+}
+
+func NewTextGenerationChatInput() *TextGenerationChatInput {
+	return &TextGenerationChatInput{
+		Prompt:        "Who are you?",
+		SystemMessage: "You are a lovely cat, named Penguin.",
+		MaxNewTokens:  512,
+		TopK:          10,
+		Temperature:   0.7,
+		Seed:          1024,
+	}
 }
 
 type VisualQuestionAnsweringInput struct {
@@ -58,9 +101,27 @@ type VisualQuestionAnsweringInput struct {
 	ExtraParams   string
 }
 
+func NewVisualQuestionAnsweringInput() *VisualQuestionAnsweringInput {
+	return &VisualQuestionAnsweringInput{
+		Prompt:        "What is in the picture?",
+		PromptImages:  "https://artifacts.instill.tech/imgs/dog.jpg",
+		SystemMessage: "You are a helpful assistant.",
+		MaxNewTokens:  512,
+		Temperature:   0.7,
+		TopK:          10,
+		Seed:          1024,
+	}
+}
+
 type ImageInput struct {
 	ImgURL    string
 	ImgBase64 string
+}
+
+func NewImageInput() *ImageInput {
+	return &ImageInput{
+		ImgURL: "https://artifacts.instill.tech/imgs/dog.jpg",
+	}
 }
 
 type DetectionOutput struct {

--- a/pkg/ray/preprocess.go
+++ b/pkg/ray/preprocess.go
@@ -24,13 +24,10 @@ func PreProcess(modelName string, version string, inferInput InferInput, task co
 		case commonPB.Task_TASK_VISUAL_QUESTION_ANSWERING,
 			commonPB.Task_TASK_TEXT_GENERATION_CHAT,
 			commonPB.Task_TASK_TEXT_GENERATION:
-			var inputShape []int64
-			inputShape = []int64{1}
-
 			inferInputs = append(inferInputs, &rayserver.InferTensor{
 				Name:     modelMetadata.Inputs[i].Name,
 				Datatype: modelMetadata.Inputs[i].Datatype,
-				Shape:    inputShape,
+				Shape:    []int64{1},
 			})
 		case commonPB.Task_TASK_CLASSIFICATION,
 			commonPB.Task_TASK_DETECTION,

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -114,6 +114,10 @@ func (s *service) DBToPBModel(ctx context.Context, modelDef *datamodel.ModelDefi
 		License:          dbModel.License,
 	}
 
+	if err := appendSampleInputOutput(&pbModel); err != nil {
+		return nil, err
+	}
+
 	return &pbModel, nil
 }
 
@@ -185,4 +189,296 @@ func (s *service) DBToPBModelDefinitions(ctx context.Context, dbModelDefinitions
 	}
 
 	return pbModelDefinitions, nil
+}
+
+func appendSampleInputOutput(pbModel *modelPB.Model) error {
+	steps := int32(10)
+	cfgScale := float32(7)
+	samples := int32(1)
+	maxNewTokens := int32(512)
+	topK := int32(10)
+	temperature := float32(0.7)
+	seed := int32(1024)
+
+	sampleInput := modelPB.TaskInput{}
+	sampleOutput := modelPB.TaskOutput{}
+	switch pbModel.Task {
+	case commonPB.Task_TASK_CLASSIFICATION:
+		sampleInput.Input = &modelPB.TaskInput_Classification{
+			Classification: &modelPB.ClassificationInput{
+				Type: &modelPB.ClassificationInput_ImageUrl{
+					ImageUrl: "https://artifacts.instill.tech/imgs/dog.jpg",
+				},
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_Classification{
+			Classification: &modelPB.ClassificationOutput{
+				Category: "golden retriever",
+				Score:    0.98,
+			},
+		}
+	case commonPB.Task_TASK_DETECTION:
+		sampleInput.Input = &modelPB.TaskInput_Detection{
+			Detection: &modelPB.DetectionInput{
+				Type: &modelPB.DetectionInput_ImageUrl{
+					ImageUrl: "https://artifacts.instill.tech/imgs/dog.jpg",
+				},
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_Detection{
+			Detection: &modelPB.DetectionOutput{
+				Objects: []*modelPB.DetectionObject{
+					{
+						Category: "dog",
+						Score:    0.9582795,
+						BoundingBox: &modelPB.BoundingBox{
+							Top:    102,
+							Left:   324,
+							Width:  208,
+							Height: 403,
+						},
+					},
+					{
+						Category: "dog",
+						Score:    0.9457829,
+						BoundingBox: &modelPB.BoundingBox{
+							Top:    198,
+							Left:   130,
+							Width:  198,
+							Height: 236,
+						},
+					},
+				},
+			},
+		}
+	case commonPB.Task_TASK_KEYPOINT:
+		sampleInput.Input = &modelPB.TaskInput_Keypoint{
+			Keypoint: &modelPB.KeypointInput{
+				Type: &modelPB.KeypointInput_ImageUrl{
+					ImageUrl: "https://artifacts.instill.tech/imgs/dance.jpg",
+				},
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_Keypoint{
+			Keypoint: &modelPB.KeypointOutput{
+				Objects: []*modelPB.KeypointObject{
+					{
+						Keypoints: []*modelPB.Keypoint{
+							{
+								X: 542.82764,
+								Y: 86.63817,
+								V: 0.53722847,
+							},
+							{
+								X: 553.0073,
+								Y: 79.440636,
+								V: 0.634061,
+							},
+						},
+						Score: 0.94,
+						BoundingBox: &modelPB.BoundingBox{
+							Top:    86,
+							Left:   185,
+							Width:  571,
+							Height: 203,
+						},
+					},
+				},
+			},
+		}
+	case commonPB.Task_TASK_OCR:
+		sampleInput.Input = &modelPB.TaskInput_Ocr{
+			Ocr: &modelPB.OcrInput{
+				Type: &modelPB.OcrInput_ImageUrl{
+					ImageUrl: "https://artifacts.instill.tech/imgs/sign-small.jpg",
+				},
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_Ocr{
+			Ocr: &modelPB.OcrOutput{
+				Objects: []*modelPB.OcrObject{
+					{
+						Text:  "ENDS",
+						Score: 0.99,
+						BoundingBox: &modelPB.BoundingBox{
+							Top:    298,
+							Left:   279,
+							Width:  134,
+							Height: 59,
+						},
+					},
+					{
+						Text:  "PAVEMENT",
+						Score: 0.99,
+						BoundingBox: &modelPB.BoundingBox{
+							Top:    228,
+							Left:   216,
+							Width:  255,
+							Height: 65,
+						},
+					},
+				},
+			},
+		}
+	case commonPB.Task_TASK_INSTANCE_SEGMENTATION:
+		sampleInput.Input = &modelPB.TaskInput_InstanceSegmentation{
+			InstanceSegmentation: &modelPB.InstanceSegmentationInput{
+				Type: &modelPB.InstanceSegmentationInput_ImageUrl{
+					ImageUrl: "https://artifacts.instill.tech/imgs/dog.jpg",
+				},
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_InstanceSegmentation{
+			InstanceSegmentation: &modelPB.InstanceSegmentationOutput{
+				Objects: []*modelPB.InstanceSegmentationObject{
+					{
+						Score: 0.99,
+						BoundingBox: &modelPB.BoundingBox{
+							Top:    95,
+							Left:   320,
+							Width:  215,
+							Height: 406,
+						},
+						Category: "dog",
+						Rle:      "472,26,35,31,31,34,28,35,27,36,25,37,25,37,24,37,24,38,23,39,23,40,22,40,22,41,21,41,21,41,21,40,22,39,22,40,22,39,23,39,23,39,24,38,25,37,26,35,28,32,31,29,34,27,36,26,37,25,38,25,38,24,39,23,40,21,42,16,47,11,53,8,55,7,50",
+					},
+					{
+						Score: 0.97,
+						BoundingBox: &modelPB.BoundingBox{
+							Top:    194,
+							Left:   130,
+							Width:  197,
+							Height: 248,
+						},
+						Category: "dog",
+						Rle:      "158,43,22,45,20,47,19,48,18,49,17,50,16,51,13,54,9,58,6,60,6,60,6,60,7,59,8,59,8,58,9,57,9,56,11,48,19,45,22,44,23,43,25,41,26,40,28,38,30,35,34,25,168",
+					},
+				},
+			},
+		}
+	case commonPB.Task_TASK_SEMANTIC_SEGMENTATION:
+		sampleInput.Input = &modelPB.TaskInput_SemanticSegmentation{
+			SemanticSegmentation: &modelPB.SemanticSegmentationInput{
+				Type: &modelPB.SemanticSegmentationInput_ImageUrl{
+					ImageUrl: "https://artifacts.instill.tech/imgs/dog.jpg",
+				},
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_SemanticSegmentation{
+			SemanticSegmentation: &modelPB.SemanticSegmentationOutput{
+				Stuffs: []*modelPB.SemanticSegmentationStuff{
+					{
+						Rle:      "472,26,35,31,31,34,28,35,27,36,25,37,25,37,24,37,24,38,23,39,23,40,22,40,22,41,21,41,21,41,21,40,22,39,22,40,22,39,23,39,23,39,24,38,25,37,26,35,28,32,31,29,34,27,36,26,37,25,38,25,38,24,39,23,40,21,42,16,47,11,53,8,55,7,50",
+						Category: "person",
+					},
+					{
+						Rle:      "158,43,22,45,20,47,19,48,18,49,17,50,16,51,13,54,9,58,6,60,6,60,6,60,7,59,8,59,8,58,9,57,9,56,11,48,19,45,22,44,23,43,25,41,26,40,28,38,30,35,34,25,168",
+						Category: "sky",
+					},
+				},
+			},
+		}
+	case commonPB.Task_TASK_TEXT_TO_IMAGE:
+
+		sampleInput.Input = &modelPB.TaskInput_TextToImage{
+			TextToImage: &modelPB.TextToImageInput{
+				Prompt:   "A stunning landscape with metropolitan view",
+				CfgScale: &cfgScale,
+				Steps:    &steps,
+				Samples:  &samples,
+				Seed:     &seed,
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_TextToImage{
+			TextToImage: &modelPB.TextToImageOutput{
+				Images: []string{
+					"/9j/4AAQSkZJRgABAQAAAQABAAD/...",
+					"/9j/2wCEAAEBAQEBAQEFKEPOFAFD...",
+				},
+			},
+		}
+	case commonPB.Task_TASK_IMAGE_TO_IMAGE:
+		prompt := "cute dog"
+		sampleInput.Input = &modelPB.TaskInput_ImageToImage{
+			ImageToImage: &modelPB.ImageToImageInput{
+				Prompt: &prompt,
+				Type: &modelPB.ImageToImageInput_PromptImageUrl{
+					PromptImageUrl: "https://artifacts.instill.tech/imgs/dog.jpg",
+				},
+				CfgScale: &cfgScale,
+				Steps:    &steps,
+				Samples:  &samples,
+				Seed:     &seed,
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_ImageToImage{
+			ImageToImage: &modelPB.ImageToImageOutput{
+				Images: []string{
+					"/9j/4AAQSkZJRgABAQAAAQABAAD/...",
+				},
+			},
+		}
+	case commonPB.Task_TASK_TEXT_GENERATION:
+		systemMessage := "You are a helpful assistant."
+		sampleInput.Input = &modelPB.TaskInput_TextGeneration{
+			TextGeneration: &modelPB.TextGenerationInput{
+				Prompt:        "The winds of change",
+				SystemMessage: &systemMessage,
+				MaxNewTokens:  &maxNewTokens,
+				TopK:          &topK,
+				Temperature:   &temperature,
+				Seed:          &seed,
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_TextGeneration{
+			TextGeneration: &modelPB.TextGenerationOutput{
+				Text: "The winds of change are blowing strong, bring new beginnings, righting wrongs. The world around us is constantly turning, and with each sunrise, our spirits are yearning.",
+			},
+		}
+	case commonPB.Task_TASK_TEXT_GENERATION_CHAT:
+		systemMessage := "You are a lovely cat, named Penguin."
+		sampleInput.Input = &modelPB.TaskInput_TextGenerationChat{
+			TextGenerationChat: &modelPB.TextGenerationChatInput{
+				Prompt:        "Who are you?",
+				SystemMessage: &systemMessage,
+				MaxNewTokens:  &maxNewTokens,
+				TopK:          &topK,
+				Temperature:   &temperature,
+				Seed:          &seed,
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_TextGenerationChat{
+			TextGenerationChat: &modelPB.TextGenerationChatOutput{
+				Text: "*rubs against leg* Oh, hello there! My name is Penguin, and I'm a lovely cat. I'm a bit of a gentle soul, with soft gray fur and bright green eyes. I love to lounge in the sunbeams that stream through the windows, chase the occasional fly, and purr contentedly as I watch the world go by. I'm a bit of a cuddlebug, too - I adore being petted and snuggled, and I'll often curl up in my human's lap for a good nap.",
+			},
+		}
+	case commonPB.Task_TASK_VISUAL_QUESTION_ANSWERING:
+		systemMessage := "You are a helpful assistant."
+		sampleInput.Input = &modelPB.TaskInput_VisualQuestionAnswering{
+			VisualQuestionAnswering: &modelPB.VisualQuestionAnsweringInput{
+				Prompt: "What is in the picture?",
+				PromptImages: []*modelPB.PromptImage{
+					{
+						Type: &modelPB.PromptImage_PromptImageUrl{
+							PromptImageUrl: "https://artifacts.instill.tech/imgs/dog.jpg",
+						},
+					},
+				},
+				SystemMessage: &systemMessage,
+				MaxNewTokens:  &maxNewTokens,
+				TopK:          &topK,
+				Temperature:   &temperature,
+				Seed:          &seed,
+			},
+		}
+		sampleOutput.Output = &modelPB.TaskOutput_VisualQuestionAnswering{
+			VisualQuestionAnswering: &modelPB.VisualQuestionAnsweringOutput{
+				Text: "The picture shows two dogs standing in a snowy outdoor setting. The dog on the left appears to be a young Labrador Retriever puppy with a light cream or yellowish coat, while the dog on the right is an adult",
+			},
+		}
+	}
+	pbModel.SampleInput = &sampleInput
+	pbModel.SampleOutput = &sampleOutput
+
+	return nil
 }

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -114,9 +114,7 @@ func (s *service) DBToPBModel(ctx context.Context, modelDef *datamodel.ModelDefi
 		License:          dbModel.License,
 	}
 
-	if err := appendSampleInputOutput(&pbModel); err != nil {
-		return nil, err
-	}
+	appendSampleInputOutput(&pbModel)
 
 	return &pbModel, nil
 }
@@ -191,7 +189,7 @@ func (s *service) DBToPBModelDefinitions(ctx context.Context, dbModelDefinitions
 	return pbModelDefinitions, nil
 }
 
-func appendSampleInputOutput(pbModel *modelPB.Model) error {
+func appendSampleInputOutput(pbModel *modelPB.Model) {
 	steps := int32(10)
 	cfgScale := float32(7)
 	samples := int32(1)
@@ -479,6 +477,4 @@ func appendSampleInputOutput(pbModel *modelPB.Model) error {
 	}
 	pbModel.SampleInput = &sampleInput
 	pbModel.SampleOutput = &sampleOutput
-
-	return nil
 }

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -71,10 +71,10 @@ var UnmarshalOptions protojson.UnmarshalOptions = protojson.UnmarshalOptions{
 const DefaultPageSize = 10
 
 const (
-	TextToImageSteps    = int32(10)
-	ImageToTextCFGScale = float32(7)
-	ImageToTextSeed     = int32(1024)
-	ImageToTextSamples  = int32(1)
+	ToImageSteps    = int32(10)
+	ToImageCFGScale = float32(7)
+	ToImageSeed     = int32(1024)
+	ToImageSamples  = int32(1)
 )
 
 const (


### PR DESCRIPTION
Because

- allow FE to show sample input/output payload on overview page

This commit

- embed sample input/output in model proto message
