### PR TITLE
feat(endpoints): use camelCase for `filter` query string

### DIFF
--- a/integration-test/grpc_create_model.js
+++ b/integration-test/grpc_create_model.js
@@ -24,7 +24,7 @@ export function CreateUserModel(header) {
     let createRes = client.invoke('model.model.v1alpha.ModelPublicService/CreateUserModel', {
       model: {
         id: model_id,
-        model_definition: constant.model_def_name,
+        modelDefinition: constant.model_def_name,
         visibility: "VISIBILITY_PUBLIC",
         region: "REGION_GCP_EUROPE_WEST_4",
         hardware: "CPU",
@@ -49,7 +49,7 @@ export function CreateUserModel(header) {
     check(client.invoke('model.model.v1alpha.ModelPublicService/CreateUserModel', {
       model: {
         id: randomString(10),
-        model_definition: randomString(10),
+        modelDefinition: randomString(10),
         visibility: "VISIBILITY_PUBLIC",
         region: "REGION_GCP_EUROPE_WEST_4",
         hardware: "CPU",
@@ -64,7 +64,7 @@ export function CreateUserModel(header) {
 
     check(client.invoke('model.model.v1alpha.ModelPublicService/CreateUserModel', {
       model: {
-        model_definition: constant.model_def_name,
+        modelDefinition: constant.model_def_name,
         visibility: "VISIBILITY_PUBLIC",
         region: "REGION_GCP_EUROPE_WEST_4",
         hardware: "CPU",
@@ -80,7 +80,7 @@ export function CreateUserModel(header) {
     check(client.invoke('model.model.v1alpha.ModelPublicService/CreateUserModel', {
       model: {
         id: randomString(10),
-        model_definition: constant.model_def_name,
+        modelDefinition: constant.model_def_name,
         visibility: "VISIBILITY_PUBLIC",
         region: "REGION_GCP_EUROPE_WEST_4",
         hardware: "CPU",
@@ -95,7 +95,7 @@ export function CreateUserModel(header) {
     check(client.invoke('model.model.v1alpha.ModelPublicService/CreateUserModel', {
       model: {
         id: randomString(10),
-        model_definition: constant.model_def_name,
+        modelDefinition: constant.model_def_name,
         visibility: "VISIBILITY_PUBLIC",
         region: "REGION_GCP_EUROPE_WEST_4",
         configuration: {
@@ -110,7 +110,7 @@ export function CreateUserModel(header) {
     check(client.invoke('model.model.v1alpha.ModelPublicService/CreateUserModel', {
       model: {
         id: randomString(10),
-        model_definition: constant.model_def_name,
+        modelDefinition: constant.model_def_name,
         visibility: "VISIBILITY_PUBLIC",
         hardware: "CPU",
         configuration: {

--- a/integration-test/grpc_deploy_model.js
+++ b/integration-test/grpc_deploy_model.js
@@ -37,7 +37,7 @@ export function DeployUndeployUserModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),

--- a/integration-test/grpc_deploy_model_private.js
+++ b/integration-test/grpc_deploy_model_private.js
@@ -48,7 +48,7 @@ export function CheckModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -129,7 +129,7 @@ export function DeployUndeployModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),

--- a/integration-test/grpc_publish_model.js
+++ b/integration-test/grpc_publish_model.js
@@ -41,7 +41,7 @@ export function PublishUnPublishUserModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -75,12 +75,12 @@ export function PublishUnPublishUserModel(header) {
       "PublishModel response model.uid": (r) => r.message.model.uid !== undefined,
       "PublishModel response model.id": (r) => r.message.model.id === model_id,
       "PublishModel response model.description": (r) => r.message.model.description === model_description,
-      "PublishModel response model.model_definition": (r) => r.message.model.modelDefinition === model_def_name,
+      "PublishModel response model.modelDefinition": (r) => r.message.model.modelDefinition === model_def_name,
       "PublishModel response model.configuration": (r) => r.message.model.configuration !== undefined,
       "PublishModel response model.visibility": (r) => r.message.model.visibility === "VISIBILITY_PUBLIC",
       "PublishModel response model.ownerName": (r) => isValidOwner(r.message.model.ownerName),
-      "PublishModel response model.create_time": (r) => r.message.model.createTime !== undefined,
-      "PublishModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
+      "PublishModel response model.createTime": (r) => r.message.model.createTime !== undefined,
+      "PublishModel response model.updateTime": (r) => r.message.model.updateTime !== undefined,
     });
 
     check(client.invoke('model.model.v1alpha.ModelPublicService/UnpublishUserModel', {
@@ -91,12 +91,12 @@ export function PublishUnPublishUserModel(header) {
       "UnpublishModel response model.uid": (r) => r.message.model.uid !== undefined,
       "UnpublishModel response model.id": (r) => r.message.model.id === model_id,
       "UnpublishModel response model.description": (r) => r.message.model.description === model_description,
-      "UnpublishModel response model.model_definition": (r) => r.message.model.modelDefinition === model_def_name,
+      "UnpublishModel response model.modelDefinition": (r) => r.message.model.modelDefinition === model_def_name,
       "UnpublishModel response model.configuration": (r) => r.message.model.configuration !== undefined,
       "UnpublishModel response model.visibility": (r) => r.message.model.visibility === "VISIBILITY_PRIVATE",
       "UnpublishModel response model.ownerName": (r) => isValidOwner(r.message.model.ownerName),
-      "UnpublishModel response model.create_time": (r) => r.message.model.createTime !== undefined,
-      "UnpublishModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
+      "UnpublishModel response model.createTime": (r) => r.message.model.createTime !== undefined,
+      "UnpublishModel response model.updateTime": (r) => r.message.model.updateTime !== undefined,
     });
 
     check(client.invoke('model.model.v1alpha.ModelPublicService/PublishUserModel', {

--- a/integration-test/grpc_query_model.js
+++ b/integration-test/grpc_query_model.js
@@ -38,7 +38,7 @@ export function GetUserModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -72,12 +72,12 @@ export function GetUserModel(header) {
       "GetModel response model.uid": (r) => r.message.model.uid !== undefined,
       "GetModel response model.id": (r) => r.message.model.id === model_id,
       "GetModel response model.description": (r) => r.message.model.description === model_description,
-      "GetModel response model.model_definition": (r) => r.message.model.modelDefinition === model_def_name,
+      "GetModel response model.modelDefinition": (r) => r.message.model.modelDefinition === model_def_name,
       "GetModel response model.configuration": (r) => r.message.model.configuration !== undefined,
       "GetModel response model.visibility": (r) => r.message.model.visibility === "VISIBILITY_PRIVATE",
       "GetModel response model.ownerName": (r) => isValidOwner(r.message.model.ownerName),
-      "GetModel response model.create_time": (r) => r.message.model.createTime !== undefined,
-      "GetModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
+      "GetModel response model.createTime": (r) => r.message.model.createTime !== undefined,
+      "GetModel response model.updateTime": (r) => r.message.model.updateTime !== undefined,
     });
 
     check(client.invoke('model.model.v1alpha.ModelPublicService/GetUserModel', {
@@ -119,7 +119,7 @@ export function ListUserModels(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -153,12 +153,12 @@ export function ListUserModels(header) {
       "ListModels response models[0].uid": (r) => r.message.models[0].uid !== undefined,
       "ListModels response models[0].id": (r) => r.message.models[0].id === model_id,
       "ListModels response models[0].description": (r) => r.message.models[0].description !== undefined,
-      "ListModels response models[0].model_definition": (r) => r.message.models[0].modelDefinition === model_def_name,
+      "ListModels response models[0].modelDefinition": (r) => r.message.models[0].modelDefinition === model_def_name,
       "ListModels response models[0].configuration": (r) => r.message.models[0].configuration !== undefined,
       "ListModels response models[0].visibility": (r) => r.message.models[0].visibility === "VISIBILITY_PRIVATE",
       "ListModels response models[0].owner": (r) => isValidOwner(r.message.models[0].ownerName),
-      "ListModels response models[0].create_time": (r) => r.message.models[0].createTime !== undefined,
-      "ListModels response models[0].update_time": (r) => r.message.models[0].updateTime !== undefined,
+      "ListModels response models[0].createTime": (r) => r.message.models[0].createTime !== undefined,
+      "ListModels response models[0].updateTime": (r) => r.message.models[0].updateTime !== undefined,
     });
     currentTime = new Date().getTime();
     timeoutTime = new Date().getTime() + 120000;
@@ -193,7 +193,7 @@ export function LookupModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -230,12 +230,12 @@ export function LookupModel(header) {
       "LookUpModel response model.uid": (r) => r.message.model.uid !== undefined,
       "LookUpModel response model.id": (r) => r.message.model.id === model_id,
       "LookUpModel response model.description": (r) => r.message.model.description === model_description,
-      "LookUpModel response model.model_definition": (r) => r.message.model.modelDefinition === model_def_name,
+      "LookUpModel response model.modelDefinition": (r) => r.message.model.modelDefinition === model_def_name,
       "LookUpModel response model.configuration": (r) => r.message.model.configuration !== undefined,
       "LookUpModel response model.visibility": (r) => r.message.model.visibility === "VISIBILITY_PRIVATE",
       "LookUpModel response model.ownerName": (r) => isValidOwner(r.message.model.ownerName),
-      "LookUpModel response model.create_time": (r) => r.message.model.createTime !== undefined,
-      "LookUpModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
+      "LookUpModel response model.createTime": (r) => r.message.model.createTime !== undefined,
+      "LookUpModel response model.updateTime": (r) => r.message.model.updateTime !== undefined,
     });
 
     check(client.invoke('model.model.v1alpha.ModelPublicService/LookUpModel', {

--- a/integration-test/grpc_query_model_definition.js
+++ b/integration-test/grpc_query_model_definition.js
@@ -27,8 +27,8 @@ export function GetModelDefinition(header) {
       "GetModelDefinition response modelDefinition.icon": (r) => r.message.modelDefinition.icon !== undefined,
       "GetModelDefinition response modelDefinition.documentationUrl": (r) => r.message.modelDefinition.documentationUrl !== undefined,
       "GetModelDefinition response modelDefinition.modelSpec": (r) => r.message.modelDefinition.modelSpec !== undefined,
-      "GetModelDefinition response modelDefinition.create_time": (r) => r.message.modelDefinition.createTime !== undefined,
-      "GetModelDefinition response modelDefinition.update_time": (r) => r.message.modelDefinition.updateTime !== undefined,
+      "GetModelDefinition response modelDefinition.createTime": (r) => r.message.modelDefinition.createTime !== undefined,
+      "GetModelDefinition response modelDefinition.updateTime": (r) => r.message.modelDefinition.updateTime !== undefined,
     });
     client.close();
   });
@@ -48,8 +48,8 @@ export function ListModelDefinitions(header) {
       "ListModelDefinitions response modelDefinitions[0].icon": (r) => r.message.modelDefinitions[0].icon !== undefined,
       "ListModelDefinitions response modelDefinitions[0].documentationUrl": (r) => r.message.modelDefinitions[0].documentationUrl !== undefined,
       "ListModelDefinitions response modelDefinitions[0].modelSpec": (r) => r.message.modelDefinitions[0].modelSpec !== undefined,
-      "ListModelDefinitions response modelDefinitions[0].create_time": (r) => r.message.modelDefinitions[0].createTime !== undefined,
-      "ListModelDefinitions response modelDefinitions[0].update_time": (r) => r.message.modelDefinitions[0].updateTime !== undefined,
+      "ListModelDefinitions response modelDefinitions[0].createTime": (r) => r.message.modelDefinitions[0].createTime !== undefined,
+      "ListModelDefinitions response modelDefinitions[0].updateTime": (r) => r.message.modelDefinitions[0].updateTime !== undefined,
     });
     client.close();
   });

--- a/integration-test/grpc_query_model_private.js
+++ b/integration-test/grpc_query_model_private.js
@@ -47,7 +47,7 @@ export function ListModels(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -82,12 +82,12 @@ export function ListModels(header) {
       "ListModelsAdmin response models[0].uid": (r) => r.message.models[0].uid !== undefined,
       "ListModelsAdmin response models[0].id": (r) => r.message.models[0].id === model_id,
       "ListModelsAdmin response models[0].description": (r) => r.message.models[0].description !== undefined,
-      "ListModelsAdmin response models[0].model_definition": (r) => r.message.models[0].modelDefinition === model_def_name,
+      "ListModelsAdmin response models[0].modelDefinition": (r) => r.message.models[0].modelDefinition === model_def_name,
       "ListModelsAdmin response models[0].configuration": (r) => r.message.models[0].configuration !== undefined,
       "ListModelsAdmin response models[0].visibility": (r) => r.message.models[0].visibility === "VISIBILITY_PRIVATE",
       "ListModelsAdmin response models[0].ownerName": (r) => isValidOwner(r.message.models[0].ownerName),
-      "ListModelsAdmin response models[0].create_time": (r) => r.message.models[0].createTime !== undefined,
-      "ListModelsAdmin response models[0].update_time": (r) => r.message.models[0].updateTime !== undefined,
+      "ListModelsAdmin response models[0].createTime": (r) => r.message.models[0].createTime !== undefined,
+      "ListModelsAdmin response models[0].updateTime": (r) => r.message.models[0].updateTime !== undefined,
     });
     currentTime = new Date().getTime();
     timeoutTime = new Date().getTime() + 120000;
@@ -128,7 +128,7 @@ export function LookUpModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -166,12 +166,12 @@ export function LookUpModel(header) {
       "LookUpModelAdmin response model.uid": (r) => r.message.model.uid !== undefined,
       "LookUpModelAdmin response model.id": (r) => r.message.model.id === model_id,
       "LookUpModelAdmin response model.description": (r) => r.message.model.description === model_description,
-      "LookUpModelAdmin response model.model_definition": (r) => r.message.model.modelDefinition === model_def_name,
+      "LookUpModelAdmin response model.modelDefinition": (r) => r.message.model.modelDefinition === model_def_name,
       "LookUpModelAdmin response model.configuration": (r) => r.message.model.configuration !== undefined,
       "LookUpModelAdmin response model.visibility": (r) => r.message.model.visibility === "VISIBILITY_PRIVATE",
       "LookUpModelAdmin response model.ownerName": (r) => isValidOwner(r.message.model.ownerName),
-      "LookUpModelAdmin response model.create_time": (r) => r.message.model.createTime !== undefined,
-      "LookUpModelAdmin response model.update_time": (r) => r.message.model.updateTime !== undefined,
+      "LookUpModelAdmin response model.createTime": (r) => r.message.model.createTime !== undefined,
+      "LookUpModelAdmin response model.updateTime": (r) => r.message.model.updateTime !== undefined,
     });
 
     check(privateClient.invoke('model.model.v1alpha.ModelPrivateService/LookUpModelAdmin', {

--- a/integration-test/grpc_update_model.js
+++ b/integration-test/grpc_update_model.js
@@ -39,7 +39,7 @@ export function UpdateUserModel(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", model_def_name);
+    fd_cls.append("modelDefinition", model_def_name);
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
       headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.metadata.Authorization),
@@ -77,12 +77,12 @@ export function UpdateUserModel(header) {
       "UpdateModel response model.uid": (r) => r.message.model.uid !== undefined,
       "UpdateModel response model.id": (r) => r.message.model.id === model_id,
       "UpdateModel response model.description": (r) => r.message.model.description === "new_description",
-      "UpdateModel response model.model_definition": (r) => r.message.model.modelDefinition === model_def_name,
+      "UpdateModel response model.modelDefinition": (r) => r.message.model.modelDefinition === model_def_name,
       "UpdateModel response model.configuration": (r) => r.message.model.configuration !== undefined,
       "UpdateModel response model.visibility": (r) => r.message.model.visibility === "VISIBILITY_PRIVATE",
       "UpdateModel response model.ownerName": (r) => isValidOwner(r.message.model.ownerName),
-      "UpdateModel response model.create_time": (r) => r.message.model.createTime !== undefined,
-      "UpdateModel response model.update_time": (r) => r.message.model.updateTime !== undefined,
+      "UpdateModel response model.createTime": (r) => r.message.model.createTime !== undefined,
+      "UpdateModel response model.updateTime": (r) => r.message.model.updateTime !== undefined,
     });
     currentTime = new Date().getTime();
     timeoutTime = new Date().getTime() + 120000;

--- a/integration-test/rest_create_model.js
+++ b/integration-test/rest_create_model.js
@@ -27,7 +27,7 @@ export function CreateModelFromLocal(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id_cls);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", "model-definitions/local");
+      fd_cls.append("modelDefinition", "model-definitions/local");
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -60,7 +60,7 @@ export function CreateModelFromLocal(header) {
       model_description = randomString(20)
       fd_det.append("id", model_id_det);
       fd_det.append("description", model_description);
-      fd_det.append("model_definition", "model-definitions/local");
+      fd_det.append("modelDefinition", "model-definitions/local");
       fd_det.append("content", http.file(constant.det_model, "dummy-det-model.zip"));
       let createDetModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_det.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`, header.headers.Authorization),
@@ -93,7 +93,7 @@ export function CreateModelFromLocal(header) {
       model_description = randomString(20)
       fd_keypoint.append("id", model_id_keypoint);
       fd_keypoint.append("description", model_description);
-      fd_keypoint.append("model_definition", "model-definitions/local");
+      fd_keypoint.append("modelDefinition", "model-definitions/local");
       fd_keypoint.append("content", http.file(constant.keypoint_model, "dummy-keypoint-model.zip"));
       let createKpModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_keypoint.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_keypoint.boundary}`, header.headers.Authorization),
@@ -126,7 +126,7 @@ export function CreateModelFromLocal(header) {
       // model_description = randomString(20)
       // fd_unspecified.append("id", model_id_unspecified);
       // fd_unspecified.append("description", model_description);
-      // fd_unspecified.append("model_definition", "model-definitions/local");
+      // fd_unspecified.append("modelDefinition", "model-definitions/local");
       // fd_unspecified.append("content", http.file(constant.unspecified_model, "dummy-unspecified-model.zip"));
       // let createUnspecifiedModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_unspecified.body(), {
       //   headers: genHeader(`multipart/form-data; boundary=${fd_unspecified.boundary}`, header.headers.Authorization),
@@ -204,7 +204,7 @@ export function CreateModelFromLocal(header) {
     //   let model_description = randomString(20)
     //   fd_cls.append("id", model_id_cls);
     //   fd_cls.append("description", model_description);
-    //   fd_cls.append("model_definition", "model-definitions/local");
+    //   fd_cls.append("modelDefinition", "model-definitions/local");
     //   fd_cls.append("content", http.file(constant.cls_model_bz17, "dummy-cls-model-bz17.zip"));
     //   check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
     //     headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -218,7 +218,7 @@ export function CreateModelFromLocal(header) {
     //   model_description = randomString(20)
     //   fd_det.append("id", model_id_det);
     //   fd_det.append("description", model_description);
-    //   fd_det.append("model_definition", "model-definitions/local");
+    //   fd_det.append("modelDefinition", "model-definitions/local");
     //   fd_det.append("content", http.file(constant.det_model_bz9, "dummy-det-model-bz9.zip"));
     //   check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_det.body(), {
     //     headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`, header.headers.Authorization),
@@ -232,7 +232,7 @@ export function CreateModelFromLocal(header) {
     //   model_description = randomString(20)
     //   fd_keypoint.append("id", model_id_keypoint);
     //   fd_keypoint.append("description", model_description);
-    //   fd_keypoint.append("model_definition", "model-definitions/local");
+    //   fd_keypoint.append("modelDefinition", "model-definitions/local");
     //   fd_keypoint.append("content", http.file(constant.keypoint_model_bz9, "dummy-keypoint-model-bz9.zip"));
     //   check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_keypoint.body(), {
     //     headers: genHeader(`multipart/form-data; boundary=${fd_keypoint.boundary}`, header.headers.Authorization),
@@ -246,7 +246,7 @@ export function CreateModelFromLocal(header) {
     //   model_description = randomString(20)
     //   fd_unspecified.append("id", model_id_unspecified);
     //   fd_unspecified.append("description", model_description);
-    //   fd_unspecified.append("model_definition", "model-definitions/local");
+    //   fd_unspecified.append("modelDefinition", "model-definitions/local");
     //   fd_unspecified.append("content", http.file(constant.unspecified_model_bz3, "dummy-unspecified-model-bz3.zip"));
     //   check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_unspecified.body(), {
     //     headers: genHeader(`multipart/form-data; boundary=${fd_unspecified.boundary}`, header.headers.Authorization),
@@ -260,7 +260,7 @@ export function CreateModelFromLocal(header) {
     //   model_description = randomString(20)
     //   fd_semantic.append("id", model_id_semantic);
     //   fd_semantic.append("description", model_description);
-    //   fd_semantic.append("model_definition", "model-definitions/local");
+    //   fd_semantic.append("modelDefinition", "model-definitions/local");
     //   fd_semantic.append("content", http.file(constant.semantic_segmentation_model_bz9, "dummy-semantic-segmentation-model-bz9.zip"));
     //   check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_semantic.body(), {
     //     headers: genHeader(`multipart/form-data; boundary=${fd_semantic.boundary}`, header.headers.Authorization),
@@ -274,7 +274,7 @@ export function CreateModelFromLocal(header) {
     //   model_description = randomString(20)
     //   fd_instance.append("id", model_id_instance);
     //   fd_instance.append("description", model_description);
-    //   fd_instance.append("model_definition", "model-definitions/local");
+    //   fd_instance.append("modelDefinition", "model-definitions/local");
     //   fd_instance.append("content", http.file(constant.instance_segmentation_model_bz9, "dummy-instance-segmentation-model-bz9.zip"));
     //   check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_instance.body(), {
     //     headers: genHeader(`multipart/form-data; boundary=${fd_instance.boundary}`, header.headers.Authorization),
@@ -329,7 +329,7 @@ export function CreateModelFromGitHub(header) {
       let model_id = randomString(10)
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-dummy-cls",
           "tag": "v1.0-cpu"
@@ -361,7 +361,7 @@ export function CreateModelFromGitHub(header) {
 
       check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": randomString(10),
-        "model_definition": randomString(10),
+        "modelDefinition": randomString(10),
         "configuration": {
           "repository": "admin/model-dummy-cls"
         },
@@ -371,7 +371,7 @@ export function CreateModelFromGitHub(header) {
       });
 
       check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-dummy-cls"
         }
@@ -382,7 +382,7 @@ export function CreateModelFromGitHub(header) {
 
       check(http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": randomString(10),
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {}
       }), header), {
         "POST /v1alpha/models by github missing github_url status": (r) =>

--- a/integration-test/rest_create_model_with_jwt.js
+++ b/integration-test/rest_create_model_with_jwt.js
@@ -28,7 +28,7 @@ export function CreateModelFromLocal(header) {
     let model_description = randomString(20)
     fd_cls.append("id", model_id);
     fd_cls.append("description", model_description);
-    fd_cls.append("model_definition", "model-definitions/local");
+    fd_cls.append("modelDefinition", "model-definitions/local");
     fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
     group(`Model Backend API: CreateModelFromLocal [with random "Instill-User-Uid" header]`, function () {
@@ -97,7 +97,7 @@ export function CreateModelFromGitHub(header) {
     let model_id = randomString(10)
     let payload = JSON.stringify({
       "id": model_id,
-      "model_definition": "model-definitions/github",
+      "modelDefinition": "model-definitions/github",
       "configuration": {
         "repository": "admin/model-dummy-cls",
         "tag": "v1.0-cpu"

--- a/integration-test/rest_deploy_model.js
+++ b/integration-test/rest_deploy_model.js
@@ -28,7 +28,7 @@ export function DeployUndeployModel(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),

--- a/integration-test/rest_deploy_model_private.js
+++ b/integration-test/rest_deploy_model_private.js
@@ -28,7 +28,7 @@ export function DeployUndeployModel(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),

--- a/integration-test/rest_deploy_model_with_jwt.js
+++ b/integration-test/rest_deploy_model_with_jwt.js
@@ -27,7 +27,7 @@ export function DeployUndeployModel(header) {
       let fd_cls = new FormData();
       let model_id = randomString(10)
       fd_cls.append("id", model_id);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),

--- a/integration-test/rest_infer_github_model.js
+++ b/integration-test/rest_infer_github_model.js
@@ -29,7 +29,7 @@ export function InferGitHubModel(header) {
       let model_id = randomString(10)
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-mobilenetv2",
           "tag": "v1.0-cpu"
@@ -238,7 +238,7 @@ export function InferGitHubModel(header) {
       let model_id = randomString(10)
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-mobilenetv2-dvc"
         },
@@ -447,7 +447,7 @@ export function InferGitHubModel(header) {
       let model_id = randomString(10)
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-yolov4"
         },
@@ -755,7 +755,7 @@ export function InferGitHubModel(header) {
       let model_id = randomString(10)
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-yolov4-dvc"
         },
@@ -1063,7 +1063,7 @@ export function InferGitHubModel(header) {
       let model_id = randomString(10)
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-yolov7-pose-dvc"
         },
@@ -1356,7 +1356,7 @@ export function InferGitHubModel(header) {
   //   group("Model Backend API: Predict Model with semantic segmentation model", function () {
   //     let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
   //       "id": model_id,
-  //       "model_definition": "model-definitions/github",
+  //       "modelDefinition": "model-definitions/github",
   //       "configuration": {
   //         "repository": "admin/model-semantic-segmentation-dvc"
   //       },
@@ -1608,7 +1608,7 @@ export function InferGitHubModel(header) {
   //   group("Model Backend API: Predict Model with instance segmentation model", function () {
   //     let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
   //       "id": model_id,
-  //       "model_definition": "model-definitions/github",
+  //       "modelDefinition": "model-definitions/github",
   //       "configuration": {
   //         "repository": "admin/model-instance-segmentation-dvc"
   //       },

--- a/integration-test/rest_infer_model.js
+++ b/integration-test/rest_infer_model.js
@@ -30,7 +30,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -240,7 +240,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd_det.append("id", model_id);
       fd_det.append("description", model_description);
-      fd_det.append("model_definition", model_def_name);
+      fd_det.append("modelDefinition", model_def_name);
       fd_det.append("content", http.file(constant.det_model, "dummy-det-model.zip"));
 
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_det.body(), {
@@ -551,7 +551,7 @@ export function InferModel(header) {
   //     let model_description = randomString(20)
   //     fd.append("id", model_id);
   //     fd.append("description", model_description);
-  //     fd.append("model_definition", model_def_name);
+  //     fd.append("modelDefinition", model_def_name);
   //     fd.append("content", http.file(constant.unspecified_model, "dummy-unspecified-model.zip"));
 
   //     let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
@@ -807,7 +807,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd_keypoint.append("id", model_id);
       fd_keypoint.append("description", model_description);
-      fd_keypoint.append("model_definition", model_def_name);
+      fd_keypoint.append("modelDefinition", model_def_name);
       fd_keypoint.append("content", http.file(constant.keypoint_model, "dummy-keypoint-model.zip"));
 
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_keypoint.body(), {
@@ -1099,7 +1099,7 @@ export function InferModel(header) {
   //     let model_description = randomString(20)
   //     fd_empty.append("id", model_id);
   //     fd_empty.append("description", model_description);
-  //     fd_empty.append("model_definition", model_def_name);
+  //     fd_empty.append("modelDefinition", model_def_name);
   //     fd_empty.append("content", http.file(constant.empty_response_model, "empty-response-model.zip"));
 
   //     let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_empty.body(), {
@@ -1390,7 +1390,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd.append("id", model_id);
       fd.append("description", model_description);
-      fd.append("model_definition", model_def_name);
+      fd.append("modelDefinition", model_def_name);
       fd.append("content", http.file(constant.semantic_segmentation_model, "dummy-semantic_segmentation_model.zip"));
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
@@ -1620,7 +1620,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd.append("id", model_id);
       fd.append("description", model_description);
-      fd.append("model_definition", model_def_name);
+      fd.append("modelDefinition", model_def_name);
       fd.append("content", http.file(constant.instance_segmentation_model, "dummy-instance-segmentation-model.zip"));
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
@@ -1946,7 +1946,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd.append("id", model_id);
       fd.append("description", model_description);
-      fd.append("model_definition", model_def_name);
+      fd.append("modelDefinition", model_def_name);
       fd.append("content", http.file(constant.text_to_image_model, "dummy-text-to-image-model.zip"));
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
@@ -2163,7 +2163,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd.append("id", model_id);
       fd.append("description", model_description);
-      fd.append("model_definition", model_def_name);
+      fd.append("modelDefinition", model_def_name);
       fd.append("content", http.file(constant.image_to_image_model, "dummy-image-to-image-model.zip"));
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
@@ -2384,7 +2384,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd.append("id", model_id);
       fd.append("description", model_description);
-      fd.append("model_definition", model_def_name);
+      fd.append("modelDefinition", model_def_name);
       fd.append("content", http.file(constant.text_generation_model, "dummy-text-generation-model.zip"));
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
@@ -2566,7 +2566,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd.append("id", model_id);
       fd.append("description", model_description);
-      fd.append("model_definition", model_def_name);
+      fd.append("modelDefinition", model_def_name);
       fd.append("content", http.file(constant.text_generation_chat_model, "dummy-text-generation-chat-model.zip"));
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),
@@ -2750,7 +2750,7 @@ export function InferModel(header) {
       let model_description = randomString(20)
       fd.append("id", model_id);
       fd.append("description", model_description);
-      fd.append("model_definition", model_def_name);
+      fd.append("modelDefinition", model_def_name);
       fd.append("content", http.file(constant.visual_question_answering, "dummy-visual-question-answering-model.zip"));
       let createModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`, header.headers.Authorization),

--- a/integration-test/rest_longrunning_operation.js
+++ b/integration-test/rest_longrunning_operation.js
@@ -30,7 +30,7 @@ export function GetLongRunningOperation(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),

--- a/integration-test/rest_model_card.js
+++ b/integration-test/rest_model_card.js
@@ -29,7 +29,7 @@ export function GetModelCard(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -94,7 +94,7 @@ export function GetModelCard(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_no_readme_model, "dummy-cls-no-readme.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),

--- a/integration-test/rest_model_card_with_jwt.js
+++ b/integration-test/rest_model_card_with_jwt.js
@@ -28,7 +28,7 @@ export function GetModelCard(header) {
   let model_description = randomString(20)
   fd_cls.append("id", model_id);
   fd_cls.append("description", model_description);
-  fd_cls.append("model_definition", model_def_name);
+  fd_cls.append("modelDefinition", model_def_name);
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
   {
     let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {

--- a/integration-test/rest_publish_model.js
+++ b/integration-test/rest_publish_model.js
@@ -29,7 +29,7 @@ export function PublishUnpublishModel(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -64,18 +64,18 @@ export function PublishUnpublishModel(header) {
           r.json().model.id === model_id,
         [`POST /v1alpha/models/${model_id}/publish task cls response model.description`]: (r) =>
           r.json().model.description === model_description,
-        [`POST /v1alpha/models/${model_id}/publish task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`POST /v1alpha/models/${model_id}/publish task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`POST /v1alpha/models/${model_id}/publish task cls response model.configuration`]: (r) =>
           r.json().model.configuration !== undefined,
         [`POST /v1alpha/models/${model_id}/publish task cls response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PUBLIC",
         [`POST /v1alpha/models/${model_id}/publish task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`POST /v1alpha/models/${model_id}/publish task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`POST /v1alpha/models/${model_id}/publish task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`POST /v1alpha/models/${model_id}/publish task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`POST /v1alpha/models/${model_id}/publish task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}/unpublish`, null, header), {
@@ -89,18 +89,18 @@ export function PublishUnpublishModel(header) {
           r.json().model.id === model_id,
         [`POST /v1alpha/models/${model_id}/unpublish task cls response model.description`]: (r) =>
           r.json().model.description === model_description,
-        [`POST /v1alpha/models/${model_id}/unpublish task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`POST /v1alpha/models/${model_id}/unpublish task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`POST /v1alpha/models/${model_id}/unpublish task cls response model.configuration`]: (r) =>
           r.json().model.configuration !== undefined,
         [`POST /v1alpha/models/${model_id}/unpublish task cls response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`POST /v1alpha/models/${model_id}/unpublish task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`POST /v1alpha/models/${model_id}/unpublish task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`POST /v1alpha/models/${model_id}/unpublish task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`POST /v1alpha/models/${model_id}/unpublish task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`POST /v1alpha/models/${model_id}/unpublish task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       check(http.post(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${randomString(10)}/publish`, null, header), {

--- a/integration-test/rest_publish_model_with_jwt.js
+++ b/integration-test/rest_publish_model_with_jwt.js
@@ -25,7 +25,7 @@ export function PublishUnpublishModel(header) {
   let fd_cls = new FormData();
   let model_id = randomString(10)
   fd_cls.append("id", model_id);
-  fd_cls.append("model_definition", model_def_name);
+  fd_cls.append("modelDefinition", model_def_name);
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
   {

--- a/integration-test/rest_query_model.js
+++ b/integration-test/rest_query_model.js
@@ -29,7 +29,7 @@ export function GetModel(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -67,18 +67,18 @@ export function GetModel(header) {
           r.json().model.task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models/${model_id} task cls response model.state`]: (r) =>
           r.json().model.state === "STATE_OFFLINE",
-        [`GET /v1alpha/models/${model_id} task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`GET /v1alpha/models/${model_id} task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`GET /v1alpha/models/${model_id} task cls response model.configuration`]: (r) =>
           r.json().model.configuration === null,
         [`GET /v1alpha/models/${model_id} task cls response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models/${model_id} task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`GET /v1alpha/models/${model_id} task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`GET /v1alpha/models/${model_id} task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`GET /v1alpha/models/${model_id} task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`GET /v1alpha/models/${model_id} task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/${model_id}?view=VIEW_FULL`, header), {
@@ -96,18 +96,18 @@ export function GetModel(header) {
           r.json().model.task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models/${model_id} task cls response model.state`]: (r) =>
           r.json().model.state === "STATE_OFFLINE",
-        [`GET /v1alpha/models/${model_id} task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`GET /v1alpha/models/${model_id} task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`GET /v1alpha/models/${model_id} task cls response model.configuration.content`]: (r) =>
           r.json().model.configuration.content === "dummy-cls-model.zip",
         [`GET /v1alpha/models/${model_id} task cls response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models/${model_id} task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`GET /v1alpha/models/${model_id} task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`GET /v1alpha/models/${model_id} task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`GET /v1alpha/models/${model_id} task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`GET /v1alpha/models/${model_id} task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       currentTime = new Date().getTime();
@@ -137,7 +137,7 @@ export function ListModels(header) {
       let model_id_1 = randomString(10)
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id_1,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-dummy-cls",
           "tag": "v1.0-cpu"
@@ -165,7 +165,7 @@ export function ListModels(header) {
       let model_id_2 = randomString(10)
       createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id_2,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-dummy-cls",
           "tag": "v1.0-cpu"
@@ -211,18 +211,18 @@ export function ListModels(header) {
           r.json().models[0].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models task cls response models[0].state`]: (r) =>
           r.json().models[0].state === "STATE_OFFLINE",
-        [`GET /v1alpha/models task cls response models[0].model_definition`]: (r) =>
-          r.json().models[0].model_definition === "model-definitions/github",
+        [`GET /v1alpha/models task cls response models[0].modelDefinition`]: (r) =>
+          r.json().models[0].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/models task cls response models[0].configuration`]: (r) =>
           r.json().models[0].configuration === null,
         [`GET /v1alpha/models task cls response models[0].visibility`]: (r) =>
           r.json().models[0].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models task cls response models[0].owner_name`]: (r) =>
           isValidOwner(r.json().models[0].owner_name),
-        [`GET /v1alpha/models task cls response models[0].create_time`]: (r) =>
-          r.json().models[0].create_time !== undefined,
-        [`GET /v1alpha/models task cls response models[0].update_time`]: (r) =>
-          r.json().models[0].update_time !== undefined,
+        [`GET /v1alpha/models task cls response models[0].createTime`]: (r) =>
+          r.json().models[0].createTime !== undefined,
+        [`GET /v1alpha/models task cls response models[0].updateTime`]: (r) =>
+          r.json().models[0].updateTime !== undefined,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models?page_size=1&page_token=${resp.json().next_page_token}`, header), {
@@ -246,18 +246,18 @@ export function ListModels(header) {
           r.json().models[0].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models task cls response models[0].state`]: (r) =>
           r.json().models[0].state === "STATE_OFFLINE",
-        [`GET /v1alpha/models task cls response models[0].model_definition`]: (r) =>
-          r.json().models[0].model_definition === "model-definitions/github",
+        [`GET /v1alpha/models task cls response models[0].modelDefinition`]: (r) =>
+          r.json().models[0].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/models task cls response models[0].configuration`]: (r) =>
           r.json().models[0].configuration === null,
         [`GET /v1alpha/models task cls response models[0].visibility`]: (r) =>
           r.json().models[0].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models task cls response models[0].owner_name`]: (r) =>
           isValidOwner(r.json().models[0].owner_name),
-        [`GET /v1alpha/models task cls response models[0].create_time`]: (r) =>
-          r.json().models[0].create_time !== undefined,
-        [`GET /v1alpha/models task cls response models[0].update_time`]: (r) =>
-          r.json().models[0].update_time !== undefined,
+        [`GET /v1alpha/models task cls response models[0].createTime`]: (r) =>
+          r.json().models[0].createTime !== undefined,
+        [`GET /v1alpha/models task cls response models[0].updateTime`]: (r) =>
+          r.json().models[0].updateTime !== undefined,
       });
       check(http.get(`${constant.apiPublicHost}/v1alpha/${constant.namespace}/models?view=VIEW_FULL`, header), {
         [`GET /v1alpha/models?view=VIEW_FULL task cls response status`]: (r) =>
@@ -280,8 +280,8 @@ export function ListModels(header) {
           r.json().models[0].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].state`]: (r) =>
           r.json().models[0].state === "STATE_OFFLINE",
-        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].model_definition`]: (r) =>
-          r.json().models[0].model_definition === "model-definitions/github",
+        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].modelDefinition`]: (r) =>
+          r.json().models[0].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].configuration.repository`]: (r) =>
           r.json().models[0].configuration.repository === "admin/model-dummy-cls",
         [`GET /v1alpha/models?view=VIEW_FULL tag cls response models[0].configuration.tag`]: (r) =>
@@ -292,10 +292,10 @@ export function ListModels(header) {
           r.json().models[0].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].owner_name`]: (r) =>
           isValidOwner(r.json().models[0].owner_name),
-        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].create_time`]: (r) =>
-          r.json().models[0].create_time !== undefined,
-        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].update_time`]: (r) =>
-          r.json().models[0].update_time !== undefined,
+        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].createTime`]: (r) =>
+          r.json().models[0].createTime !== undefined,
+        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[0].updateTime`]: (r) =>
+          r.json().models[0].updateTime !== undefined,
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].name`]: (r) =>
           r.json().models[1].name === `${constant.namespace}/models/${model_id_1}`,
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].uid`]: (r) =>
@@ -308,8 +308,8 @@ export function ListModels(header) {
           r.json().models[1].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].state`]: (r) =>
           r.json().models[1].state === "STATE_OFFLINE",
-        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].model_definition`]: (r) =>
-          r.json().models[1].model_definition === "model-definitions/github",
+        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].modelDefinition`]: (r) =>
+          r.json().models[1].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].configuration.repository`]: (r) =>
           r.json().models[1].configuration.repository === "admin/model-dummy-cls",
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].configuration.tag`]: (r) =>
@@ -320,10 +320,10 @@ export function ListModels(header) {
           r.json().models[1].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].owner_name`]: (r) =>
           isValidOwner(r.json().models[1].owner_name),
-        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].create_time`]: (r) =>
-          r.json().models[1].create_time !== undefined,
-        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].update_time`]: (r) =>
-          r.json().models[1].update_time !== undefined,
+        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].createTime`]: (r) =>
+          r.json().models[1].createTime !== undefined,
+        [`GET /v1alpha/models?view=VIEW_FULL task cls response models[1].updateTime`]: (r) =>
+          r.json().models[1].updateTime !== undefined,
       });
 
       currentTime = new Date().getTime();
@@ -360,7 +360,7 @@ export function LookupModel(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -399,18 +399,18 @@ export function LookupModel(header) {
           r.json().model.task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.state`]: (r) =>
           r.json().model.state === "STATE_OFFLINE",
-        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.configuration`]: (r) =>
           r.json().model.configuration === null,
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       check(http.get(`${constant.apiPublicHost}/v1alpha/models/${modelRes.json().model.uid}/lookUp?view=VIEW_FULL`, header), {
@@ -428,18 +428,18 @@ export function LookupModel(header) {
           r.json().model.task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.state`]: (r) =>
           r.json().model.state === "STATE_OFFLINE",
-        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.configuration.content`]: (r) =>
           r.json().model.configuration.content === "dummy-cls-model.zip",
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`GET /v1alpha/models/${modelRes.json().model.uid}/lookUp task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       currentTime = new Date().getTime();

--- a/integration-test/rest_query_model_definition.js
+++ b/integration-test/rest_query_model_definition.js
@@ -23,22 +23,22 @@ export function ListModelDefinitions(header) {
           r.json().next_page_token !== undefined,
         [`GET /v1alpha/model-definitions response total_size`]: (r) =>
           r.json().total_size == 3,
-        [`GET /v1alpha/model-definitions response model_definitions.length`]: (r) =>
-          r.json().model_definitions.length === 3,
-        [`GET /v1alpha/model-definitions response model_definitions[0].name`]: (r) =>
-          r.json().model_definitions[0].name === "model-definitions/container",
-        [`GET /v1alpha/model-definitions response model_definitions[0].uid`]: (r) =>
-          r.json().model_definitions[0].uid !== undefined,
-        [`GET /v1alpha/model-definitions response model_definitions[0].id`]: (r) =>
-          r.json().model_definitions[0].id === "container",
-        [`GET /v1alpha/model-definitions response model_definitions[0].title`]: (r) =>
-          r.json().model_definitions[0].title === "Container",
-        [`GET /v1alpha/model-definitions response model_definitions[0].documentation_url`]: (r) =>
-          r.json().model_definitions[0].documentation_url === "https://www.instill.tech/docs/import-models/local",
-        [`GET /v1alpha/model-definitions response model_definitions[0].icon`]: (r) =>
-          r.json().model_definitions[0].icon === "local.svg",
-        [`GET /v1alpha/model-definitions response model_definitions[0].model_spec`]: (r) =>
-          r.json().model_definitions[0].model_spec === null,
+        [`GET /v1alpha/model-definitions response modelDefinitions.length`]: (r) =>
+          r.json().modelDefinitions.length === 3,
+        [`GET /v1alpha/model-definitions response modelDefinitions[0].name`]: (r) =>
+          r.json().modelDefinitions[0].name === "model-definitions/container",
+        [`GET /v1alpha/model-definitions response modelDefinitions[0].uid`]: (r) =>
+          r.json().modelDefinitions[0].uid !== undefined,
+        [`GET /v1alpha/model-definitions response modelDefinitions[0].id`]: (r) =>
+          r.json().modelDefinitions[0].id === "container",
+        [`GET /v1alpha/model-definitions response modelDefinitions[0].title`]: (r) =>
+          r.json().modelDefinitions[0].title === "Container",
+        [`GET /v1alpha/model-definitions response modelDefinitions[0].documentation_url`]: (r) =>
+          r.json().modelDefinitions[0].documentation_url === "https://www.instill.tech/docs/import-models/local",
+        [`GET /v1alpha/model-definitions response modelDefinitions[0].icon`]: (r) =>
+          r.json().modelDefinitions[0].icon === "local.svg",
+        [`GET /v1alpha/model-definitions response modelDefinitions[0].model_spec`]: (r) =>
+          r.json().modelDefinitions[0].model_spec === null,
       });
     });
 
@@ -49,22 +49,22 @@ export function ListModelDefinitions(header) {
         r.json().next_page_token !== undefined,
       [`GET /v1alpha/model-definitions?view=VIEW_FULL response total_size`]: (r) =>
         r.json().total_size == 3,
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions.length`]: (r) =>
-        r.json().model_definitions.length === 3,
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions[0].name`]: (r) =>
-        r.json().model_definitions[0].name === "model-definitions/container",
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions[0].uid`]: (r) =>
-        r.json().model_definitions[0].uid !== undefined,
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions[0].id`]: (r) =>
-        r.json().model_definitions[0].id === "container",
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions[0].title`]: (r) =>
-        r.json().model_definitions[0].title === "Container",
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions[0].documentation_url`]: (r) =>
-        r.json().model_definitions[0].documentation_url === "https://www.instill.tech/docs/import-models/local",
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions[0].icon`]: (r) =>
-        r.json().model_definitions[0].icon === "local.svg",
-      [`GET /v1alpha/model-definitions?view=VIEW_FULL response model_definitions[0].model_spec`]: (r) =>
-        r.json().model_definitions[0].model_spec !== null,
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions.length`]: (r) =>
+        r.json().modelDefinitions.length === 3,
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions[0].name`]: (r) =>
+        r.json().modelDefinitions[0].name === "model-definitions/container",
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions[0].uid`]: (r) =>
+        r.json().modelDefinitions[0].uid !== undefined,
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions[0].id`]: (r) =>
+        r.json().modelDefinitions[0].id === "container",
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions[0].title`]: (r) =>
+        r.json().modelDefinitions[0].title === "Container",
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions[0].documentation_url`]: (r) =>
+        r.json().modelDefinitions[0].documentation_url === "https://www.instill.tech/docs/import-models/local",
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions[0].icon`]: (r) =>
+        r.json().modelDefinitions[0].icon === "local.svg",
+      [`GET /v1alpha/model-definitions?view=VIEW_FULL response modelDefinitions[0].model_spec`]: (r) =>
+        r.json().modelDefinitions[0].model_spec !== null,
     });
   }
 }
@@ -76,22 +76,22 @@ export function GetModelDefinition(header) {
       check(http.get(`${constant.apiPublicHost}/v1alpha/${model_def_name}`, header), {
         [`GET /v1alpha/model-definitions/${model_def_name} response status`]: (r) =>
           r.status === 200,
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.name`]: (r) =>
-          r.json().model_definition.name === model_def_name,
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.id`]: (r) =>
-          r.json().model_definition.id === "local",
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.uid`]: (r) =>
-          r.json().model_definition.uid !== undefined,
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.title`]: (r) =>
-          r.json().model_definition.title === "Local",
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.documentation_url`]: (r) =>
-          r.json().model_definition.documentation_url !== undefined,
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.model_spec`]: (r) =>
-          r.json().model_definition.model_spec !== undefined,
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.create_time`]: (r) =>
-          r.json().model_definition.create_time !== undefined,
-        [`GET /v1alpha/model-definitions/${model_def_name} response model_definition.update_time`]: (r) =>
-          r.json().model_definition.update_time !== undefined,
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.name`]: (r) =>
+          r.json().modelDefinition.name === model_def_name,
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.id`]: (r) =>
+          r.json().modelDefinition.id === "local",
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.uid`]: (r) =>
+          r.json().modelDefinition.uid !== undefined,
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.title`]: (r) =>
+          r.json().modelDefinition.title === "Local",
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.documentation_url`]: (r) =>
+          r.json().modelDefinition.documentation_url !== undefined,
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.model_spec`]: (r) =>
+          r.json().modelDefinition.model_spec !== undefined,
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.createTime`]: (r) =>
+          r.json().modelDefinition.createTime !== undefined,
+        [`GET /v1alpha/model-definitions/${model_def_name} response modelDefinition.updateTime`]: (r) =>
+          r.json().modelDefinition.updateTime !== undefined,
       });
     });
   }

--- a/integration-test/rest_query_model_private.js
+++ b/integration-test/rest_query_model_private.js
@@ -28,7 +28,7 @@ export function ListModelsAdmin(header) {
       let model_id_1 = randomString(10)
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id_1,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-dummy-cls",
           "tag": "v1.0-cpu"
@@ -56,7 +56,7 @@ export function ListModelsAdmin(header) {
       let model_id_2 = randomString(10)
       createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models`, JSON.stringify({
         "id": model_id_2,
-        "model_definition": "model-definitions/github",
+        "modelDefinition": "model-definitions/github",
         "configuration": {
           "repository": "admin/model-dummy-cls",
           "tag": "v1.0-cpu"
@@ -102,18 +102,18 @@ export function ListModelsAdmin(header) {
           r.json().models[0].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/admin/models task cls response models[0].state`]: (r) =>
           r.json().models[0].state === "STATE_OFFLINE",
-        [`GET /v1alpha/admin/models task cls response models[0].model_definition`]: (r) =>
-          r.json().models[0].model_definition === "model-definitions/github",
+        [`GET /v1alpha/admin/models task cls response models[0].modelDefinition`]: (r) =>
+          r.json().models[0].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/admin/models task cls response models[0].configuration`]: (r) =>
           r.json().models[0].configuration === null,
         [`GET /v1alpha/admin/models task cls response models[0].visibility`]: (r) =>
           r.json().models[0].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/admin/models task cls response models[0].owner_name`]: (r) =>
           isValidOwner(r.json().models[0].owner_name),
-        [`GET /v1alpha/admin/models task cls response models[0].create_time`]: (r) =>
-          r.json().models[0].create_time !== undefined,
-        [`GET /v1alpha/admin/models task cls response models[0].update_time`]: (r) =>
-          r.json().models[0].update_time !== undefined,
+        [`GET /v1alpha/admin/models task cls response models[0].createTime`]: (r) =>
+          r.json().models[0].createTime !== undefined,
+        [`GET /v1alpha/admin/models task cls response models[0].updateTime`]: (r) =>
+          r.json().models[0].updateTime !== undefined,
       });
 
       check(http.get(`${constant.apiPrivateHost}/v1alpha/admin/models?page_size=1&page_token=${resp.json().next_page_token}`, header), {
@@ -137,18 +137,18 @@ export function ListModelsAdmin(header) {
           r.json().models[0].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/admin/models task cls response models[0].state`]: (r) =>
           r.json().models[0].state === "STATE_OFFLINE",
-        [`GET /v1alpha/admin/models task cls response models[0].model_definition`]: (r) =>
-          r.json().models[0].model_definition === "model-definitions/github",
+        [`GET /v1alpha/admin/models task cls response models[0].modelDefinition`]: (r) =>
+          r.json().models[0].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/admin/models task cls response models[0].configuration`]: (r) =>
           r.json().models[0].configuration === null,
         [`GET /v1alpha/admin/models task cls response models[0].visibility`]: (r) =>
           r.json().models[0].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/admin/models task cls response models[0].owner_name`]: (r) =>
           isValidOwner(r.json().models[0].owner_name),
-        [`GET /v1alpha/admin/models task cls response models[0].create_time`]: (r) =>
-          r.json().models[0].create_time !== undefined,
-        [`GET /v1alpha/admin/models task cls response models[0].update_time`]: (r) =>
-          r.json().models[0].update_time !== undefined,
+        [`GET /v1alpha/admin/models task cls response models[0].createTime`]: (r) =>
+          r.json().models[0].createTime !== undefined,
+        [`GET /v1alpha/admin/models task cls response models[0].updateTime`]: (r) =>
+          r.json().models[0].updateTime !== undefined,
       });
 
       check(http.get(`${constant.apiPrivateHost}/v1alpha/admin/models?view=VIEW_FULL`, header), {
@@ -172,8 +172,8 @@ export function ListModelsAdmin(header) {
           r.json().models[0].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].state`]: (r) =>
           r.json().models[0].state === "STATE_OFFLINE",
-        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].model_definition`]: (r) =>
-          r.json().models[0].model_definition === "model-definitions/github",
+        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].modelDefinition`]: (r) =>
+          r.json().models[0].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].configuration.repository`]: (r) =>
           r.json().models[0].configuration.repository === "admin/model-dummy-cls",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].configuration.html_url`]: (r) =>
@@ -182,10 +182,10 @@ export function ListModelsAdmin(header) {
           r.json().models[0].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].owner_name`]: (r) =>
           isValidOwner(r.json().models[0].owner_name),
-        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].create_time`]: (r) =>
-          r.json().models[0].create_time !== undefined,
-        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].update_time`]: (r) =>
-          r.json().models[0].update_time !== undefined,
+        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].createTime`]: (r) =>
+          r.json().models[0].createTime !== undefined,
+        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[0].updateTime`]: (r) =>
+          r.json().models[0].updateTime !== undefined,
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].name`]: (r) =>
           r.json().models[1].name === `${constant.namespace}/models/${model_id_1}`,
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].uid`]: (r) =>
@@ -198,8 +198,8 @@ export function ListModelsAdmin(header) {
           r.json().models[1].task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].state`]: (r) =>
           r.json().models[1].state === "STATE_OFFLINE",
-        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].model_definition`]: (r) =>
-          r.json().models[1].model_definition === "model-definitions/github",
+        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].modelDefinition`]: (r) =>
+          r.json().models[1].modelDefinition === "model-definitions/github",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].configuration.repository`]: (r) =>
           r.json().models[1].configuration.repository === "admin/model-dummy-cls",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].configuration.html_url`]: (r) =>
@@ -208,10 +208,10 @@ export function ListModelsAdmin(header) {
           r.json().models[1].visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].owner_name`]: (r) =>
           isValidOwner(r.json().models[1].owner_name),
-        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].create_time`]: (r) =>
-          r.json().models[1].create_time !== undefined,
-        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].update_time`]: (r) =>
-          r.json().models[1].update_time !== undefined,
+        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].createTime`]: (r) =>
+          r.json().models[1].createTime !== undefined,
+        [`GET /v1alpha/admin/models?view=VIEW_FULL task cls response models[1].updateTime`]: (r) =>
+          r.json().models[1].updateTime !== undefined,
       });
 
       currentTime = new Date().getTime();
@@ -248,7 +248,7 @@ export function LookupModelAdmin(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -286,8 +286,8 @@ export function LookupModelAdmin(header) {
           r.json().model.id === model_id,
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.description`]: (r) =>
           r.json().model.description === model_description,
-        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.task`]: (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.state`]: (r) =>
@@ -298,10 +298,10 @@ export function LookupModelAdmin(header) {
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       check(http.get(`${constant.apiPrivateHost}/v1alpha/admin/models/${modelUid}/lookUp?view=VIEW_FULL`, header), {
@@ -319,18 +319,18 @@ export function LookupModelAdmin(header) {
           r.json().model.task === "TASK_CLASSIFICATION",
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.state`]: (r) =>
           r.json().model.state === "STATE_OFFLINE",
-        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.configuration.content`]: (r) =>
           r.json().model.configuration.content === "dummy-cls-model.zip",
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`GET /v1alpha/admin/models/${modelUid}/lookUp task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       currentTime = new Date().getTime();

--- a/integration-test/rest_query_model_with_jwt.js
+++ b/integration-test/rest_query_model_with_jwt.js
@@ -24,7 +24,7 @@ export function GetModel(header) {
   let model_description = randomString(20)
   fd_cls.append("id", model_id);
   fd_cls.append("description", model_description);
-  fd_cls.append("model_definition", "model-definitions/local");
+  fd_cls.append("modelDefinition", "model-definitions/local");
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
   {
@@ -134,7 +134,7 @@ export function LookupModel(header) {
   let model_description = randomString(20)
   fd_cls.append("id", model_id);
   fd_cls.append("description", model_description);
-  fd_cls.append("model_definition", "model-definitions/local");
+  fd_cls.append("modelDefinition", "model-definitions/local");
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
   {

--- a/integration-test/rest_update_model.js
+++ b/integration-test/rest_update_model.js
@@ -29,7 +29,7 @@ export function UpdateModel(header) {
       let model_description = randomString(20)
       fd_cls.append("id", model_id);
       fd_cls.append("description", model_description);
-      fd_cls.append("model_definition", model_def_name);
+      fd_cls.append("modelDefinition", model_def_name);
       fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
       let createClsModelRes = http.request("POST", `${constant.apiPublicHost}/v1alpha/${constant.namespace}/models/multipart`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`, header.headers.Authorization),
@@ -68,8 +68,8 @@ export function UpdateModel(header) {
           r.json().model.id === model_id,
         [`PATCH /v1alpha/models/${model_id} task cls response model.description`]: (r) =>
           r.json().model.description === new_description,
-        [`PATCH /v1alpha/models/${model_id} task cls response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`PATCH /v1alpha/models/${model_id} task cls response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`PATCH /v1alpha/models/${model_id} task cls response model.task`]: (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
         [`PATCH /v1alpha/models/${model_id} task cls response model.state`]: (r) =>
@@ -80,10 +80,10 @@ export function UpdateModel(header) {
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`PATCH /v1alpha/models/${model_id} task cls response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`PATCH /v1alpha/models/${model_id} task cls response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`PATCH /v1alpha/models/${model_id} task cls response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`PATCH /v1alpha/models/${model_id} task cls response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`PATCH /v1alpha/models/${model_id} task cls response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       payload = JSON.stringify({
@@ -104,18 +104,18 @@ export function UpdateModel(header) {
           r.json().model.task === "TASK_CLASSIFICATION",
         [`PATCH /v1alpha/models/${model_id} task cls description empty response model.state`]: (r) =>
           r.json().model.state === "STATE_OFFLINE",
-        [`PATCH /v1alpha/models/${model_id} task cls description empty response model.model_definition`]: (r) =>
-          r.json().model.model_definition === model_def_name,
+        [`PATCH /v1alpha/models/${model_id} task cls description empty response model.modelDefinition`]: (r) =>
+          r.json().model.modelDefinition === model_def_name,
         [`PATCH /v1alpha/models/${model_id} task cls description empty response model.configuration`]: (r) =>
           r.json().model.configuration !== undefined,
         [`PATCH /v1alpha/models/${model_id} task cls description empty response model.visibility`]: (r) =>
           r.json().model.visibility === "VISIBILITY_PRIVATE",
         [`PATCH /v1alpha/models/${model_id} task cls description empty response model.owner_name`]: (r) =>
           isValidOwner(r.json().model.owner_name),
-        [`PATCH /v1alpha/models/${model_id} task cls description empty response model.create_time`]: (r) =>
-          r.json().model.create_time !== undefined,
-        [`PATCH /v1alpha/models/${model_id} task cls description empty response model.update_time`]: (r) =>
-          r.json().model.update_time !== undefined,
+        [`PATCH /v1alpha/models/${model_id} task cls description empty response model.createTime`]: (r) =>
+          r.json().model.createTime !== undefined,
+        [`PATCH /v1alpha/models/${model_id} task cls description empty response model.updateTime`]: (r) =>
+          r.json().model.updateTime !== undefined,
       });
 
       currentTime = new Date().getTime();

--- a/integration-test/rest_update_model_with_jwt.js
+++ b/integration-test/rest_update_model_with_jwt.js
@@ -27,7 +27,7 @@ export function UpdateModel(header) {
   let model_description = randomString(20)
   fd_cls.append("id", model_id);
   fd_cls.append("description", model_description);
-  fd_cls.append("model_definition", model_def_name);
+  fd_cls.append("modelDefinition", model_def_name);
   fd_cls.append("content", http.file(constant.cls_model, "dummy-cls-model.zip"));
 
   {

--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -26,8 +26,8 @@ func (h *PrivateHandler) ListModelsAdmin(ctx context.Context, req *modelPB.ListM
 		filtering.DeclareIdent("id", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),
 		filtering.DeclareIdent("owner", filtering.TypeString),
-		filtering.DeclareIdent("create_time", filtering.TypeTimestamp),
-		filtering.DeclareIdent("update_time", filtering.TypeTimestamp),
+		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
+		filtering.DeclareIdent("updateTime", filtering.TypeTimestamp),
 	}...)
 	if err != nil {
 		return nil, err

--- a/pkg/handler/public.go
+++ b/pkg/handler/public.go
@@ -71,8 +71,8 @@ func (h *PublicHandler) ListModels(ctx context.Context, req *modelPB.ListModelsR
 		filtering.DeclareIdent("tag", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),
 		filtering.DeclareIdent("owner", filtering.TypeString),
-		filtering.DeclareIdent("create_time", filtering.TypeTimestamp),
-		filtering.DeclareIdent("update_time", filtering.TypeTimestamp),
+		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
+		filtering.DeclareIdent("updateTime", filtering.TypeTimestamp),
 	}...)
 	if err != nil {
 		span.SetStatus(1, err.Error())
@@ -273,8 +273,8 @@ func (h *PublicHandler) listNamespaceModels(ctx context.Context, req ListNamespa
 		filtering.DeclareIdent("tag", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),
 		filtering.DeclareIdent("owner", filtering.TypeString),
-		filtering.DeclareIdent("create_time", filtering.TypeTimestamp),
-		filtering.DeclareIdent("update_time", filtering.TypeTimestamp),
+		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
+		filtering.DeclareIdent("updateTime", filtering.TypeTimestamp),
 	}...)
 	if err != nil {
 		span.SetStatus(1, err.Error())

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-redis/redis/v9"
 	"github.com/gofrs/uuid"
+	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.einride.tech/aip/filtering"
 	"go.einride.tech/aip/ordering"
@@ -138,7 +139,7 @@ func (r *repository) listModels(ctx context.Context, where string, whereArgs []a
 		})
 	}
 	for _, field := range order.Fields {
-		orderString := field.Path + transformBoolToDescString(field.Desc)
+		orderString := strcase.ToSnake(field.Path) + transformBoolToDescString(field.Desc)
 		queryBuilder.Order(orderString)
 	}
 	queryBuilder.Order("uid DESC")
@@ -210,9 +211,9 @@ func (r *repository) listModels(ctx context.Context, where string, whereArgs []a
 		}
 
 		for _, field := range order.Fields {
-			orderString := field.Path + transformBoolToDescString(!field.Desc)
+			orderString := strcase.ToSnake(field.Path) + transformBoolToDescString(!field.Desc)
 			lastItemQueryBuilder.Order(orderString)
-			switch field.Path {
+			switch strcase.ToSnake(field.Path) {
 			case "id":
 				tokens[field.Path] = lastID
 			case "create_time":

--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/iancoleman/strcase"
 	"go.einride.tech/aip/filtering"
 	"gorm.io/gorm/clause"
 
@@ -117,7 +118,7 @@ func (t *Transpiler) transpileIdentExpr(e *expr.Expr) (*clause.Expr, error) {
 		}
 	}
 	return &clause.Expr{
-		SQL:                identExpr.Name,
+		SQL:                strcase.ToSnake(identExpr.Name),
 		Vars:               nil,
 		WithoutParentheses: true,
 	}, nil


### PR DESCRIPTION
Because

- We should use camelCase for query strings to align with the HTTP body.

This commit

- Updates query strings `filter` and `orderBy` to use camelCase.