### PR TITLE
feat(handler): use camelCase for HTTP body

### DIFF
--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -45,7 +45,7 @@ export function setup() {
 
   var metadata = {
     "metadata": {
-      "Authorization": `Bearer ${loginResp.json().access_token}`
+      "Authorization": `Bearer ${loginResp.json().accessToken}`
     },
     "timeout": "600s",
   }

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -52,7 +52,7 @@ export function setup() {
 
   var header = {
     "headers": {
-      "Authorization": `Bearer ${loginResp.json().access_token}`
+      "Authorization": `Bearer ${loginResp.json().accessToken}`
     },
     "timeout": "600s",
   }

--- a/integration-test/rest_with_jwt.js
+++ b/integration-test/rest_with_jwt.js
@@ -35,7 +35,7 @@ export function setup() {
 
   var header = {
     "headers": {
-      "Authorization": `Bearer ${loginResp.json().access_token}`
+      "Authorization": `Bearer ${loginResp.json().accessToken}`
     },
     "timeout": "600s",
   }

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -59,7 +59,6 @@ const MaxBatchSize int = 32
 const DefaultGCPServiceAccountFile = "https://artifacts.instill.tech/default-service-account.json"
 
 var MarshalOptions protojson.MarshalOptions = protojson.MarshalOptions{
-	UseProtoNames:   true,
 	EmitUnpopulated: true,
 	UseEnumNumbers:  false,
 }


### PR DESCRIPTION
Because

- Currently, our API HTTP request and response bodies are a mix of camelCase and snake_case, which is not consistent.

This commit

- Uses camelCase for HTTP bodies.