### PR TITLE
chore(schema): add temporary field to toggle object image input

### DIFF
--- a/config/model/task_input.json
+++ b/config/model/task_input.json
@@ -339,6 +339,7 @@
       },
       "prompt_images": {
         "description": "The prompt images",
+        "instillModelPromptImageBase64ObjectFormat": true,
         "instillAcceptFormats": [
           "array:image/*"
         ],
@@ -446,6 +447,7 @@
       },
       "prompt_images": {
         "description": "The prompt images",
+        "instillModelPromptImageBase64ObjectFormat": true,
         "instillAcceptFormats": [
           "array:image/*"
         ],
@@ -553,6 +555,7 @@
       },
       "prompt_images": {
         "description": "The prompt images",
+        "instillModelPromptImageBase64ObjectFormat": true,
         "instillAcceptFormats": [
           "array:image/*"
         ],


### PR DESCRIPTION
Because

- Trigger form on FE cannot provide the necessary payload object with the current schema, add a temporary field to allow FE to construct the correct trigger payload
- This addition should be temporary, proper design will follow

This commit

- add `instillModelPromptImageBase64ObjectFormat` for FE to construct a fixed payload object as a workaround
