### PR TITLE
refactor(all): remove model prediction and related functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ deploy.yaml
 tmp
 
 .DS_Store
+.idea

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,7 +24,7 @@ database:
   host: pg-sql
   port: 5432
   name: model
-  version: 6
+  version: 7
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -97,24 +97,6 @@ type ModelVersion struct {
 	UpdateTime time.Time `gorm:"autoUpdateTime:nano"`
 }
 
-type ModelPrediction struct {
-	BaseStaticHardDelete
-	OwnerUID            uuid.UUID      `json:"owner_uid,omitempty"`
-	OwnerType           UserType       `json:"owner_type,omitempty"`
-	UserUID             uuid.UUID      `json:"user_uid,omitempty"`
-	UserType            UserType       `json:"user_type,omitempty"`
-	Mode                Mode           `json:"mode,omitempty"`
-	ModelDefinitionUID  uuid.UUID      `json:"model_definition_uid,omitempty"`
-	TriggerTime         time.Time      `json:"trigger_time,omitempty"`
-	ComputeTimeDuration float64        `json:"compute_time_duration,omitempty"`
-	ModelTask           ModelTask      `json:"model_task,omitempty"`
-	Status              Status         `json:"status,omitempty"`
-	Input               datatypes.JSON `json:"input,omitempty"`
-	Output              datatypes.JSON `json:"output,omitempty"`
-	ModelUID            uuid.UUID      `json:"model_uid,omitempty"`
-	ModelVersion        string         `json:"model_version,omitempty"`
-}
-
 type ModelTag struct {
 	ModelUID   string
 	TagName    string

--- a/pkg/db/migration/000007_remove_model_prediction.down.sql
+++ b/pkg/db/migration/000007_remove_model_prediction.down.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "model_prediction" (
+    "uid" UUID PRIMARY KEY,
+    "owner_uid" UUID NOT NULL,
+    "owner_type" VALID_USER_TYPE NOT NULL,
+    "user_uid" UUID NOT NULL,
+    "user_type" VALID_USER_TYPE NOT NULL,
+    "mode" VALID_MODE NOT NULL,
+    "model_definition_uid" UUID NOT NULL,
+    "trigger_time" TIMESTAMPTZ NOT NULL,
+    "compute_time_duration" FLOAT(24) NOT NULL,
+    "model_task" VALID_TASK NOT NULL,
+    "status" VALID_STATUS NOT NULL,
+    "input" JSONB NOT NULL,
+    "output" JSONB NULL,
+    "create_time" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "update_time" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "model_uid" UUID NOT NULL,
+    "model_version_uid" UUID NOT NULL,
+    CONSTRAINT fk_model_version
+    FOREIGN KEY ("model_version_uid")
+    REFERENCES model_version ("uid")
+    ON DELETE CASCADE
+);
+
+COMMIT;

--- a/pkg/db/migration/000007_remove_model_prediction.up.sql
+++ b/pkg/db/migration/000007_remove_model_prediction.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS "model_prediction";
+
+COMMIT;

--- a/pkg/handler/mock_service_test.go
+++ b/pkg/handler/mock_service_test.go
@@ -9,18 +9,19 @@ import (
 	reflect "reflect"
 
 	longrunningpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
-	redis "github.com/redis/go-redis/v9"
 	uuid "github.com/gofrs/uuid"
 	gomock "github.com/golang/mock/gomock"
-	resource "github.com/instill-ai/model-backend/pkg/resource"
 	acl "github.com/instill-ai/model-backend/pkg/acl"
 	datamodel "github.com/instill-ai/model-backend/pkg/datamodel"
 	repository "github.com/instill-ai/model-backend/pkg/repository"
+	resource "github.com/instill-ai/model-backend/pkg/resource"
 	utils "github.com/instill-ai/model-backend/pkg/utils"
 	taskv1alpha "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	mgmtv1beta "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	modelv1alpha "github.com/instill-ai/protogen-go/model/model/v1alpha"
+	redis "github.com/redis/go-redis/v9"
 	filtering "go.einride.tech/aip/filtering"
+	ordering "go.einride.tech/aip/ordering"
 )
 
 // MockService is a mock of Service interface.
@@ -91,20 +92,6 @@ func (mr *MockServiceMockRecorder) ConvertRepositoryNameToRscName(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertRepositoryNameToRscName", reflect.TypeOf((*MockService)(nil).ConvertRepositoryNameToRscName), arg0)
 }
 
-// CreateModelPrediction mocks base method.
-func (m *MockService) CreateModelPrediction(arg0 context.Context, arg1 *datamodel.ModelPrediction) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateModelPrediction", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateModelPrediction indicates an expected call of CreateModelPrediction.
-func (mr *MockServiceMockRecorder) CreateModelPrediction(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModelPrediction", reflect.TypeOf((*MockService)(nil).CreateModelPrediction), arg0, arg1)
-}
-
 // CreateModelVersionAdmin mocks base method.
 func (m *MockService) CreateModelVersionAdmin(arg0 context.Context, arg1 *datamodel.ModelVersion) error {
 	m.ctrl.T.Helper()
@@ -134,18 +121,18 @@ func (mr *MockServiceMockRecorder) CreateNamespaceModel(arg0, arg1, arg2 interfa
 }
 
 // DBToPBModel mocks base method.
-func (m *MockService) DBToPBModel(arg0 context.Context, arg1 *datamodel.ModelDefinition, arg2 *datamodel.Model) (*modelv1alpha.Model, error) {
+func (m *MockService) DBToPBModel(arg0 context.Context, arg1 *datamodel.ModelDefinition, arg2 *datamodel.Model, arg3 modelv1alpha.View, arg4 bool) (*modelv1alpha.Model, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DBToPBModel", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DBToPBModel", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*modelv1alpha.Model)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DBToPBModel indicates an expected call of DBToPBModel.
-func (mr *MockServiceMockRecorder) DBToPBModel(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) DBToPBModel(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBToPBModel", reflect.TypeOf((*MockService)(nil).DBToPBModel), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBToPBModel", reflect.TypeOf((*MockService)(nil).DBToPBModel), arg0, arg1, arg2, arg3, arg4)
 }
 
 // DBToPBModelDefinition mocks base method.
@@ -179,32 +166,32 @@ func (mr *MockServiceMockRecorder) DBToPBModelDefinitions(arg0, arg1 interface{}
 }
 
 // DBToPBModels mocks base method.
-func (m *MockService) DBToPBModels(arg0 context.Context, arg1 []*datamodel.Model) ([]*modelv1alpha.Model, error) {
+func (m *MockService) DBToPBModels(arg0 context.Context, arg1 []*datamodel.Model, arg2 modelv1alpha.View, arg3 bool) ([]*modelv1alpha.Model, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DBToPBModels", arg0, arg1)
+	ret := m.ctrl.Call(m, "DBToPBModels", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*modelv1alpha.Model)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DBToPBModels indicates an expected call of DBToPBModels.
-func (mr *MockServiceMockRecorder) DBToPBModels(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) DBToPBModels(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBToPBModels", reflect.TypeOf((*MockService)(nil).DBToPBModels), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBToPBModels", reflect.TypeOf((*MockService)(nil).DBToPBModels), arg0, arg1, arg2, arg3)
 }
 
 // DeleteModelVersionAdmin mocks base method.
-func (m *MockService) DeleteModelVersionAdmin(arg0 context.Context, arg1 *datamodel.ModelVersion) error {
+func (m *MockService) DeleteModelVersionAdmin(arg0 context.Context, arg1 uuid.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteModelVersionAdmin", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeleteModelVersionAdmin", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteModelVersionAdmin indicates an expected call of DeleteModelVersionAdmin.
-func (mr *MockServiceMockRecorder) DeleteModelVersionAdmin(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) DeleteModelVersionAdmin(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteModelVersionAdmin", reflect.TypeOf((*MockService)(nil).DeleteModelVersionAdmin), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteModelVersionAdmin", reflect.TypeOf((*MockService)(nil).DeleteModelVersionAdmin), arg0, arg1, arg2)
 }
 
 // DeleteNamespaceModelByID mocks base method.
@@ -339,6 +326,21 @@ func (mr *MockServiceMockRecorder) GetModelVersionAdmin(arg0, arg1, arg2 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelVersionAdmin", reflect.TypeOf((*MockService)(nil).GetModelVersionAdmin), arg0, arg1, arg2)
 }
 
+// GetNamespaceLatestModelOperation mocks base method.
+func (m *MockService) GetNamespaceLatestModelOperation(arg0 context.Context, arg1 resource.Namespace, arg2 string, arg3 modelv1alpha.View) (*longrunningpb.Operation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespaceLatestModelOperation", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*longrunningpb.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNamespaceLatestModelOperation indicates an expected call of GetNamespaceLatestModelOperation.
+func (mr *MockServiceMockRecorder) GetNamespaceLatestModelOperation(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceLatestModelOperation", reflect.TypeOf((*MockService)(nil).GetNamespaceLatestModelOperation), arg0, arg1, arg2, arg3)
+}
+
 // GetNamespaceModelByID mocks base method.
 func (m *MockService) GetNamespaceModelByID(arg0 context.Context, arg1 resource.Namespace, arg2 string, arg3 modelv1alpha.View) (*modelv1alpha.Model, error) {
 	m.ctrl.T.Helper()
@@ -447,9 +449,9 @@ func (mr *MockServiceMockRecorder) ListModelDefinitions(arg0, arg1, arg2, arg3 i
 }
 
 // ListModels mocks base method.
-func (m *MockService) ListModels(arg0 context.Context, arg1 int32, arg2 string, arg3 modelv1alpha.View, arg4 *modelv1alpha.Model_Visibility, arg5 filtering.Filter, arg6 bool) ([]*modelv1alpha.Model, int32, string, error) {
+func (m *MockService) ListModels(arg0 context.Context, arg1 int32, arg2 string, arg3 modelv1alpha.View, arg4 *modelv1alpha.Model_Visibility, arg5 filtering.Filter, arg6 bool, arg7 ordering.OrderBy) ([]*modelv1alpha.Model, int32, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "ListModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].([]*modelv1alpha.Model)
 	ret1, _ := ret[1].(int32)
 	ret2, _ := ret[2].(string)
@@ -458,9 +460,9 @@ func (m *MockService) ListModels(arg0 context.Context, arg1 int32, arg2 string, 
 }
 
 // ListModels indicates an expected call of ListModels.
-func (mr *MockServiceMockRecorder) ListModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) ListModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModels", reflect.TypeOf((*MockService)(nil).ListModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModels", reflect.TypeOf((*MockService)(nil).ListModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // ListModelsAdmin mocks base method.
@@ -499,9 +501,9 @@ func (mr *MockServiceMockRecorder) ListNamespaceModelVersions(arg0, arg1, arg2, 
 }
 
 // ListNamespaceModels mocks base method.
-func (m *MockService) ListNamespaceModels(arg0 context.Context, arg1 resource.Namespace, arg2 int32, arg3 string, arg4 modelv1alpha.View, arg5 *modelv1alpha.Model_Visibility, arg6 filtering.Filter, arg7 bool) ([]*modelv1alpha.Model, int32, string, error) {
+func (m *MockService) ListNamespaceModels(arg0 context.Context, arg1 resource.Namespace, arg2 int32, arg3 string, arg4 modelv1alpha.View, arg5 *modelv1alpha.Model_Visibility, arg6 filtering.Filter, arg7 bool, arg8 ordering.OrderBy) ([]*modelv1alpha.Model, int32, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNamespaceModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "ListNamespaceModels", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].([]*modelv1alpha.Model)
 	ret1, _ := ret[1].(int32)
 	ret2, _ := ret[2].(string)
@@ -510,17 +512,18 @@ func (m *MockService) ListNamespaceModels(arg0 context.Context, arg1 resource.Na
 }
 
 // ListNamespaceModels indicates an expected call of ListNamespaceModels.
-func (mr *MockServiceMockRecorder) ListNamespaceModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) ListNamespaceModels(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaceModels", reflect.TypeOf((*MockService)(nil).ListNamespaceModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaceModels", reflect.TypeOf((*MockService)(nil).ListNamespaceModels), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 // PBToDBModel mocks base method.
-func (m *MockService) PBToDBModel(arg0 context.Context, arg1 resource.Namespace, arg2 *modelv1alpha.Model) *datamodel.Model {
+func (m *MockService) PBToDBModel(arg0 context.Context, arg1 resource.Namespace, arg2 *modelv1alpha.Model) (*datamodel.Model, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PBToDBModel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*datamodel.Model)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PBToDBModel indicates an expected call of PBToDBModel.

--- a/pkg/handler/trigger.go
+++ b/pkg/handler/trigger.go
@@ -399,7 +399,7 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 
 	userUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
 
-	// TODO: temporary solution to store input json
+	// TODO: temporary solution to store input json for latest operation
 	inputRequestJSON, err := protojson.Marshal(req)
 	if err != nil {
 		return nil, err

--- a/pkg/handler/trigger.go
+++ b/pkg/handler/trigger.go
@@ -135,11 +135,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		}
 	}
 
-	inputJSON, err := json.Marshal(req.GetTaskInputs())
-	if err != nil {
-		return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
 	userUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
 
 	usageData := &utils.UsageMetricData{
@@ -155,25 +150,8 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		ModelTask:          pbModel.Task,
 	}
 
-	modelPrediction := &datamodel.ModelPrediction{
-		BaseStaticHardDelete: datamodel.BaseStaticHardDelete{
-			UID: logUUID,
-		},
-		OwnerUID:           ns.NsUID,
-		OwnerType:          datamodel.UserType(usageData.OwnerType),
-		UserUID:            uuid.FromStringOrNil(userUID),
-		UserType:           datamodel.UserType(usageData.UserType),
-		Mode:               datamodel.Mode(usageData.Mode),
-		ModelDefinitionUID: modelDef.UID,
-		TriggerTime:        startTime,
-		ModelTask:          datamodel.ModelTask(usageData.ModelTask),
-		ModelUID:           uuid.FromStringOrNil(pbModel.GetUid()),
-		ModelVersion:       version.Version,
-		Input:              inputJSON,
-	}
-
 	// write usage/metric datapoint and prediction record
-	defer func(_ *datamodel.ModelPrediction, u *utils.UsageMetricData, startTime time.Time) {
+	defer func(u *utils.UsageMetricData, startTime time.Time) {
 		// TODO: prediction feature not ready
 		// pred.ComputeTimeDuration = time.Since(startTime).Seconds()
 		// if err := h.service.CreateModelPrediction(ctx, pred); err != nil {
@@ -183,7 +161,7 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err := h.service.WriteNewDataPoint(ctx, usageData); err != nil {
 			logger.Warn("usage/metric write failed")
 		}
-	}(modelPrediction, usageData, startTime)
+	}(usageData, startTime)
 
 	var parsedInput any
 	var lenInputs = 1
@@ -199,7 +177,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = len(imageInput)
@@ -209,7 +186,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -219,7 +195,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -229,7 +204,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		parsedInput = visualQuestionAnswering
@@ -238,7 +212,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -248,7 +221,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -260,13 +232,11 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		if !doSupportBatch {
 			span.SetStatus(1, "The model do not support batching, so could not make inference with multiple images")
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, "The model do not support batching, so could not make inference with multiple images")
 		}
 	}
@@ -274,7 +244,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 	parsedInputJSON, err := json.Marshal(parsedInput)
 	if err != nil {
 		usageData.Status = mgmtpb.Status_STATUS_ERRORED
-		modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 		return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -304,18 +273,10 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		}
 		span.SetStatus(1, st.Err().Error())
 		usageData.Status = mgmtpb.Status_STATUS_ERRORED
-		modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 		return commonpb.Task_TASK_UNSPECIFIED, nil, st.Err()
 	}
 
 	usageData.Status = mgmtpb.Status_STATUS_COMPLETED
-
-	jsonOutput, err := json.Marshal(response)
-	if err != nil {
-		logger.Warn("json marshal error for task inputs")
-	}
-	modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_COMPLETED)
-	modelPrediction.Output = jsonOutput
 
 	logger.Info(string(custom_otel.NewLogMessage(
 		ctx,
@@ -463,26 +424,8 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		ModelTask:          pbModel.Task,
 	}
 
-	modelPrediction := &datamodel.ModelPrediction{
-		BaseStaticHardDelete: datamodel.BaseStaticHardDelete{
-			UID: logUUID,
-		},
-		OwnerUID:            ns.NsUID,
-		OwnerType:           datamodel.UserType(usageData.OwnerType),
-		UserUID:             uuid.FromStringOrNil(userUID),
-		UserType:            datamodel.UserType(usageData.UserType),
-		Mode:                datamodel.Mode(usageData.Mode),
-		ModelDefinitionUID:  modelDef.UID,
-		TriggerTime:         startTime,
-		ComputeTimeDuration: usageData.ComputeTimeDuration,
-		ModelTask:           datamodel.ModelTask(usageData.ModelTask),
-		ModelUID:            uuid.FromStringOrNil(pbModel.GetUid()),
-		ModelVersion:        version.Version,
-		Input:               inputJSON,
-	}
-
 	// write usage/metric datapoint and prediction record
-	defer func(_ *datamodel.ModelPrediction, u *utils.UsageMetricData, startTime time.Time) {
+	defer func(u *utils.UsageMetricData, startTime time.Time) {
 		if u.Status == mgmtpb.Status_STATUS_ERRORED {
 			// TODO: prediction feature not ready
 			// pred.ComputeTimeDuration = time.Since(startTime).Seconds()
@@ -494,7 +437,7 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 				logger.Warn("usage/metric write failed")
 			}
 		}
-	}(modelPrediction, usageData, startTime)
+	}(usageData, startTime)
 
 	var parsedInput any
 	var lenInputs = 1
@@ -510,7 +453,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = len(imageInput)
@@ -520,7 +462,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -530,7 +471,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -545,7 +485,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		parsedInput = visualQuestionAnswering
@@ -554,7 +493,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -564,7 +502,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		lenInputs = 1
@@ -576,13 +513,11 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		if !doSupportBatch {
 			span.SetStatus(1, "The model do not support batching, so could not make inference with multiple images")
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, status.Error(codes.InvalidArgument, "The model do not support batching, so could not make inference with multiple images")
 		}
 	}
@@ -590,7 +525,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 	parsedInputJSON, err := json.Marshal(parsedInput)
 	if err != nil {
 		usageData.Status = mgmtpb.Status_STATUS_ERRORED
-		modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -599,7 +533,6 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			usageData.Status = mgmtpb.Status_STATUS_ERRORED
-			modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_ERRORED)
 			return nil, err
 		}
 	}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -57,8 +57,6 @@ type Repository interface {
 	GetLatestModelVersionByModelUID(ctx context.Context, modelUID uuid.UUID) (version *datamodel.ModelVersion, err error)
 	ListModelVersions(ctx context.Context, modelUID uuid.UUID) (versions []*datamodel.ModelVersion, err error)
 
-	CreateModelPrediction(ctx context.Context, prediction *datamodel.ModelPrediction) error
-
 	CreateModelTag(ctx context.Context, modelUID uuid.UUID, tagName string) error
 	DeleteModelTag(ctx context.Context, modelUID uuid.UUID, tagName string) error
 	ListModelTags(ctx context.Context, modelUID uuid.UUID) ([]*datamodel.ModelTag, error)
@@ -382,18 +380,6 @@ func (r *repository) DeleteNamespaceModelByID(ctx context.Context, ownerPermalin
 
 	if result.RowsAffected == 0 {
 		return ErrNoDataDeleted
-	}
-
-	return nil
-}
-
-func (r *repository) CreateModelPrediction(ctx context.Context, prediction *datamodel.ModelPrediction) error {
-
-	r.pinUser(ctx, "model_prediction")
-	db := r.checkPinnedUser(ctx, r.db, "model_prediction")
-
-	if result := db.Model(&datamodel.ModelPrediction{}).Create(&prediction); result.Error != nil {
-		return result.Error
 	}
 
 	return nil

--- a/pkg/service/mock_repository_test.go
+++ b/pkg/service/mock_repository_test.go
@@ -39,20 +39,6 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 	return m.recorder
 }
 
-// CreateModelPrediction mocks base method.
-func (m *MockRepository) CreateModelPrediction(arg0 context.Context, arg1 *datamodel.ModelPrediction) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateModelPrediction", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateModelPrediction indicates an expected call of CreateModelPrediction.
-func (mr *MockRepositoryMockRecorder) CreateModelPrediction(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModelPrediction", reflect.TypeOf((*MockRepository)(nil).CreateModelPrediction), arg0, arg1)
-}
-
 // CreateModelTag mocks base method.
 func (m *MockRepository) CreateModelTag(arg0 context.Context, arg1 uuid.UUID, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -524,14 +524,6 @@ func (s *service) TriggerAsyncNamespaceModelByID(ctx context.Context, ns resourc
 		return nil, ErrNoPermission
 	}
 
-	inputKey := fmt.Sprintf("model_trigger_input:%s", triggerUID)
-	s.redisClient.Set(
-		ctx,
-		inputKey,
-		inferInput,
-		time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-	)
-
 	parsedInputKey := fmt.Sprintf("model_trigger_input_parsed:%s", triggerUID)
 	s.redisClient.Set(
 		ctx,
@@ -566,7 +558,6 @@ func (s *service) TriggerAsyncNamespaceModelByID(ctx context.Context, ns resourc
 			UserType:           mgmtpb.OwnerType_OWNER_TYPE_USER.String(),
 			ModelDefinitionUID: dbModel.ModelDefinitionUID,
 			Task:               task,
-			InputKey:           inputKey,
 			ParsedInputKey:     parsedInputKey,
 			Mode:               mgmtpb.Mode_MODE_ASYNC,
 		})

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -77,8 +77,6 @@ type Service interface {
 	GetModelDefinitionByUID(ctx context.Context, uid uuid.UUID) (*modelpb.ModelDefinition, error)
 	ListModelDefinitions(ctx context.Context, view modelpb.View, pageSize int32, pageToken string) ([]*modelpb.ModelDefinition, int32, string, error)
 
-	CreateModelPrediction(ctx context.Context, prediction *datamodel.ModelPrediction) error
-
 	GetOperation(ctx context.Context, workflowID string) (*longrunningpb.Operation, error)
 	GetNamespaceLatestModelOperation(ctx context.Context, ns resource.Namespace, modelID string, view modelpb.View) (*longrunningpb.Operation, error)
 
@@ -943,8 +941,4 @@ func (s *service) CreateModelVersionAdmin(ctx context.Context, version *datamode
 
 func (s *service) DeleteModelVersionAdmin(ctx context.Context, modelUID uuid.UUID, versionID string) error {
 	return s.repository.DeleteModelVersionByID(ctx, modelUID, versionID)
-}
-
-func (s *service) CreateModelPrediction(ctx context.Context, prediction *datamodel.ModelPrediction) error {
-	return s.repository.CreateModelPrediction(ctx, prediction)
 }

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -85,12 +85,7 @@ func (w *worker) TriggerModelWorkflow(ctx workflow.Context, param *TriggerModelW
 	}
 
 	var usageData *utils.UsageMetricData
-	var modelPrediction *datamodel.ModelPrediction
 	if param.Mode == mgmtpb.Mode_MODE_ASYNC {
-		inputBlob, err := w.redisClient.Get(sCtx, param.InputKey).Bytes()
-		if err != nil {
-			return nil, w.toApplicationError(err, param.ModelID, ModelWorkflowError)
-		}
 		usageData = &utils.UsageMetricData{
 			TriggerUID:         param.TriggerUID.String(),
 			OwnerUID:           param.OwnerUID.String(),
@@ -103,23 +98,6 @@ func (w *worker) TriggerModelWorkflow(ctx workflow.Context, param *TriggerModelW
 			ModelDefinitionUID: param.ModelDefinitionUID.String(),
 			ModelTask:          param.Task,
 			TriggerTime:        startTime.Format(time.RFC3339Nano),
-		}
-		modelPrediction = &datamodel.ModelPrediction{
-			BaseStaticHardDelete: datamodel.BaseStaticHardDelete{
-				UID: param.TriggerUID,
-			},
-			OwnerUID:            param.OwnerUID,
-			OwnerType:           datamodel.UserType(usageData.OwnerType),
-			UserUID:             param.UserUID,
-			UserType:            datamodel.UserType(usageData.UserType),
-			Mode:                datamodel.Mode(usageData.Mode),
-			ModelDefinitionUID:  param.ModelDefinitionUID,
-			TriggerTime:         startTime,
-			ComputeTimeDuration: usageData.ComputeTimeDuration,
-			ModelTask:           datamodel.ModelTask(usageData.ModelTask),
-			ModelUID:            param.ModelUID,
-			ModelVersion:        param.ModelVersion.Version,
-			Input:               inputBlob,
 		}
 	}
 
@@ -149,9 +127,6 @@ func (w *worker) TriggerModelWorkflow(ctx workflow.Context, param *TriggerModelW
 	if param.Mode == mgmtpb.Mode_MODE_ASYNC {
 		usageData.ComputeTimeDuration = time.Since(startTime).Seconds()
 		usageData.Status = mgmtpb.Status_STATUS_COMPLETED
-		modelPrediction.ComputeTimeDuration = time.Since(startTime).Seconds()
-		modelPrediction.Status = datamodel.Status(mgmtpb.Status_STATUS_COMPLETED)
-		modelPrediction.Output = triggerResult.TaskOutputBytes
 		if err := w.writeNewDataPoint(sCtx, usageData); err != nil {
 			logger.Warn(err.Error())
 		}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -41,7 +41,6 @@ type TriggerModelWorkflowRequest struct {
 	UserType           string
 	ModelDefinitionUID uuid.UUID
 	Task               commonpb.Task
-	InputKey           string
 	ParsedInputKey     string
 	Mode               mgmtpb.Mode
 }
@@ -168,7 +167,6 @@ func (w *worker) TriggerModelActivity(ctx context.Context, param *TriggerModelAc
 	}
 	defer func() {
 		w.redisClient.Del(ctx, param.ParsedInputKey)
-		w.redisClient.Del(ctx, param.InputKey)
 		w.redisClient.Expire(
 			ctx,
 			fmt.Sprintf("model_trigger_input:%s:%s", param.UserUID, param.ModelUID.String()),


### PR DESCRIPTION
Because

- model prediction data struct is not needed anymore

This commit

- removed the struct and related functions
