### PR TITLE
chore(ray): replace acc type with custom resource

### DIFF
--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -272,7 +272,8 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 				)
 			} else {
 				runOptions = append(runOptions,
-					fmt.Sprintf("-e %s=%s", EnvRayAcceleratorType, accelerator),
+					// fmt.Sprintf("-e %s=%s", EnvRayAcceleratorType, accelerator),
+					fmt.Sprintf("-e %s=%s", EnvRayCustomResource, hardware),
 					fmt.Sprintf("-e %s=%v", EnvTotalVRAM, SupportedAcceleratorTypeMemory[hardware]),
 					"--device nvidia.com/gpu=all",
 				)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -52,7 +52,7 @@ type Repository interface {
 	GetModelVersionByID(ctx context.Context, modelUID uuid.UUID, versionID string) (version *datamodel.ModelVersion, err error)
 	GetLatestModelVersionByModelUID(ctx context.Context, modelUID uuid.UUID) (version *datamodel.ModelVersion, err error)
 	DeleteModelVersion(ctx context.Context, ownerPermalink string, version *datamodel.ModelVersion) error
-	ListModelVerions(ctx context.Context, modelUID uuid.UUID) (versions []*datamodel.ModelVersion, err error)
+	ListModelVersions(ctx context.Context, modelUID uuid.UUID) (versions []*datamodel.ModelVersion, err error)
 
 	CreateModelPrediction(ctx context.Context, prediction *datamodel.ModelPrediction) error
 }
@@ -426,7 +426,7 @@ func (r *repository) GetModelVersionByID(ctx context.Context, modelUID uuid.UUID
 	return version, nil
 }
 
-func (r *repository) ListModelVerions(ctx context.Context, modelUID uuid.UUID) (versions []*datamodel.ModelVersion, err error) {
+func (r *repository) ListModelVersions(ctx context.Context, modelUID uuid.UUID) (versions []*datamodel.ModelVersion, err error) {
 	db := r.checkPinnedUser(ctx, r.db, "model")
 
 	if result := db.Model(&datamodel.ModelVersion{}).Where("model_uid", modelUID).Find(&versions); result.Error != nil {

--- a/pkg/service/mock_repository_test.go
+++ b/pkg/service/mock_repository_test.go
@@ -245,19 +245,19 @@ func (mr *MockRepositoryMockRecorder) ListModelDefinitions(arg0, arg1, arg2 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinitions", reflect.TypeOf((*MockRepository)(nil).ListModelDefinitions), arg0, arg1, arg2)
 }
 
-// ListModelVerions mocks base method.
-func (m *MockRepository) ListModelVerions(arg0 context.Context, arg1 uuid.UUID) ([]*datamodel.ModelVersion, error) {
+// ListModelVersions mocks base method.
+func (m *MockRepository) ListModelVersions(arg0 context.Context, arg1 uuid.UUID) ([]*datamodel.ModelVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelVerions", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListModelVersions", arg0, arg1)
 	ret0, _ := ret[0].([]*datamodel.ModelVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListModelVerions indicates an expected call of ListModelVerions.
-func (mr *MockRepositoryMockRecorder) ListModelVerions(arg0, arg1 interface{}) *gomock.Call {
+// ListModelVersions indicates an expected call of ListModelVersions.
+func (mr *MockRepositoryMockRecorder) ListModelVersions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelVerions", reflect.TypeOf((*MockRepository)(nil).ListModelVerions), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelVersions", reflect.TypeOf((*MockRepository)(nil).ListModelVersions), arg0, arg1)
 }
 
 // ListModels mocks base method.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -721,7 +721,7 @@ func (s *service) DeleteNamespaceModelByID(ctx context.Context, ns resource.Name
 		return ErrNoPermission
 	}
 
-	versions, err := s.repository.ListModelVerions(ctx, dbModel.UID)
+	versions, err := s.repository.ListModelVersions(ctx, dbModel.UID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Because

- `accelerator_type` seems to cause auto-scaling issue

This commit

- replace acc type with custom resource
