### PR TITLE
chore(trigger): updated protogen-go and implemented model run logging…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
 	// todo: fetch from main branch when protogen-go changes merged
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240815012837-dd1e03c7d89a
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240816101745-44cbb332d242
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -1331,6 +1331,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240815012837-dd1e03c7d89a h1:Rl4kEfNkvg8281rgI5rFM3c5823/aRrert2BaIQQxvY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240815012837-dd1e03c7d89a/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240816101745-44cbb332d242 h1:4mP3CToV4oO5MkzAVVbcGqoMNS49AiaT0biNNv805Vs=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240816101745-44cbb332d242/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/datamodel/modeltrigger.go
+++ b/pkg/datamodel/modeltrigger.go
@@ -7,31 +7,31 @@ import (
 	"github.com/gofrs/uuid"
 	"gopkg.in/guregu/null.v4"
 
-	modelpb "github.com/instill-ai/protogen-go/model/model/v1alpha"
+	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
 )
 
 // for saving the protobuf types as string values
 type (
-	TriggerStatus modelpb.ModelRun_RunStatus
-	TriggerSource modelpb.ModelRun_RunSource
+	TriggerStatus runpb.RunStatus
+	TriggerSource runpb.RunSource
 )
 
 func (v *TriggerStatus) Scan(value any) error {
-	*v = TriggerStatus(modelpb.ModelRun_RunStatus_value[value.(string)])
+	*v = TriggerStatus(runpb.RunStatus_value[value.(string)])
 	return nil
 }
 
 func (v TriggerStatus) Value() (driver.Value, error) {
-	return modelpb.ModelRun_RunStatus(v).String(), nil
+	return runpb.RunStatus(v).String(), nil
 }
 
 func (v *TriggerSource) Scan(value any) error {
-	*v = TriggerSource(modelpb.ModelRun_RunSource_value[value.(string)])
+	*v = TriggerSource(runpb.RunSource_value[value.(string)])
 	return nil
 }
 
 func (v TriggerSource) Value() (driver.Value, error) {
-	return modelpb.ModelRun_RunSource(v).String(), nil
+	return runpb.RunSource(v).String(), nil
 }
 
 type ModelTrigger struct {

--- a/pkg/handler/mock_service_test.go
+++ b/pkg/handler/mock_service_test.go
@@ -432,18 +432,18 @@ func (mr *MockServiceMockRecorder) ListModelDefinitions(arg0, arg1, arg2, arg3 i
 }
 
 // ListModelTriggers mocks base method.
-func (m *MockService) ListModelTriggers(arg0 context.Context, arg1 *modelv1alpha.ListModelRunsRequest) (*modelv1alpha.ListModelRunsResponse, error) {
+func (m *MockService) ListModelTriggers(arg0 context.Context, arg1 *modelv1alpha.ListModelRunsRequest, arg2 filtering.Filter) (*modelv1alpha.ListModelRunsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelTriggers", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListModelTriggers", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*modelv1alpha.ListModelRunsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListModelTriggers indicates an expected call of ListModelTriggers.
-func (mr *MockServiceMockRecorder) ListModelTriggers(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) ListModelTriggers(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelTriggers", reflect.TypeOf((*MockService)(nil).ListModelTriggers), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelTriggers", reflect.TypeOf((*MockService)(nil).ListModelTriggers), arg0, arg1, arg2)
 }
 
 // ListModels mocks base method.

--- a/pkg/mock/mock_repository.go
+++ b/pkg/mock/mock_repository.go
@@ -7,7 +7,6 @@ package mock
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	uuid "github.com/gofrs/uuid"
 	gomock "github.com/golang/mock/gomock"
@@ -291,9 +290,9 @@ func (mr *MockRepositoryMockRecorder) ListModelTags(arg0, arg1 interface{}) *gom
 }
 
 // ListModelTriggers mocks base method.
-func (m *MockRepository) ListModelTriggers(arg0 context.Context, arg1, arg2 int64, arg3 ordering.OrderBy, arg4 string, arg5, arg6 *time.Time) ([]*datamodel.ModelTrigger, int64, error) {
+func (m *MockRepository) ListModelTriggers(arg0 context.Context, arg1, arg2 int64, arg3 filtering.Filter, arg4 ordering.OrderBy, arg5 string) ([]*datamodel.ModelTrigger, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelTriggers", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "ListModelTriggers", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].([]*datamodel.ModelTrigger)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
@@ -301,9 +300,9 @@ func (m *MockRepository) ListModelTriggers(arg0 context.Context, arg1, arg2 int6
 }
 
 // ListModelTriggers indicates an expected call of ListModelTriggers.
-func (mr *MockRepositoryMockRecorder) ListModelTriggers(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListModelTriggers(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelTriggers", reflect.TypeOf((*MockRepository)(nil).ListModelTriggers), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelTriggers", reflect.TypeOf((*MockRepository)(nil).ListModelTriggers), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // ListModelVersions mocks base method.

--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -16,7 +16,8 @@ import (
 
 // Transpiler data
 type Transpiler struct {
-	filter filtering.Filter
+	filter    filtering.Filter
+	tableName string
 }
 
 func NewTranspiler(filter filtering.Filter) Transpiler {
@@ -181,7 +182,7 @@ func (t *Transpiler) transpileComparisonCallExpr(e *expr.Expr, op any) (*clause.
 	// TODO: we should remove the hardcode table prefix here.
 	// Add "pipeline." prefix to prevent ambiguous since tag table also has the two columns.
 	if ident.SQL == "create_time" || ident.SQL == "update_time" {
-		ident.SQL = "model." + ident.SQL
+		ident.SQL = t.tableName + "." + ident.SQL
 	}
 	switch op.(type) {
 	case clause.Eq:

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/gojuno/minimock/v3"
 	"github.com/golang/mock/gomock"
+	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
 	taskv1alpha "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 	"github.com/redis/go-redis/v9"
@@ -86,7 +87,7 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 		param.ParsedInputKey = "ParsedInputKey"
 		param.Task = taskv1alpha.Task_TASK_TEXT_GENERATION
 		param.Visibility = datamodel.ModelVisibility(modelPB.Model_VISIBILITY_PRIVATE)
-		param.Source = datamodel.TriggerSource(modelPB.ModelRun_RUN_SOURCE_API)
+		param.Source = datamodel.TriggerSource(runpb.RunSource_RUN_SOURCE_API)
 
 		mockRay := NewMockRay(ctrl)
 		ctx := context.Background()
@@ -128,7 +129,7 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 			UID:              uid,
 			ModelUID:         param.ModelUID,
 			ModelVersion:     param.ModelVersion.Version,
-			Status:           datamodel.TriggerStatus(modelPB.ModelRun_RUN_STATUS_PROCESSING),
+			Status:           datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
 			Source:           param.Source,
 			RequesterUID:     param.RequesterUID,
 			InputReferenceID: param.InputReferenceID,
@@ -158,7 +159,7 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 		param.ParsedInputKey = "ParsedInputKey"
 		param.Task = taskv1alpha.Task_TASK_TEXT_GENERATION
 		param.Visibility = datamodel.ModelVisibility(modelPB.Model_VISIBILITY_PRIVATE)
-		param.Source = datamodel.TriggerSource(modelPB.ModelRun_RUN_SOURCE_API)
+		param.Source = datamodel.TriggerSource(runpb.RunSource_RUN_SOURCE_API)
 
 		mockRay := NewMockRay(ctrl)
 		ctx := context.Background()
@@ -176,7 +177,7 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 			UID:              uid,
 			ModelUID:         param.ModelUID,
 			ModelVersion:     param.ModelVersion.Version,
-			Status:           datamodel.TriggerStatus(modelPB.ModelRun_RUN_STATUS_PROCESSING),
+			Status:           datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
 			Source:           param.Source,
 			RequesterUID:     param.RequesterUID,
 			InputReferenceID: param.InputReferenceID,

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
 	"github.com/minio/minio-go/v7"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -172,7 +173,7 @@ func (w *worker) TriggerModelActivity(ctx context.Context, param *TriggerModelAc
 	runLog, err := w.repository.CreateModelTrigger(ctx, &datamodel.ModelTrigger{
 		ModelUID:         param.ModelUID,
 		ModelVersion:     param.ModelVersion.Version,
-		Status:           datamodel.TriggerStatus(modelpb.ModelRun_RUN_STATUS_PROCESSING),
+		Status:           datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
 		Source:           param.Source,
 		RequesterUID:     param.RequesterUID,
 		InputReferenceID: param.InputReferenceID,
@@ -185,7 +186,7 @@ func (w *worker) TriggerModelActivity(ctx context.Context, param *TriggerModelAc
 	succeeded := false
 	defer func() {
 		if err != nil || !succeeded {
-			runLog.Status = datamodel.TriggerStatus(modelpb.ModelRun_RUN_STATUS_FAILED)
+			runLog.Status = datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_FAILED)
 			endTime := time.Now()
 			timeUsed := endTime.Sub(start)
 			runLog.TotalDuration = null.IntFrom(timeUsed.Milliseconds())
@@ -343,7 +344,7 @@ func (w *worker) TriggerModelActivity(ctx context.Context, param *TriggerModelAc
 	runLog.TotalDuration = null.IntFrom(timeUsed.Milliseconds())
 	runLog.EndTime = null.TimeFrom(endTime)
 	runLog.OutputReferenceID = null.StringFrom(outputReferenceID)
-	runLog.Status = datamodel.TriggerStatus(modelpb.ModelRun_RUN_STATUS_COMPLETED)
+	runLog.Status = datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_COMPLETED)
 	if err = w.repository.UpdateModelTrigger(ctx, runLog); err != nil {
 		return nil, w.toApplicationError(err, param.ModelID, ModelActivityError)
 	}


### PR DESCRIPTION
… filter

Because

- we need to view details for a single run

This commit

- updated protogen-go and implemented model run logging filter

![image](https://github.com/user-attachments/assets/201db4c0-9df8-4225-a71f-cf2dbd683ed9)
