### PR TITLE
chore(ray): set custom resource along with acc type

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,7 +89,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: instill-ai/instill-core
-          ref: update-ray-infra
 
       - name: Load .env file (instill-core)
         uses: cardinalby/export-env-action@v2

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -273,6 +273,7 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 			} else {
 				runOptions = append(runOptions,
 					fmt.Sprintf("-e %s=%s", EnvRayAcceleratorType, accelerator),
+					fmt.Sprintf("-e %s=%s", EnvRayCustomResource, hardware),
 					fmt.Sprintf("-e %s=%v", EnvTotalVRAM, SupportedAcceleratorTypeMemory[hardware]),
 					"--device nvidia.com/gpu=all",
 				)


### PR DESCRIPTION
Because

- accelerator type default to fractional of `0.001` and its causing auto-scaling problems

This commit

- set custom resource label along with accelerator type
