### PR TITLE
chore(ray): show offline when replica number is 0

### DIFF
--- a/pkg/handler/payload.go
+++ b/pkg/handler/payload.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	_ "golang.org/x/image/tiff"
 
@@ -23,6 +24,11 @@ import (
 	custom_logger "github.com/instill-ai/model-backend/pkg/logger"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
+
+func trimBase64Mime(b64 string) string {
+	splitB64 := strings.Split(b64, ",")
+	return splitB64[len(splitB64)-1]
+}
 
 func parseImageFromURL(ctx context.Context, url string) (image.Image, error) {
 
@@ -67,6 +73,8 @@ func parseImageFromURL(ctx context.Context, url string) (image.Image, error) {
 func parseImageFromBase64(ctx context.Context, encoded string) (image.Image, error) {
 
 	logger, _ := custom_logger.GetZapLogger(ctx)
+
+	encoded = trimBase64Mime(encoded)
 
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -165,7 +165,11 @@ func (r *ray) ModelReady(ctx context.Context, modelName string, version string) 
 		for i := range application.Deployments {
 			switch application.Deployments[i].Status {
 			case rayserver.DeploymentStatusStrHealthy:
-				return modelPB.State_STATE_ACTIVE.Enum(), application.Deployments[i].Message, nil
+				if len(application.Deployments[i].Replicas) == 0 {
+					return modelPB.State_STATE_OFFLINE.Enum(), application.Deployments[i].Message, nil
+				} else {
+					return modelPB.State_STATE_ACTIVE.Enum(), application.Deployments[i].Message, nil
+				}
 			case rayserver.DeploymentStatusStrUpdating:
 				return modelPB.State_STATE_UNSPECIFIED.Enum(), application.Deployments[i].Message, nil
 			case rayserver.DeploymentStatusStrUpscaling, rayserver.DeploymentStatusStrDownscaling:


### PR DESCRIPTION
Because

- State should be `Offline` when there is 0 replica of a certain model version
- BE should handle `image_base64` input with mime type

This commit

- update ray application status
- trim mime from `base64` string
