### PR TITLE
feat(model): support watch latest model and `order_by` for list endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240523173832-a9412b87f7de
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240528180658-a8ebced10a42
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1314,8 +1314,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240523173832-a9412b87f7de h1:zf8KFMXqCbblG6Ezbv3RIDAySfZRRrtpfxMzVt62IHQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240523173832-a9412b87f7de/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240528180658-a8ebced10a42 h1:17S3vNvi+TzvYqZFpwHhGhiK03MHaiVoG+TblOWZjLQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240528180658-a8ebced10a42/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/handler/public.go
+++ b/pkg/handler/public.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/iancoleman/strcase"
 	"go.einride.tech/aip/filtering"
+	"go.einride.tech/aip/ordering"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -73,17 +74,23 @@ func (h *PublicHandler) ListModels(ctx context.Context, req *modelPB.ListModelsR
 	}...)
 	if err != nil {
 		span.SetStatus(1, err.Error())
-		return nil, err
+		return &modelPB.ListModelsResponse{}, err
 	}
 
 	filter, err := filtering.ParseFilter(req, declarations)
 	if err != nil {
 		span.SetStatus(1, err.Error())
-		return nil, err
+		return &modelPB.ListModelsResponse{}, err
 	}
 	visibility := req.GetVisibility()
 
-	pbModels, totalSize, nextPageToken, err := h.service.ListModels(ctx, req.GetPageSize(), req.GetPageToken(), parseView(req.GetView()), &visibility, filter, req.GetShowDeleted())
+	orderBy, err := ordering.ParseOrderBy(req)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return &modelPB.ListModelsResponse{}, err
+	}
+
+	pbModels, totalSize, nextPageToken, err := h.service.ListModels(ctx, req.GetPageSize(), req.GetPageToken(), parseView(req.GetView()), &visibility, filter, req.GetShowDeleted(), orderBy)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return &modelPB.ListModelsResponse{}, err
@@ -213,6 +220,7 @@ type ListNamespaceModelRequestInterface interface {
 	GetParent() string
 	GetFilter() string
 	GetVisibility() modelPB.Model_Visibility
+	GetOrderBy() string
 	GetShowDeleted() bool
 }
 
@@ -276,7 +284,13 @@ func (h *PublicHandler) listNamespaceModels(ctx context.Context, req ListNamespa
 	}
 	visibility := req.GetVisibility()
 
-	pbModels, totalSize, nextPageToken, err := h.service.ListNamespaceModels(ctx, ns, req.GetPageSize(), req.GetPageToken(), parseView(req.GetView()), &visibility, filter, req.GetShowDeleted())
+	orderBy, err := ordering.ParseOrderBy(req)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, "", 0, err
+	}
+
+	pbModels, totalSize, nextPageToken, err := h.service.ListNamespaceModels(ctx, ns, req.GetPageSize(), req.GetPageToken(), parseView(req.GetView()), &visibility, filter, req.GetShowDeleted(), orderBy)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, "", 0, err
@@ -859,6 +873,30 @@ func (h *PublicHandler) WatchOrganizationModel(ctx context.Context, req *modelPB
 	return resp, err
 }
 
+func (h *PublicHandler) WatchUserLatestModel(ctx context.Context, req *modelPB.WatchUserLatestModelRequest) (resp *modelPB.WatchUserLatestModelResponse, err error) {
+	resp = &modelPB.WatchUserLatestModelResponse{}
+
+	r := &modelPB.WatchUserModelRequest{
+		Name: req.GetName(),
+	}
+
+	resp.State, resp.Message, err = h.watchNamespaceModel(ctx, r)
+
+	return resp, err
+}
+
+func (h *PublicHandler) WatchOrganizationLatestModel(ctx context.Context, req *modelPB.WatchOrganizationLatestModelRequest) (resp *modelPB.WatchOrganizationLatestModelResponse, err error) {
+	resp = &modelPB.WatchOrganizationLatestModelResponse{}
+
+	r := &modelPB.WatchOrganizationModelRequest{
+		Name: req.GetName(),
+	}
+
+	resp.State, resp.Message, err = h.watchNamespaceModel(ctx, r)
+
+	return resp, err
+}
+
 func (h *PublicHandler) watchNamespaceModel(ctx context.Context, req WatchNamespaceModelRequestInterface) (modelPB.State, string, error) {
 
 	eventName := "WatchNamespaceModel"
@@ -890,7 +928,22 @@ func (h *PublicHandler) watchNamespaceModel(ctx context.Context, req WatchNamesp
 		return modelPB.State_STATE_ERROR, "", err
 	}
 
-	state, message, err := h.service.WatchModel(ctx, ns, modelID, req.GetVersion())
+	pbModel, err := h.service.GetNamespaceModelByID(ctx, ns, modelID, modelPB.View_VIEW_BASIC)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return modelPB.State_STATE_ERROR, "", err
+	}
+
+	versionID := req.GetVersion()
+	if versionID == "" {
+		version, err := h.service.GetRepository().GetLatestModelVersionByModelUID(ctx, uuid.FromStringOrNil(pbModel.Uid))
+		if err != nil {
+			return modelPB.State_STATE_ERROR, "", err
+		}
+		versionID = version.Version
+	}
+
+	state, message, err := h.service.WatchModel(ctx, ns, modelID, versionID)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		logger.Info(string(custom_otel.NewLogMessage(

--- a/pkg/repository/utils.go
+++ b/pkg/repository/utils.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+func transformBoolToDescString(b bool) string {
+	if b {
+		return " DESC"
+	}
+	return ""
+}
+
+// TODO: we should refactor this to have a flexible format and merge it into x package.
+
+// DecodeToken decodes the token string into create_time and UUID
+func DecodeToken(encodedToken string) (map[string]string, error) {
+	byt, err := base64.StdEncoding.DecodeString(encodedToken)
+	if err != nil {
+		return nil, err
+	}
+	tokens := map[string]string{}
+	err = json.Unmarshal(byt, &tokens)
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+// EncodeToken encodes create_time and UUID into a single string
+func EncodeToken(tokens map[string]string) (string, error) {
+	b, err := json.Marshal(tokens)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}

--- a/pkg/service/mock_repository_test.go
+++ b/pkg/service/mock_repository_test.go
@@ -13,6 +13,7 @@ import (
 	datamodel "github.com/instill-ai/model-backend/pkg/datamodel"
 	modelv1alpha "github.com/instill-ai/protogen-go/model/model/v1alpha"
 	filtering "go.einride.tech/aip/filtering"
+	ordering "go.einride.tech/aip/ordering"
 )
 
 // MockRepository is a mock of Repository interface.
@@ -261,9 +262,9 @@ func (mr *MockRepositoryMockRecorder) ListModelVersions(arg0, arg1 interface{}) 
 }
 
 // ListModels mocks base method.
-func (m *MockRepository) ListModels(arg0 context.Context, arg1 int64, arg2 string, arg3 bool, arg4 filtering.Filter, arg5 []uuid.UUID, arg6 bool) ([]*datamodel.Model, int64, string, error) {
+func (m *MockRepository) ListModels(arg0 context.Context, arg1 int64, arg2 string, arg3 bool, arg4 filtering.Filter, arg5 []uuid.UUID, arg6 bool, arg7 ordering.OrderBy) ([]*datamodel.Model, int64, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "ListModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].([]*datamodel.Model)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(string)
@@ -272,9 +273,9 @@ func (m *MockRepository) ListModels(arg0 context.Context, arg1 int64, arg2 strin
 }
 
 // ListModels indicates an expected call of ListModels.
-func (mr *MockRepositoryMockRecorder) ListModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModels", reflect.TypeOf((*MockRepository)(nil).ListModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModels", reflect.TypeOf((*MockRepository)(nil).ListModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // ListModelsAdmin mocks base method.
@@ -295,9 +296,9 @@ func (mr *MockRepositoryMockRecorder) ListModelsAdmin(arg0, arg1, arg2, arg3, ar
 }
 
 // ListNamespaceModels mocks base method.
-func (m *MockRepository) ListNamespaceModels(arg0 context.Context, arg1 string, arg2 int64, arg3 string, arg4 bool, arg5 filtering.Filter, arg6 []uuid.UUID, arg7 bool) ([]*datamodel.Model, int64, string, error) {
+func (m *MockRepository) ListNamespaceModels(arg0 context.Context, arg1 string, arg2 int64, arg3 string, arg4 bool, arg5 filtering.Filter, arg6 []uuid.UUID, arg7 bool, arg8 ordering.OrderBy) ([]*datamodel.Model, int64, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNamespaceModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "ListNamespaceModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].([]*datamodel.Model)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(string)
@@ -306,9 +307,9 @@ func (m *MockRepository) ListNamespaceModels(arg0 context.Context, arg1 string, 
 }
 
 // ListNamespaceModels indicates an expected call of ListNamespaceModels.
-func (mr *MockRepositoryMockRecorder) ListNamespaceModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListNamespaceModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaceModels", reflect.TypeOf((*MockRepository)(nil).ListNamespaceModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaceModels", reflect.TypeOf((*MockRepository)(nil).ListNamespaceModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 // UpdateNamespaceModelByID mocks base method.


### PR DESCRIPTION
Because

- Model hub page support `order_by` option
- Model banner needs to show latest model state

This commit

- implement `order_by` input query string
- add watch latest model endpoints

resolves INS-4775