### PR TITLE
refactor(version): update model version name and updateTime

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -114,15 +114,14 @@ func main() {
 		if ExpectedVersion <= step {
 			fmt.Printf("Migration to version %d complete\n", step)
 			break
-		} else {
-			fmt.Printf("Step up to version %d\n", step+1)
-			if err := m.Steps(1); err != nil {
-				panic(err)
-			}
 		}
 
-		step, _, err = m.Version()
-		if err != nil {
+		fmt.Printf("Step up to version %d\n", step+1)
+		if err := m.Steps(1); err != nil {
+			panic(err)
+		}
+
+		if step, _, err = m.Version(); err != nil {
 			panic(err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240620151439-31aafaea1fc9
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -1316,8 +1316,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba h1:EJd2eHk3H+nXcSxHjvjeWRaJ5EhMOP/8ZcfuM9wE2T4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240614102540-80a2963307ba/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240620151439-31aafaea1fc9 h1:6zaUnchKUaA1m5i47LTDtH2Yr4gQFZP1ZrxTT5a64+0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240620151439-31aafaea1fc9/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/db/migration/000006_init.up.sql
+++ b/pkg/db/migration/000006_init.up.sql
@@ -1,16 +1,15 @@
 BEGIN;
 
-ALTER TABLE model_prediction
-DROP COLUMN IF EXISTS delete_time,
-DROP COLUMN IF EXISTS model_version_uid,
-ADD COLUMN IF NOT EXISTS model_version VARCHAR(255) NOT NULL,
-DROP CONSTRAINT IF EXISTS fk_model_version;
-
 DELETE FROM model_version WHERE delete_time IS NOT NULL;
 
-ALTER TABLE model_version
-DROP COLUMN IF EXISTS delete_time,
-DROP COLUMN IF EXISTS uid;
+ALTER TABLE model_prediction DROP COLUMN IF EXISTS delete_time;
+ALTER TABLE model_prediction DROP COLUMN IF EXISTS model_version_uid;
+ALTER TABLE model_prediction ADD COLUMN model_version VARCHAR(255) NOT NULL;
+ALTER TABLE model_prediction DROP CONSTRAINT IF EXISTS fk_model_version;
+
+
+ALTER TABLE model_version DROP COLUMN IF EXISTS delete_time;
+ALTER TABLE model_version DROP COLUMN IF EXISTS uid;
 
 CREATE INDEX IF NOT EXISTS version_model_uid ON model_version (model_uid);
 CREATE UNIQUE INDEX IF NOT EXISTS version_unique_model_version ON model_version (model_uid, version);


### PR DESCRIPTION
Because

- id is ambiguous, use `version` instead

This commit

- rename `id` to `version`
- use updateTime in model db record