### PR TITLE
chore(handler): allow visibility patch and fix hardware update

### DIFF
--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -1,7 +1,7 @@
 package handler
 
 // immutableFields are Protobuf message fields with IMMUTABLE field_behavior annotation
-var immutableFields = []string{"id", "model_definition", "configuration", "task", "visibility", "region"}
+var immutableFields = []string{"id", "model_definition", "configuration", "task", "region"}
 
 // outputOnlyFields are Protobuf message fields with OUTPUT_ONLY field_behavior annotation
 var outputOnlyFields = []string{"name", "uid", "ownerName", "owner", "create_time", "update_time", "delete_time"}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -65,7 +65,7 @@ type Service interface {
 	CreateNamespaceModel(ctx context.Context, ns resource.Namespace, model *datamodel.Model) error
 	DeleteNamespaceModelByID(ctx context.Context, ns resource.Namespace, modelID string) error
 	RenameNamespaceModelByID(ctx context.Context, ns resource.Namespace, modelID string, newModelID string) (*modelPB.Model, error)
-	UpdateNamespaceModelByID(ctx context.Context, ns resource.Namespace, modelID string, model *modelPB.Model, reDeploy bool) (*modelPB.Model, error)
+	UpdateNamespaceModelByID(ctx context.Context, ns resource.Namespace, modelID string, model *modelPB.Model) (*modelPB.Model, error)
 	ListNamespaceModelVersions(ctx context.Context, ns resource.Namespace, page int32, pageSize int32, modelID string) ([]*modelPB.ModelVersion, int32, int32, int32, error)
 	WatchModel(ctx context.Context, ns resource.Namespace, modelID string, version string) (*modelPB.State, string, error)
 
@@ -782,7 +782,7 @@ func (s *service) RenameNamespaceModelByID(ctx context.Context, ns resource.Name
 	return s.DBToPBModel(ctx, modelDef, updatedDBModel, modelPB.View_VIEW_BASIC, true)
 }
 
-func (s *service) UpdateNamespaceModelByID(ctx context.Context, ns resource.Namespace, modelID string, toUpdateModel *modelPB.Model, reDeploy bool) (*modelPB.Model, error) {
+func (s *service) UpdateNamespaceModelByID(ctx context.Context, ns resource.Namespace, modelID string, toUpdateModel *modelPB.Model) (*modelPB.Model, error) {
 
 	ownerPermalink := ns.Permalink()
 
@@ -832,7 +832,7 @@ func (s *service) UpdateNamespaceModelByID(ctx context.Context, ns resource.Name
 		}
 	}
 
-	if reDeploy {
+	if updatedDBModel.Hardware != dbModel.Hardware {
 		versions, totalSize, _, page, err := s.ListNamespaceModelVersions(ctx, ns, 0, 10, updatedDBModel.ID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Because

- User should be allowed to `PATCH` model visibility
- should not redeploy if `hardware` type is not changed

This commit

- remove visibility restriction in update endpoint
- fix `hardware` update check
