### PR TITLE
fix(redis): avoid possibility to see other's request and response

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1020,7 +1020,7 @@ func (s *service) DeleteNamespaceModelByID(ctx context.Context, ns resource.Name
 
 	ownerPermalink := ns.Permalink()
 
-	userUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+	requesterUID, userUID := utils.GetRequesterUIDAndUserUID(ctx)
 
 	dbModel, err := s.repository.GetNamespaceModelByID(ctx, ownerPermalink, modelID, false, false)
 	if err != nil {
@@ -1051,10 +1051,10 @@ func (s *service) DeleteNamespaceModelByID(ctx context.Context, ns resource.Name
 		if err := s.DeleteModelVersionByID(ctx, ns, modelID, version.Version); err != nil {
 			return err
 		}
-		s.redisClient.Del(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s", userUID, dbModel.UID.String(), version.Version))
+		s.redisClient.Del(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s:%s", userUID, requesterUID, dbModel.UID.String(), version.Version))
 	}
 
-	s.redisClient.Del(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s", userUID, dbModel.UID.String(), ""))
+	s.redisClient.Del(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s:%s", userUID, requesterUID, dbModel.UID.String(), ""))
 
 	err = s.aclClient.Purge(ctx, "model_", dbModel.UID)
 	if err != nil {

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -33,7 +33,7 @@ func (s *service) GetOperation(ctx context.Context, workflowID string) (*longrun
 func (s *service) GetNamespaceLatestModelOperation(ctx context.Context, ns resource.Namespace, modelID string, view modelpb.View) (*longrunningpb.Operation, error) {
 	ownerPermalink := ns.Permalink()
 
-	requesterUID, _ := utils.GetRequesterUIDAndUserUID(ctx)
+	requesterUID, userID := utils.GetRequesterUIDAndUserUID(ctx)
 
 	dbModel, err := s.repository.GetNamespaceModelByID(ctx, ownerPermalink, modelID, true, false)
 	if err != nil {
@@ -52,7 +52,7 @@ func (s *service) GetNamespaceLatestModelOperation(ctx context.Context, ns resou
 		return nil, ErrNoPermission
 	}
 
-	outputWorkflowID, err := s.redisClient.Get(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s", requesterUID, dbModel.UID.String(), "")).Result()
+	outputWorkflowID, err := s.redisClient.Get(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s:%s", userID, requesterUID, dbModel.UID.String(), "")).Result()
 
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
@@ -87,7 +87,7 @@ func (s *service) GetNamespaceLatestModelOperation(ctx context.Context, ns resou
 func (s *service) GetNamespaceModelOperation(ctx context.Context, ns resource.Namespace, modelID string, version string, view modelpb.View) (*longrunningpb.Operation, error) {
 	ownerPermalink := ns.Permalink()
 
-	requesterUID, _ := utils.GetRequesterUIDAndUserUID(ctx)
+	requesterUID, userID := utils.GetRequesterUIDAndUserUID(ctx)
 
 	dbModel, err := s.repository.GetNamespaceModelByID(ctx, ownerPermalink, modelID, true, false)
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *service) GetNamespaceModelOperation(ctx context.Context, ns resource.Na
 		return nil, ErrNoPermission
 	}
 
-	outputWorkflowID, err := s.redisClient.Get(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s", requesterUID, dbModel.UID.String(), version)).Result()
+	outputWorkflowID, err := s.redisClient.Get(ctx, fmt.Sprintf("model_trigger_output_key:%s:%s:%s:%s", userID, requesterUID, dbModel.UID.String(), version)).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return nil, nil

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -103,12 +103,12 @@ func (w *worker) TriggerModelWorkflow(ctx workflow.Context, param *TriggerModelW
 		if param.Mode == mgmtpb.Mode_MODE_ASYNC {
 			w.redisClient.ExpireGT(
 				sCtx,
-				fmt.Sprintf("model_trigger_output_key:%s:%s:%s", param.UserUID, param.ModelUID.String(), param.ModelVersion.Version),
+				fmt.Sprintf("model_trigger_output_key:%s:%s:%s:%s", param.UserUID, param.RequesterUID, param.ModelUID.String(), param.ModelVersion.Version),
 				time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
 			)
 			w.redisClient.ExpireGT(
 				sCtx,
-				fmt.Sprintf("model_trigger_output_key:%s:%s:%s", param.UserUID, param.ModelUID.String(), ""),
+				fmt.Sprintf("model_trigger_output_key:%s:%s:%s:%s", param.UserUID, param.RequesterUID, param.ModelUID.String(), ""),
 				time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
 			)
 		}


### PR DESCRIPTION
Because

- When users are impersonating the same entity, they can see others input/output

This commit

- append both userUID and requesterUID in redis operation key to make it unique
