### PR TITLE
feat(redis): replace I/O data retrieval from redis with minio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
 	// todo: fetch from main branch when protogen-go changes merged
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240821064525-8e6de58da061
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823094247-7e590cc3a0d2
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -1329,8 +1329,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240821064525-8e6de58da061 h1:oewJfLF4UlabEV3CLuCjLgwo1untxckrOtq9pqJitR4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240821064525-8e6de58da061/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823094247-7e590cc3a0d2 h1:xHQ4UVh6u/cESlZ2CRNP5AemV0ogJ6wezoq+M4S4Z6I=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823094247-7e590cc3a0d2/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -20,5 +20,3 @@ const HeaderUserAgent = "Instill-User-Agent"
 const RayProtoPath string = "assets/ray/proto"
 
 const ContentTypeJSON = "application/json"
-
-const ModelTriggerInputKey = "model_trigger_input"

--- a/pkg/datamodel/modeltrigger.go
+++ b/pkg/datamodel/modeltrigger.go
@@ -2,7 +2,6 @@ package datamodel
 
 import (
 	"database/sql/driver"
-	"time"
 
 	"github.com/gofrs/uuid"
 	"gopkg.in/guregu/null.v4"
@@ -35,7 +34,7 @@ func (v TriggerSource) Value() (driver.Value, error) {
 }
 
 type ModelTrigger struct {
-	UID               uuid.UUID `gorm:"type:uuid;primary_key;default:uuid_generate_v4()"`
+	BaseStaticHardDelete
 	ModelUID          uuid.UUID
 	ModelVersion      string
 	Status            TriggerStatus
@@ -46,6 +45,4 @@ type ModelTrigger struct {
 	InputReferenceID  string
 	OutputReferenceID null.String
 	Error             null.String
-	CreateTime        time.Time `gorm:"autoCreateTime:nano"`
-	UpdateTime        time.Time `gorm:"autoUpdateTime:nano"`
 }

--- a/pkg/db/migration/000009_model_trigger.up.sql
+++ b/pkg/db/migration/000009_model_trigger.up.sql
@@ -5,7 +5,7 @@ CREATE TYPE valid_trigger_source AS ENUM ('RUN_SOURCE_CONSOLE', 'RUN_SOURCE_API'
 
 CREATE TABLE model_trigger
 (
-    uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    uid uuid PRIMARY KEY,
     model_uid uuid NOT NULL,
     model_version varchar(255) NOT NULL,
     status valid_trigger_status NOT NULL,

--- a/pkg/handler/public.go
+++ b/pkg/handler/public.go
@@ -1094,7 +1094,7 @@ func (h *PublicHandler) ListAvailableRegions(ctx context.Context, req *modelpb.L
 
 func (h *PublicHandler) ListModelRuns(ctx context.Context, req *modelpb.ListModelRunsRequest) (*modelpb.ListModelRunsResponse, error) {
 
-	eventName := "ListModelTriggers"
+	eventName := "ListModelRuns"
 
 	ctx, span := tracer.Start(ctx, eventName,
 		trace.WithSpanKind(trace.SpanKindServer))

--- a/pkg/handler/trigger.go
+++ b/pkg/handler/trigger.go
@@ -629,10 +629,17 @@ func (h *PublicHandler) triggerAsyncNamespaceModel(ctx context.Context, req Trig
 		return nil, err
 	}
 
-	// TODO: temporary solution to store output json
+	// latest operation
 	h.service.GetRedisClient().Set(
 		ctx,
 		fmt.Sprintf("model_trigger_output_key:%s:%s:%s", userUID, pbModel.Uid, versionID),
+		operation.GetName(),
+		time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
+	)
+	// latest version operation
+	h.service.GetRedisClient().Set(
+		ctx,
+		fmt.Sprintf("model_trigger_output_key:%s:%s:%s", userUID, pbModel.Uid, version.Version),
 		operation.GetName(),
 		time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
 	)

--- a/pkg/mock/mock_repository.go
+++ b/pkg/mock/mock_repository.go
@@ -152,6 +152,21 @@ func (mr *MockRepositoryMockRecorder) DeleteNamespaceModelByID(arg0, arg1, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespaceModelByID", reflect.TypeOf((*MockRepository)(nil).DeleteNamespaceModelByID), arg0, arg1, arg2)
 }
 
+// GetLatestModelTriggerByModelUID mocks base method.
+func (m *MockRepository) GetLatestModelTriggerByModelUID(arg0 context.Context, arg1, arg2 string) (*datamodel.ModelTrigger, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestModelTriggerByModelUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*datamodel.ModelTrigger)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestModelTriggerByModelUID indicates an expected call of GetLatestModelTriggerByModelUID.
+func (mr *MockRepositoryMockRecorder) GetLatestModelTriggerByModelUID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestModelTriggerByModelUID", reflect.TypeOf((*MockRepository)(nil).GetLatestModelTriggerByModelUID), arg0, arg1, arg2)
+}
+
 // GetLatestModelVersionByModelUID mocks base method.
 func (m *MockRepository) GetLatestModelVersionByModelUID(arg0 context.Context, arg1 uuid.UUID) (*datamodel.ModelVersion, error) {
 	m.ctrl.T.Helper()
@@ -165,6 +180,21 @@ func (m *MockRepository) GetLatestModelVersionByModelUID(arg0 context.Context, a
 func (mr *MockRepositoryMockRecorder) GetLatestModelVersionByModelUID(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestModelVersionByModelUID", reflect.TypeOf((*MockRepository)(nil).GetLatestModelVersionByModelUID), arg0, arg1)
+}
+
+// GetLatestModelVersionTriggerByModelUID mocks base method.
+func (m *MockRepository) GetLatestModelVersionTriggerByModelUID(arg0 context.Context, arg1, arg2, arg3 string) (*datamodel.ModelTrigger, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestModelVersionTriggerByModelUID", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*datamodel.ModelTrigger)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestModelVersionTriggerByModelUID indicates an expected call of GetLatestModelVersionTriggerByModelUID.
+func (mr *MockRepositoryMockRecorder) GetLatestModelVersionTriggerByModelUID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestModelVersionTriggerByModelUID", reflect.TypeOf((*MockRepository)(nil).GetLatestModelVersionTriggerByModelUID), arg0, arg1, arg2, arg3)
 }
 
 // GetModelByUID mocks base method.
@@ -225,6 +255,21 @@ func (m *MockRepository) GetModelDefinitionByUID(arg0 uuid.UUID) (*datamodel.Mod
 func (mr *MockRepositoryMockRecorder) GetModelDefinitionByUID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelDefinitionByUID", reflect.TypeOf((*MockRepository)(nil).GetModelDefinitionByUID), arg0)
+}
+
+// GetModelTriggerByTriggerUID mocks base method.
+func (m *MockRepository) GetModelTriggerByTriggerUID(arg0 context.Context, arg1 string) (*datamodel.ModelTrigger, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModelTriggerByTriggerUID", arg0, arg1)
+	ret0, _ := ret[0].(*datamodel.ModelTrigger)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetModelTriggerByTriggerUID indicates an expected call of GetModelTriggerByTriggerUID.
+func (mr *MockRepositoryMockRecorder) GetModelTriggerByTriggerUID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelTriggerByTriggerUID", reflect.TypeOf((*MockRepository)(nil).GetModelTriggerByTriggerUID), arg0, arg1)
 }
 
 // GetModelVersionByID mocks base method.

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -447,4 +447,6 @@ func (r *ray) Close() {
 	if r.connection != nil {
 		r.connection.Close()
 	}
+	close(r.configChan)
+	close(r.doneChan)
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -90,9 +90,9 @@ func UserUIDToUserPermalink(userUID uuid.UUID) string {
 	return fmt.Sprintf("users/%s", userUID.String())
 }
 
-func GetOperationID(name string) (string, error) {
-	id := strings.TrimPrefix(name, "operations/")
-	if !strings.HasPrefix(name, "operations/") || id == "" {
+func GetWorkflowID(operationID string) (string, error) {
+	id := strings.TrimPrefix(operationID, "operations/")
+	if !strings.HasPrefix(operationID, "operations/") || id == "" {
 		return "", status.Error(codes.InvalidArgument, "Error when extract operations resource id")
 	}
 	return id, nil

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -17,8 +17,8 @@ const TaskQueue = "model-backend"
 
 // Worker interface
 type Worker interface {
-	TriggerModelWorkflow(ctx workflow.Context, param *TriggerModelWorkflowRequest) (*TriggerModelWorkflowResponse, error)
-	TriggerModelActivity(ctx context.Context, param *TriggerModelActivityRequest) (*TriggerModelActivityResponse, error)
+	TriggerModelWorkflow(ctx workflow.Context, param *TriggerModelWorkflowRequest) error
+	TriggerModelActivity(ctx context.Context, param *TriggerModelActivityRequest) error
 	UploadToMinioActivity(ctx context.Context, param *UploadToMinioActivityRequest) (*UploadToMinioActivityResponse, error)
 }
 

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -47,7 +47,7 @@ func TestWorker_TriggerModelWorkflow(t *testing.T) {
 		mockRay := NewMockRay(ctrl)
 
 		w := worker.NewWorker(rc, mockRay, nil, nil, nil)
-		_, err = w.TriggerModelWorkflow(workflow.Context(nil), param)
+		err = w.TriggerModelWorkflow(workflow.Context(nil), param)
 		require.NoError(t, err)
 	})
 }
@@ -126,23 +126,20 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 
 		uid, _ := uuid.NewV4()
 		modelTrigger := &datamodel.ModelTrigger{
-			UID:              uid,
-			ModelUID:         param.ModelUID,
-			ModelVersion:     param.ModelVersion.Version,
-			Status:           datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
-			Source:           param.Source,
-			RequesterUID:     param.RequesterUID,
-			InputReferenceID: param.InputReferenceID,
+			BaseStaticHardDelete: datamodel.BaseStaticHardDelete{UID: uid},
+			ModelUID:             param.ModelUID,
+			ModelVersion:         param.ModelVersion.Version,
+			Status:               datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
+			Source:               param.Source,
+			RequesterUID:         param.RequesterUID,
+			InputReferenceID:     param.InputReferenceID,
 		}
 		repo.EXPECT().CreateModelTrigger(gomock.Any(), gomock.Any()).Return(modelTrigger, nil).Times(1)
 		repo.EXPECT().UpdateModelTrigger(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		w := worker.NewWorker(rc, mockRay, repo, mockMinio, nil)
-		resp, err := w.TriggerModelActivity(ctx, param)
+		err := w.TriggerModelActivity(ctx, param)
 		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.Contains(t, resp.OutputKey, "async_model_response:")
-		require.Contains(t, string(resp.TaskOutputBytes), "You are a friendly chatbot")
 	})
 
 	t.Run("when model is offline", func(t *testing.T) {
@@ -174,19 +171,19 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 
 		uid, _ := uuid.NewV4()
 		modelTrigger := &datamodel.ModelTrigger{
-			UID:              uid,
-			ModelUID:         param.ModelUID,
-			ModelVersion:     param.ModelVersion.Version,
-			Status:           datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
-			Source:           param.Source,
-			RequesterUID:     param.RequesterUID,
-			InputReferenceID: param.InputReferenceID,
+			BaseStaticHardDelete: datamodel.BaseStaticHardDelete{UID: uid},
+			ModelUID:             param.ModelUID,
+			ModelVersion:         param.ModelVersion.Version,
+			Status:               datamodel.TriggerStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
+			Source:               param.Source,
+			RequesterUID:         param.RequesterUID,
+			InputReferenceID:     param.InputReferenceID,
 		}
 		repo.EXPECT().CreateModelTrigger(gomock.Any(), gomock.Any()).Return(modelTrigger, nil).Times(1)
 		repo.EXPECT().UpdateModelTrigger(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		w := worker.NewWorker(rc, mockRay, repo, nil, nil)
-		_, err = w.TriggerModelActivity(ctx, param)
+		err = w.TriggerModelActivity(ctx, param)
 		require.ErrorContains(t, err, "model is offline")
 	})
 }


### PR DESCRIPTION
Because

- We now store each trigger I/O data in minio, we do not need to store/retrieve data from `redis` anymore
- FE now support triggering model with selected version

This commit

- replace I/O data retrieval from redis with minio
- support getting latest operation with particular model version
