### PR TITLE
chore(ray): revert forcing custom resource label

### DIFF
--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -273,7 +273,6 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 			} else {
 				runOptions = append(runOptions,
 					fmt.Sprintf("-e %s=%s", EnvRayAcceleratorType, accelerator),
-					fmt.Sprintf("-e %s=%s", EnvRayCustomResource, hardware),
 					fmt.Sprintf("-e %s=%v", EnvTotalVRAM, SupportedAcceleratorTypeMemory[hardware]),
 					"--device nvidia.com/gpu=all",
 				)


### PR DESCRIPTION
Because

- Force custom resource label on ray application has not effect on auto-scaling issue

This commit

- revert commit https://github.com/instill-ai/model-backend/commit/ea5a85ede67da92ce8aa824f7b97109ac302de7f
