### PR TITLE
chore(datamodel): use sql nullstring type for string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240513200432-b7987c15fd74
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240516204150-9fe7016753ed
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1314,8 +1314,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240513200432-b7987c15fd74 h1:LJL0cirO1c9rOfN/8qmhBabSivQ7pliMjkC19vs6L6Y=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240513200432-b7987c15fd74/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240516204150-9fe7016753ed h1:w//eTrCswd6yKfoOOuynpDCQjdpEco9SiIJ/sX6eM0A=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240516204150-9fe7016753ed/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -79,10 +79,10 @@ type Model struct {
 	Task               ModelTask
 	Region             string
 	Hardware           string
-	Readme             string
-	SourceURL          string
-	DocumentationURL   string
-	License            string
+	Readme             sql.NullString
+	SourceURL          sql.NullString
+	DocumentationURL   sql.NullString
+	License            sql.NullString
 	ProfileImage       sql.NullString
 }
 

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -113,14 +113,26 @@ func (s *service) PBToDBModel(ctx context.Context, ns resource.Namespace, pbMode
 			String: pbModel.GetDescription(),
 			Valid:  true,
 		},
-		Task:             datamodel.ModelTask(pbModel.GetTask()),
-		Visibility:       datamodel.ModelVisibility(pbModel.GetVisibility()),
-		Region:           pbModel.GetRegion(),
-		Hardware:         pbModel.GetHardware(),
-		Readme:           pbModel.GetReadme(),
-		SourceURL:        pbModel.GetSourceUrl(),
-		DocumentationURL: pbModel.GetDocumentationUrl(),
-		License:          pbModel.GetLicense(),
+		Task:       datamodel.ModelTask(pbModel.GetTask()),
+		Visibility: datamodel.ModelVisibility(pbModel.GetVisibility()),
+		Region:     pbModel.GetRegion(),
+		Hardware:   pbModel.GetHardware(),
+		Readme: sql.NullString{
+			String: pbModel.GetReadme(),
+			Valid:  true,
+		},
+		SourceURL: sql.NullString{
+			String: pbModel.GetSourceUrl(),
+			Valid:  true,
+		},
+		DocumentationURL: sql.NullString{
+			String: pbModel.GetDocumentationUrl(),
+			Valid:  true,
+		},
+		License: sql.NullString{
+			String: pbModel.GetLicense(),
+			Valid:  true,
+		},
 		ProfileImage: sql.NullString{
 			String: profileImage,
 			Valid:  len(profileImage) > 0,
@@ -173,9 +185,9 @@ func (s *service) DBToPBModel(ctx context.Context, modelDef *datamodel.ModelDefi
 		Owner:            owner,
 		Region:           dbModel.Region,
 		Hardware:         dbModel.Hardware,
-		SourceUrl:        dbModel.SourceURL,
-		DocumentationUrl: dbModel.DocumentationURL,
-		License:          dbModel.License,
+		SourceUrl:        &dbModel.SourceURL.String,
+		DocumentationUrl: &dbModel.DocumentationURL.String,
+		License:          &dbModel.License.String,
 		ProfileImage:     &profileImage,
 	}
 


### PR DESCRIPTION
Because

- If patch model field is nil, db record will not be updated

This commit

- use sql nullstring as type for string fields
