### PR TITLE
feat(ray): add separate state for scaling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
 	// todo: fetch from main branch when protogen-go changes merged
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240816101745-44cbb332d242
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240819185125-3f9f6f7c76a3
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -1329,10 +1329,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240815012837-dd1e03c7d89a h1:Rl4kEfNkvg8281rgI5rFM3c5823/aRrert2BaIQQxvY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240815012837-dd1e03c7d89a/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240816101745-44cbb332d242 h1:4mP3CToV4oO5MkzAVVbcGqoMNS49AiaT0biNNv805Vs=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240816101745-44cbb332d242/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240819185125-3f9f6f7c76a3 h1:fphXjgID38PyjasIEZUd5rj0wStAw2jvGWBEEq0th0Q=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240819185125-3f9f6f7c76a3/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -182,18 +182,30 @@ func (r *ray) ModelReady(ctx context.Context, modelName string, version string) 
 				}
 			case rayserver.DeploymentStatusStrUpdating:
 				return modelpb.State_STATE_STARTING.Enum(), application.Deployments[i].Message, nil
-			case rayserver.DeploymentStatusStrUpscaling, rayserver.DeploymentStatusStrDownscaling:
-				return modelpb.State_STATE_SCALING.Enum(), application.Deployments[i].Message, nil
+			case rayserver.DeploymentStatusStrUpscaling:
+				return modelpb.State_STATE_SCALING_UP.Enum(), application.Deployments[i].Message, nil
+			case rayserver.DeploymentStatusStrDownscaling:
+				return modelpb.State_STATE_SCALING_DOWN.Enum(), application.Deployments[i].Message, nil
 			case rayserver.DeploymentStatusStrUnhealthy:
 				return modelpb.State_STATE_ERROR.Enum(), application.Deployments[i].Message, nil
 			}
 		}
 		return modelpb.State_STATE_ERROR.Enum(), application.Message, nil
-	case rayserver.ApplicationStatusStrDeploying, rayserver.ApplicationStatusStrDeleting:
+	case rayserver.ApplicationStatusStrDeploying:
 		for i := range application.Deployments {
 			switch application.Deployments[i].Status {
 			case rayserver.DeploymentStatusStrUpdating:
-				return modelpb.State_STATE_SCALING.Enum(), application.Deployments[i].Message, nil
+				return modelpb.State_STATE_SCALING_UP.Enum(), application.Deployments[i].Message, nil
+			case rayserver.DeploymentStatusStrUnhealthy:
+				return modelpb.State_STATE_ERROR.Enum(), application.Deployments[i].Message, nil
+			}
+		}
+		return modelpb.State_STATE_STARTING.Enum(), application.Message, nil
+	case rayserver.ApplicationStatusStrDeleting:
+		for i := range application.Deployments {
+			switch application.Deployments[i].Status {
+			case rayserver.DeploymentStatusStrUpdating:
+				return modelpb.State_STATE_SCALING_DOWN.Enum(), application.Deployments[i].Message, nil
 			case rayserver.DeploymentStatusStrUnhealthy:
 				return modelpb.State_STATE_ERROR.Enum(), application.Deployments[i].Message, nil
 			}


### PR DESCRIPTION
Because

- When only "Scaling" is displayed, users don't know which specific status it refers to.

This commit

- add separate states for scaling