### PR TITLE
fix(version): fix delete version with residuals

### DIFF
--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -115,7 +115,7 @@ func (h *PrivateHandler) DeployNamespaceModelAdmin(ctx context.Context, req *mod
 	}
 
 	version := &datamodel.ModelVersion{
-		Name:     ns.Name(),
+		Name:     fmt.Sprintf("%s/models/%s", ns.Name(), req.GetModelId()),
 		Version:  req.GetVersion(),
 		Digest:   req.GetDigest(),
 		ModelUID: uuid.FromStringOrNil(pbModel.Uid),

--- a/pkg/handler/public.go
+++ b/pkg/handler/public.go
@@ -469,7 +469,7 @@ func (h *PublicHandler) DeleteNamespaceModelVersion(ctx context.Context, req *mo
 		return nil, err
 	}
 
-	if err := h.service.DeleteModelVersionByID(ctx, ns, req.ModelId, req.GetVersion()); err != nil {
+	if err := h.service.DeleteModelVersionDigestByID(ctx, ns, req.ModelId, req.GetVersion()); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}

--- a/pkg/mock/mock_repository.go
+++ b/pkg/mock/mock_repository.go
@@ -366,18 +366,18 @@ func (mr *MockRepositoryMockRecorder) ListModelTriggers(arg0, arg1, arg2, arg3, 
 }
 
 // ListModelVersions mocks base method.
-func (m *MockRepository) ListModelVersions(arg0 context.Context, arg1 uuid.UUID, arg2 bool) ([]*datamodel.ModelVersion, error) {
+func (m *MockRepository) ListModelVersions(arg0 context.Context, arg1 uuid.UUID) ([]*datamodel.ModelVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListModelVersions", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListModelVersions", arg0, arg1)
 	ret0, _ := ret[0].([]*datamodel.ModelVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListModelVersions indicates an expected call of ListModelVersions.
-func (mr *MockRepositoryMockRecorder) ListModelVersions(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListModelVersions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelVersions", reflect.TypeOf((*MockRepository)(nil).ListModelVersions), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelVersions", reflect.TypeOf((*MockRepository)(nil).ListModelVersions), arg0, arg1)
 }
 
 // ListModelVersionsByDigest mocks base method.


### PR DESCRIPTION
Because

- Delete model will result in `version not found` error
- Delete model will left dangling version records in db

This commit

- fix delete version with residuals
