### PR TITLE
chore(ray): adopt starting state to describe resource provisioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240603193226-becf22655052
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240604165714-28f12b657c79
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1316,6 +1316,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240603193226-becf22655052 h1:/LUY1yR6oJpr2WCiguqE5P7D7klA2tUcRkPnJTRXAGQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240603193226-becf22655052/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240604165714-28f12b657c79 h1:BS69L/vov0IxGwHPwDWqozh7dKnrX+9eU+6ms92GDXo=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240604165714-28f12b657c79/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -292,7 +292,7 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 	}
 
 	// TODO: Support custom resource configs for deployment in the future
-	if userID == "instill-ai" {
+	if userID == "instill-ai" || userID == "abrc" {
 		runOptions = append(runOptions,
 			fmt.Sprintf("-e %s=%v", EnvNumOfMinReplicas, 1),
 			fmt.Sprintf("-e %s=%v", EnvNumOfMaxReplicas, 1),

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -177,7 +177,7 @@ func (r *ray) ModelReady(ctx context.Context, modelName string, version string) 
 					return modelPB.State_STATE_ACTIVE.Enum(), application.Deployments[i].Message, nil
 				}
 			case rayserver.DeploymentStatusStrUpdating:
-				return modelPB.State_STATE_UNSPECIFIED.Enum(), application.Deployments[i].Message, nil
+				return modelPB.State_STATE_STARTING.Enum(), application.Deployments[i].Message, nil
 			case rayserver.DeploymentStatusStrUpscaling, rayserver.DeploymentStatusStrDownscaling:
 				return modelPB.State_STATE_SCALING.Enum(), application.Deployments[i].Message, nil
 			case rayserver.DeploymentStatusStrUnhealthy:
@@ -186,14 +186,14 @@ func (r *ray) ModelReady(ctx context.Context, modelName string, version string) 
 		}
 		return modelPB.State_STATE_ERROR.Enum(), application.Message, nil
 	case rayserver.ApplicationStatusStrDeploying, rayserver.ApplicationStatusStrDeleting:
-		return modelPB.State_STATE_UNSPECIFIED.Enum(), application.Message, nil
+		return modelPB.State_STATE_STARTING.Enum(), application.Message, nil
 	case rayserver.ApplicationStatusStrNotStarted:
 		return modelPB.State_STATE_OFFLINE.Enum(), application.Message, nil
 	case rayserver.ApplicationStatusStrDeployFailed:
 		return modelPB.State_STATE_ERROR.Enum(), application.Message, nil
 	}
 
-	return modelPB.State_STATE_UNSPECIFIED.Enum(), application.Message, nil
+	return modelPB.State_STATE_ERROR.Enum(), application.Message, nil
 }
 
 func (r *ray) ModelMetadataRequest(ctx context.Context, modelName string, version string) *rayserver.ModelMetadataResponse {


### PR DESCRIPTION
Because

- BE should not return `STATE_UNSPECIFIED` to client

This commit

- describe resource provisioning with `STATE_STARTING`
