### PR TITLE
fix(redis): fix input value overwrite

### DIFF
--- a/pkg/handler/stream.go
+++ b/pkg/handler/stream.go
@@ -695,6 +695,7 @@ func (h *PublicHandler) TriggerNamespaceLatestModelBinaryFileUpload(stream model
 	return err
 }
 
+// TODO: to be reimplemented
 func (h *PublicHandler) triggerNamespaceModelBinaryFileUpload(ctx context.Context, triggerInput any, namespaceID, modelID, versionID string) ([]*modelpb.TaskOutput, *commonpb.Task, error) {
 
 	startTime := time.Now()
@@ -810,7 +811,7 @@ func (h *PublicHandler) triggerNamespaceModelBinaryFileUpload(ctx context.Contex
 		return nil, nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	response, err := h.service.TriggerNamespaceModelByID(ctx, ns, modelID, version, parsedInputJSON, pbModel.Task, logUUID.String())
+	response, err := h.service.TriggerNamespaceModelByID(ctx, ns, modelID, version, parsedInputJSON, parsedInputJSON, pbModel.Task, logUUID.String())
 	if err != nil {
 		st, e := sterr.CreateErrorResourceInfo(
 			codes.FailedPrecondition,

--- a/pkg/handler/trigger.go
+++ b/pkg/handler/trigger.go
@@ -227,12 +227,6 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 	if err != nil {
 		return 0, nil, err
 	}
-	h.service.GetRedisClient().Set(
-		ctx,
-		fmt.Sprintf("%s:%s:%s", constant.ModelTriggerInputKey, userUID.String(), pbModel.Uid),
-		inputRequestJSON,
-		time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-	)
 
 	var parsedInput any
 	var lenInputs = 1
@@ -318,7 +312,7 @@ func (h *PublicHandler) triggerNamespaceModel(ctx context.Context, req TriggerNa
 		return commonpb.Task_TASK_UNSPECIFIED, nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	response, err := h.service.TriggerNamespaceModelByID(ctx, ns, req.GetModelId(), version, parsedInputJSON, pbModel.Task, logUUID.String())
+	response, err := h.service.TriggerNamespaceModelByID(ctx, ns, req.GetModelId(), version, inputRequestJSON, parsedInputJSON, pbModel.Task, logUUID.String())
 	if err != nil {
 		st, e := sterr.CreateErrorResourceInfo(
 			codes.FailedPrecondition,
@@ -668,6 +662,7 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 	return operation, nil
 }
 
+// TODO: to be reimplement
 func inferModelByUpload(s service.Service, _ repository.Repository, w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 
 	startTime := time.Now()
@@ -882,7 +877,7 @@ func inferModelByUpload(s service.Service, _ repository.Repository, w http.Respo
 	}
 
 	var response []*modelpb.TaskOutput
-	response, err = s.TriggerNamespaceModelByID(ctx, ns, modelID, version, parsedInputJSON, pbModel.Task, logUUID.String())
+	response, err = s.TriggerNamespaceModelByID(ctx, ns, modelID, version, parsedInputJSON, parsedInputJSON, pbModel.Task, logUUID.String())
 	if err != nil {
 		st, e := sterr.CreateErrorResourceInfo(
 			codes.FailedPrecondition,


### PR DESCRIPTION
Because

- We cannot use the same redis key for sync trigger input and async trigger input, it will overwrite each other.
- We do not need to use redis if uploading files is done in model-backend. Redis is only used for transferring data between model-backend and temporal workers

This commit

- remove redis.set in sync trigger handler
