### PR TITLE
chore(trigger): allow triggering in offline/start/scaling state

### DIFF
--- a/pkg/handler/trigger.go
+++ b/pkg/handler/trigger.go
@@ -427,14 +427,7 @@ type TriggerAsyncNamespaceModelRequestInterface interface {
 func (h *PublicHandler) TriggerAsyncNamespaceModel(ctx context.Context, req *modelpb.TriggerAsyncNamespaceModelRequest) (resp *modelpb.TriggerAsyncNamespaceModelResponse, err error) {
 	resp = &modelpb.TriggerAsyncNamespaceModelResponse{}
 
-	r := &modelpb.TriggerAsyncNamespaceModelRequest{
-		NamespaceId: req.GetNamespaceId(),
-		ModelId:     req.GetModelId(),
-		Version:     req.GetVersion(),
-		TaskInputs:  req.GetTaskInputs(),
-	}
-
-	resp.Operation, err = h.triggerAsyncNamespaceModel(ctx, r)
+	resp.Operation, err = h.triggerAsyncNamespaceModel(ctx, req)
 
 	return resp, err
 }

--- a/pkg/ray/const.go
+++ b/pkg/ray/const.go
@@ -292,3 +292,7 @@ const (
 	EnvNumOfMinReplicas   = "RAY_NUM_OF_MIN_REPLICAS"
 	EnvNumOfMaxReplicas   = "RAY_NUM_OF_MAX_REPLICAS"
 )
+
+const (
+	DummyModelPrefix = "dummy-"
+)

--- a/pkg/ray/util.go
+++ b/pkg/ray/util.go
@@ -12,6 +12,16 @@ import (
 	"github.com/instill-ai/model-backend/pkg/ray/rayserver"
 )
 
+func GenerateScalingConfig(modelID string) []string {
+	if strings.HasPrefix(modelID, DummyModelPrefix) {
+		return []string{
+			fmt.Sprintf("-e %s=%v", EnvIsTestModel, "true"),
+		}
+	}
+
+	return []string{}
+}
+
 func SerializeBytesTensor(tensor [][]byte) []byte {
 	// TODO: return error status here
 	// Prepend 4-byte length to the input

--- a/pkg/service/const.go
+++ b/pkg/service/const.go
@@ -1,7 +1,3 @@
 package service
 
-const (
-	DummyModelPrefix = "dummy-"
-)
-
 var preserveTags = []string{"featured", "feature"}

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -97,6 +97,18 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 		err = json.Unmarshal([]byte(`["RAEAADx8c3lzdGVtfD4KWW91IGFyZSBhIGZyaWVuZGx5IGNoYXRib3Q8L3M+Cjx8dXNlcnw+CndoYXQgZG9lcyB0aGUgY29tcGFueSB0ZXNsYSBkbz88L3M+Cjx8YXNzaXN0YW50fD4KVGhlIGNvbXBhbnkgVGVzbGEgZG9lcyBub3QgaGF2ZSBhIHBoeXNpY2FsIHByZXNlbmNlLiBIb3dldmVyLCBpdCBpcyBhIHRlY2hub2xvZ3kgY29tcGFueSB0aGF0IGRldmVsb3BzIGFuZCBtYW51ZmFjdHVyZXMgZWxlY3RyaWMgdmVoaWNsZXMgKEVWcyksIGVuZXJneSBzdG9yYWdlIHN5c3RlbXMsIGFuZCBzb2xhciBwYW5lbHMuIFRlc2xhJ3MgcHJpbWFyeSBmb2N1cyBpcyBvbiBlbGVjdHJpYw=="]`), &contents)
 		require.NoError(t, err)
 
+		state := modelPB.State_STATE_ACTIVE
+		mockRay.EXPECT().
+			ModelReady(
+				gomock.Any(),
+				fmt.Sprintf("%s/%s/%s", param.OwnerType, param.OwnerUID.String(), param.ModelID),
+				param.ModelVersion.Version,
+			).Return(
+			&state,
+			"",
+			1,
+			nil,
+		).Times(1)
 		mockRay.EXPECT().
 			ModelMetadataRequest(
 				gomock.Any(),
@@ -161,6 +173,18 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 		mockRay := NewMockRay(ctrl)
 		ctx := context.Background()
 
+		state := modelPB.State_STATE_ACTIVE
+		mockRay.EXPECT().
+			ModelReady(
+				gomock.Any(),
+				fmt.Sprintf("%s/%s/%s", param.OwnerType, param.OwnerUID.String(), param.ModelID),
+				param.ModelVersion.Version,
+			).Return(
+			&state,
+			"",
+			1,
+			nil,
+		).Times(1)
 		mockRay.EXPECT().
 			ModelMetadataRequest(
 				gomock.Any(),


### PR DESCRIPTION
Because

- We should allow model to be triggered in offline/start/scaling state
- We should only record trigger time when the model is deployed

This commit

- allow triggering in offline/start/scaling state
- check model state before processing actual request
