### PR TITLE
feat(service): check trigger permissions when impersonating an org

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -3,6 +3,7 @@ package datamodel
 import (
 	"database/sql"
 	"database/sql/driver"
+	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -85,6 +86,16 @@ type Model struct {
 	License            sql.NullString
 	ProfileImage       sql.NullString
 	Tags               []*ModelTag
+}
+
+// IsPublic returns the visibility of the model.
+func (m *Model) IsPublic() bool {
+	return m.Visibility == ModelVisibility(modelpb.Model_VISIBILITY_PUBLIC)
+}
+
+// OwnerUID returns the UID of the model owner.
+func (m *Model) OwnerUID() uuid.UUID {
+	return uuid.FromStringOrNil(strings.Split(m.Owner, "/")[1])
 }
 
 // Model version


### PR DESCRIPTION
Because

- Users can provide the `Instill-Requester-Uid` in order to trigger models on behalf of an organization.

This commit

- Limits the execution permissions when an organization namespace is
used to trigger a model. It checks:
    - User can impersonate the organization
    - If an organization is the requester and doesn't own the model, model has to be public
