### PR TITLE
chore(filter): remove wrong case

### DIFF
--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -197,9 +197,6 @@ func (t *Transpiler) transpileComparisonCallExpr(e *expr.Expr, op any) (*clause.
 		case "tag":
 			sql = "model_tag.tag_name = ?"
 			vars = append(vars, con.Vars...)
-		case "numberOfRuns":
-			sql = "number_of_runs >= ?"
-			vars = append(vars, con.Vars...)
 		default:
 			sql = fmt.Sprintf("%s = ?", ident.SQL)
 			vars = append(vars, con.Vars...)


### PR DESCRIPTION
Because

- remove wrong transpiler expr case

This commit

- remove wrong transpiler expr case
