### PR TITLE
chore(service): fix missing readme in response

### DIFF
--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -192,6 +192,7 @@ func (s *service) DBToPBModel(ctx context.Context, modelDef *datamodel.ModelDefi
 		SourceUrl:        &dbModel.SourceURL.String,
 		DocumentationUrl: &dbModel.DocumentationURL.String,
 		License:          &dbModel.License.String,
+		Readme:           &dbModel.Readme.String,
 		ProfileImage:     &profileImage,
 	}
 


### PR DESCRIPTION
Because

- We are missing `readme` in the GET model response

This commit

- add missing `readme` field in conversion
