### PR TITLE
feat(model): support num_of_runs in list filter

### DIFF
--- a/pkg/handler/public.go
+++ b/pkg/handler/public.go
@@ -68,6 +68,7 @@ func (h *PublicHandler) ListModels(ctx context.Context, req *modelpb.ListModelsR
 		filtering.DeclareIdent("id", filtering.TypeString),
 		// Currently, we only have a "featured" tag, so we'll only support single tag filter for now.
 		filtering.DeclareIdent("tag", filtering.TypeString),
+		filtering.DeclareIdent("number_of_runs", filtering.TypeInt),
 		filtering.DeclareIdent("description", filtering.TypeString),
 		filtering.DeclareIdent("owner", filtering.TypeString),
 		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
@@ -292,6 +293,7 @@ func (h *PublicHandler) ListNamespaceModels(ctx context.Context, req *modelpb.Li
 		filtering.DeclareIdent("id", filtering.TypeString),
 		// Currently, we only have a "featured" tag, so we'll only support single tag filter for now.
 		filtering.DeclareIdent("tag", filtering.TypeString),
+		filtering.DeclareIdent("number_of_runs", filtering.TypeInt),
 		filtering.DeclareIdent("description", filtering.TypeString),
 		filtering.DeclareIdent("owner", filtering.TypeString),
 		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),


### PR DESCRIPTION
Because

- When models are displayed on the Explore page, they are shown as long as they are set to "public," with no other conditions or restrictions. The Explore page aims to be attractive and meaningful to users. Therefore, it is important that models are only shared if the owner has run them successfully at least once before sharing with others.

This commit

- support `num_of_runs` in list filter
