### PR TITLE
chore(ray): update default num of gpu

### DIFF
--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -256,7 +256,8 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 		if !ok {
 			logger.Warn("accelerator type(hardware) not supported, setting it as custom resource")
 			runOptions = append(runOptions,
-				fmt.Sprintf("-e %s=%v", EnvNumOfGPUs, 0.5),
+				fmt.Sprintf("-e %s=%v", EnvTotalVRAM, config.Config.RayServer.Vram),
+				fmt.Sprintf("-e %s=%v", EnvNumOfGPUs, 1),
 				fmt.Sprintf("-e %s=%s", EnvRayCustomResource, hardware),
 				"--device nvidia.com/gpu=all",
 			)
@@ -265,7 +266,8 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 				runOptions = append(runOptions, fmt.Sprintf("-e %s=%v", EnvNumOfCPUs, 2))
 			} else if accelerator == SupportedAcceleratorType["GPU"] {
 				runOptions = append(runOptions,
-					fmt.Sprintf("-e %s=%v", EnvNumOfGPUs, 0.5),
+					fmt.Sprintf("-e %s=%v", EnvTotalVRAM, config.Config.RayServer.Vram),
+					fmt.Sprintf("-e %s=%v", EnvNumOfGPUs, 1),
 					"--device nvidia.com/gpu=all",
 				)
 			} else {


### PR DESCRIPTION
Because

- We do not assume for the user how much vram does their model use

This commit

- set default num of gpu for generic gpu type to `1`
- allow setting total vram as config
