### PR TITLE
chore(model): allow deploying models under different namespace

### DIFF
--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Build test models
         working-directory: ./assets/model-${{ matrix.model }}
-        run: instill_build -t test
+        run: instill-build -t latest
 
       - name: Push test models
         working-directory: ./assets/model-${{ matrix.model }}
-        run: instill_push -t test -u docker.io
+        run: instill-push -t latest -u docker.io

--- a/config/config.go
+++ b/config/config.go
@@ -105,10 +105,8 @@ type CacheConfig struct {
 }
 
 type InitModelConfig struct {
-	OwnerType string `koanf:"ownertype"`
-	OwnerID   string `koanf:"ownerid"`
-	Path      string `koanf:"path"`
-	Enabled   bool   `koanf:"enabled"`
+	Path    string `koanf:"path"`
+	Enabled bool   `koanf:"enabled"`
 }
 
 // MaxBatchSizeConfig defines the maximum size of the batch of a AI task

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,8 +70,6 @@ temporal:
   key:
   servername:
 initmodel:
-  ownertype: users
-  ownerid: admin
   enabled: false
   path: https://raw.githubusercontent.com/instill-ai/instill-core/main/model-hub/model_hub_test.json
 log:


### PR DESCRIPTION
Because

- Predeploy model lists has models which will be deployed under different namespace

This commit

- allow deploying models under different namespace
- update test images' tag
