### PR TITLE
chore(spec): fix wrong hardware schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ model-backend
 # local protogen-go
 protogen-go
 
+# deploy config file
+deploy.yaml
+
 # air related files and folders
 .air.toml
 tmp

--- a/config/model/model.json
+++ b/config/model/model.json
@@ -119,6 +119,11 @@
           "const": "REGION_GCP_EUROPE_WEST4",
           "instillShortDescription": "Deploy model onto GCP in Europe West4 region",
           "title": "GCP europe-west4"
+        },
+        {
+          "const": "REGION_LOCAL",
+          "instillShortDescription": "Deploy model on self-hosted instill-core",
+          "title": "Self-host Instill Core"
         }
       ]
     },
@@ -140,6 +145,11 @@
                 "title": "CPU"
               },
               {
+                "const": "GPU",
+                "instillShortDescription": "Deploy model that runs on CPU",
+                "title": "GPU"
+              },
+              {
                 "const": "NVIDIA_TESLA_T4",
                 "instillShortDescription": "Deploy model that runs on Nvidia T4 GPU",
                 "title": "Nvidia Tesla T4"
@@ -155,6 +165,21 @@
                 "title": "NVIDIA A100"
               }
             ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "region": {
+                "const": "REGION_LOCAL"
+              }
+            }
+          },
+          "then": {
+            "type": "string",
+            "title": "Hardware type",
+            "maxLength": 63,
+            "description": "Fill with the desire hardware type to deploy your model on. If you are not sure, use `CPU` or `GPU`"
           }
         }
       ]

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -279,10 +279,17 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 	}
 
 	// TODO: Support custom resource configs for deployment in the future
-	runOptions = append(runOptions,
-		fmt.Sprintf("-e %s=%v", EnvNumOfMinReplicas, 0),
-		fmt.Sprintf("-e %s=%v", EnvNumOfMaxReplicas, 5),
-	)
+	if userID == "instill-ai" {
+		runOptions = append(runOptions,
+			fmt.Sprintf("-e %s=%v", EnvNumOfMinReplicas, 1),
+			fmt.Sprintf("-e %s=%v", EnvNumOfMaxReplicas, 1),
+		)
+	} else {
+		runOptions = append(runOptions,
+			fmt.Sprintf("-e %s=%v", EnvNumOfMinReplicas, 0),
+			fmt.Sprintf("-e %s=%v", EnvNumOfMaxReplicas, 1),
+		)
+	}
 
 	applicationConfig := Application{
 		Name:        applicationMetadatValue,


### PR DESCRIPTION
Because

- Current spec schema blocks custom resource

This commit

- allow creating model with custom resource tag in local cluster
