### PR TITLE
feat(repository): support case-insensitive search models

### DIFF
--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -188,10 +188,10 @@ func (t *Transpiler) transpileComparisonCallExpr(e *expr.Expr, op any) (*clause.
 		switch ident.SQL {
 		// TODO we should support wildcards without special filter names
 		case "q":
-			sql = fmt.Sprintf("%s LIKE ?", "id")
+			sql = fmt.Sprintf("LOWER(%s) LIKE LOWER(?)", "id")
 			vars = append(vars, fmt.Sprintf("%%%s%%", con.Vars[0]))
 		case "q_title":
-			sql = fmt.Sprintf("%s LIKE ?", "title")
+			sql = fmt.Sprintf("LOWER(%s) LIKE LOWER(?)", "title")
 			vars = append(vars, fmt.Sprintf("%%%s%%", con.Vars[0]))
 		case "tag":
 			sql = "model_tag.tag_name = ?"


### PR DESCRIPTION
Because

- When performing fuzzy searches on models, case-insensitivity should be allowed.

This commit

- Supports case-insensitive searches for models.