### PR TITLE
chore(handler): add get repo tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240624201244-e8a5b1dcc4a1
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240708222431-209c7b3b6ff5
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -1320,8 +1320,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240624201244-e8a5b1dcc4a1 h1:Vxg7WEXNqzI9sj13SdDQP3wQC/6rRJ8mW1KnAnYiaIQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240624201244-e8a5b1dcc4a1/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240708222431-209c7b3b6ff5 h1:CZkUKdzp4TkVbrwov82B341R8Prw2wdmZVzDOl9jVEk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240708222431-209c7b3b6ff5/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -13,6 +13,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/resource"
 	"github.com/instill-ai/x/sterr"
 
+	artifactv1alpha "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
 	modelpb "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
@@ -110,6 +111,12 @@ func (h *PrivateHandler) deployNamespaceModelAdmin(ctx context.Context, req Depl
 		if err := h.service.CreateModelVersionAdmin(ctx, version); err != nil {
 			return err
 		}
+	}
+
+	if _, err := h.service.GetArtifactPrivateServiceClient().GetRepositoryTag(ctx, &artifactv1alpha.GetRepositoryTagRequest{
+		Name: fmt.Sprintf("repositories/%s/%s/tags/%s", ns.NsID, modelID, version.Version),
+	}); err != nil {
+		return err
 	}
 
 	if err := h.service.UpdateModelInstanceAdmin(ctx, ns, modelID, pbModel.GetHardware(), req.GetVersion(), true); err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -45,6 +45,7 @@ type Service interface {
 
 	// Utils
 	GetMgmtPrivateServiceClient() mgmtpb.MgmtPrivateServiceClient
+	GetArtifactPrivateServiceClient() artifactpb.ArtifactPrivateServiceClient
 	GetRepository() repository.Repository
 	GetRedisClient() *redis.Client
 	GetACLClient() *acl.ACLClient
@@ -158,6 +159,11 @@ func (s *service) GetACLClient() *acl.ACLClient {
 // GetMgmtPrivateServiceClient returns the management private service client
 func (s *service) GetMgmtPrivateServiceClient() mgmtpb.MgmtPrivateServiceClient {
 	return s.mgmtPrivateServiceClient
+}
+
+// GetArtifactPrivateServiceClient returns the management private service client
+func (s *service) GetArtifactPrivateServiceClient() artifactpb.ArtifactPrivateServiceClient {
+	return s.artifactPrivateServiceClient
 }
 
 // GetRayClient returns the ray client


### PR DESCRIPTION
Because

- model-backend should check the existence of the repo tag before deploying the model on Ray, to prevent fail deployment

This commit

- add repo tag check in admin deploy endpoint
