### PR TITLE
feat(model): support model statistics in model message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
-	// todo: fetch from main branch when protogen-go changes merged
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240819185125-3f9f6f7c76a3
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240820090807-8ddfc17c2eaf
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -1329,8 +1329,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240819185125-3f9f6f7c76a3 h1:fphXjgID38PyjasIEZUd5rj0wStAw2jvGWBEEq0th0Q=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240819185125-3f9f6f7c76a3/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240820090807-8ddfc17c2eaf h1:64n0248rIwujbwOVdkLv2LdCEsoBOM5ilY2/FlwtRJI=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240820090807-8ddfc17c2eaf/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -89,6 +89,13 @@ type Model struct {
 	Versions           []*ModelVersion
 	NamespaceID        string `gorm:"type:namespace_id"`
 	NamespaceType      string `gorm:"type:namespace_type"`
+
+	// Note:
+	// We store the NumberOfRuns and LastRunTime in this table
+	// to make it easier to sort the models. We should develop an approach to
+	// sync the data between InfluxDB and here.
+	LastRunTime  time.Time
+	NumberOfRuns int
 }
 
 // IsPublic returns the visibility of the model.
@@ -199,6 +206,8 @@ func (r ReleaseStage) Value() (driver.Value, error) {
 }
 
 const (
-	FieldCreateTime = "create_time"
-	FieldUpdateTime = "update_time"
+	FieldCreateTime   = "create_time"
+	FieldUpdateTime   = "update_time"
+	FieldLastRunTime  = "last_run_time"
+	FieldNumberOfRuns = "number_of_runs"
 )

--- a/pkg/db/migration/000009_model_trigger.down.sql
+++ b/pkg/db/migration/000009_model_trigger.down.sql
@@ -1,7 +1,12 @@
 BEGIN;
 
-drop table if exists model_trigger;
-drop type if exists valid_trigger_status;
-drop type if exists valid_trigger_source;
+DROP TABLE IF EXISTS model_trigger;
+DROP TYPE IF EXISTS valid_trigger_status;
+DROP TYPE IF EXISTS valid_trigger_source;
+
+ALTER TABLE model DROP COLUMN number_of_runs;
+ALTER TABLE model DROP COLUMN last_run_time;
+DROP INDEX IF EXISTS model_number_of_runs;
+DROP INDEX IF EXISTS model_last_run_time;
 
 COMMIT;

--- a/pkg/db/migration/000009_model_trigger.up.sql
+++ b/pkg/db/migration/000009_model_trigger.up.sql
@@ -1,34 +1,39 @@
 BEGIN;
 
-create type valid_trigger_status as enum ('RUN_STATUS_COMPLETED', 'RUN_STATUS_FAILED', 'RUN_STATUS_PROCESSING', 'RUN_STATUS_QUEUED');
-create type valid_trigger_source as enum ('RUN_SOURCE_CONSOLE', 'RUN_SOURCE_API');
+CREATE TYPE valid_trigger_status AS ENUM ('RUN_STATUS_COMPLETED', 'RUN_STATUS_FAILED', 'RUN_STATUS_PROCESSING', 'RUN_STATUS_QUEUED');
+CREATE TYPE valid_trigger_source AS ENUM ('RUN_SOURCE_CONSOLE', 'RUN_SOURCE_API');
 
-create table model_trigger
+CREATE TABLE model_trigger
 (
-    uid                 uuid primary key         default gen_random_uuid(),
-    model_uid           uuid                                               not null,
-    model_version       varchar(255)                                       not null,
-    status              valid_trigger_status                               not null,
-    source              valid_trigger_source                               not null,
-    total_duration      bigint,
-    end_time            timestamp with time zone,
-    requester_uid       uuid                                               not null,
-    input_reference_id  varchar(255)                                       not null,
-    output_reference_id varchar(255)                                       null,
-    error               text                     default ''::text,
-    create_time         timestamp with time zone default CURRENT_TIMESTAMP not null,
-    update_time         timestamp with time zone default CURRENT_TIMESTAMP not null
+    uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    model_uid uuid NOT NULL,
+    model_version varchar(255) NOT NULL,
+    status valid_trigger_status NOT NULL,
+    source valid_trigger_source NOT NULL,
+    total_duration bigint,
+    end_time timestamp with time zone,
+    requester_uid uuid NOT NULL,
+    input_reference_id varchar(255) NOT NULL,
+    output_reference_id varchar(255) NULL,
+    error text DEFAULT ''::text,
+    create_time timestamp with time zone DEFAULT current_timestamp NOT NULL,
+    update_time timestamp with time zone DEFAULT current_timestamp NOT NULL
 );
 
-comment on column model_trigger.total_duration is 'in milliseconds';
+COMMENT ON COLUMN model_trigger.total_duration IS 'in milliseconds';
 
-create index model_trigger_model_uid_index
-    on model_trigger (model_uid);
+CREATE INDEX model_trigger_model_uid_index
+ON model_trigger (model_uid);
 
-create index model_trigger_requester_uid_index
-    on model_trigger (requester_uid);
+CREATE INDEX model_trigger_requester_uid_index
+ON model_trigger (requester_uid);
 
-create index model_trigger_create_time_index
-    on model_trigger (create_time);
+CREATE INDEX model_trigger_create_time_index
+ON model_trigger (create_time);
+
+ALTER TABLE model ADD COLUMN number_of_runs integer DEFAULT 0;
+ALTER TABLE model ADD COLUMN last_run_time timestamptz DEFAULT '0001-01-01T00:00:00Z';
+CREATE INDEX model_number_of_runs ON model (number_of_runs);
+CREATE INDEX model_last_run_time ON model (last_run_time);
 
 COMMIT;

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -191,6 +191,10 @@ func (s *service) DBToPBModel(ctx context.Context, modelDef *datamodel.ModelDefi
 		ProfileImage:     &profileImage,
 		Tags:             dbModel.TagNames(),
 		Versions:         dbModel.VersionNames(),
+		Stats: &modelpb.Model_Stats{
+			NumberOfRuns: int32(dbModel.NumberOfRuns),
+			LastRunTime:  timestamppb.New(dbModel.LastRunTime),
+		},
 	}
 
 	pbModel.Permission = &modelpb.Permission{}


### PR DESCRIPTION
Because

- On the Explore page, all models are publicly available. Displaying the "Run" count will help new users who are unsure of what they need to start with the most popular models. One of the indicators for popularity is the number of times a model has been run.
- For users managing their own resources, it allows a quick understanding of the popularity of their models, whether public or private.

This commit

- support model statistics in model message
