### PR TITLE
chore(service): fix update model

### DIFF
--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -1,7 +1,7 @@
 package handler
 
 // immutableFields are Protobuf message fields with IMMUTABLE field_behavior annotation
-var immutableFields = []string{"id", "model_definition", "configuration", "task"}
+var immutableFields = []string{"id", "model_definition", "configuration", "task", "visibility", "region"}
 
 // outputOnlyFields are Protobuf message fields with OUTPUT_ONLY field_behavior annotation
 var outputOnlyFields = []string{"name", "uid", "ownerName", "owner", "create_time", "update_time", "delete_time"}

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -32,6 +32,12 @@ import (
 
 func (s *service) compressProfileImage(profileImage string) (string, error) {
 
+	// Due to the local env, we don't set the `InstillCoreHost` config, the avatar path is not working.
+	// As a workaround, if the profileAvatar is not a base64 string, we ignore the avatar.
+	if !strings.HasPrefix(profileImage, "data:") {
+		return "", nil
+	}
+
 	profileImageStr := strings.Split(profileImage, ",")
 	b, err := base64.StdEncoding.DecodeString(profileImageStr[len(profileImageStr)-1])
 	if err != nil {


### PR DESCRIPTION
Because

- Patch model will result in error due to image string
- Patch model hardware won't trigger redeployment
- Visibility now only support changing through publish/unpublish endpoints, will be refactored soon

This commit

- fix update model behaviors
