### PR TITLE
feat(handler): support listing available regions for model deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240506211529-26ea3855f779
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240510094646-941cbdea450d
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1313,8 +1313,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240506211529-26ea3855f779 h1:yfZ+rA5cgdQmkBGasftS+A2GGiR1ekYUGQQUfdXuzhc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240506211529-26ea3855f779/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240510094646-941cbdea450d h1:b/8lTzrkg+iaN5OKuXWSXE8HOydImKzrmuxUkLVHgiE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240510094646-941cbdea450d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/datamodel/jsonschema.go
+++ b/pkg/datamodel/jsonschema.go
@@ -29,6 +29,36 @@ var GCSUserAccountJSONSchema *jsonschema.Schema
 // GCSServiceAccountJSONSchema represents the GCS Service Account JSON Schema for validating the payload
 var GCSServiceAccountJSONSchema *jsonschema.Schema
 
+var RegionHardwareJSON RegionHardware
+
+type RegionHardware struct {
+	Properties struct {
+		Region struct {
+			OneOf []struct {
+				Const string `json:"const"`
+				Title string `json:"title"`
+			}
+		}
+		Hardware struct {
+			OneOf []struct {
+				If struct {
+					Properties struct {
+						Region struct {
+							Const string `json:"const"`
+						}
+					}
+				}
+				Then struct {
+					OneOf []struct {
+						Const string `json:"const"`
+						Title string `json:"title"`
+					}
+				}
+			}
+		}
+	}
+}
+
 // InitJSONSchema initializes JSON Schema instances with the given files
 func InitJSONSchema(ctx context.Context) {
 
@@ -92,6 +122,13 @@ func InitJSONSchema(ctx context.Context) {
 
 	ModelJSONSchema, err = compiler.Compile("config/model/model.json")
 	if err != nil {
+		logger.Fatal(fmt.Sprintf("%#v\n", err.Error()))
+	}
+	modelJSONFile, err := os.ReadFile("config/model/model.json")
+	if err != nil {
+		logger.Fatal(fmt.Sprintf("%#v\n", err.Error()))
+	}
+	if err := json.Unmarshal(modelJSONFile, &RegionHardwareJSON); err != nil {
 		logger.Fatal(fmt.Sprintf("%#v\n", err.Error()))
 	}
 


### PR DESCRIPTION
Because

- We need to provide the info about supported regions and hardware for FE to render the model creation page

This commit

- add list available region method