### PR TITLE
fix(run): fix run logging update function

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -813,12 +813,9 @@ func (r *repository) CreateModelRun(ctx context.Context, modelRun *datamodel.Mod
 func (r *repository) UpdateModelRun(ctx context.Context, modelRun *datamodel.ModelRun) error {
 
 	r.PinUser(ctx, tableModelRun)
-	db := r.CheckPinnedUser(ctx, r.db, tableModelRun)
-
-	if err := db.Save(modelRun).Error; err != nil {
-		return err
-	}
-	return nil
+	return r.CheckPinnedUser(ctx, r.db, tableModelRun).Model(&datamodel.ModelRun{}).
+		Where(&datamodel.ModelRun{BaseStaticHardDelete: datamodel.BaseStaticHardDelete{UID: modelRun.UID}}).
+		Updates(&modelRun).Error
 }
 
 func (r *repository) ListModelRunsByRequester(ctx context.Context, pageSize, page int64, filter filtering.Filter, order ordering.OrderBy,


### PR DESCRIPTION
Because

- model run is broken

This commit

- fix update model run repo function

![image](https://github.com/user-attachments/assets/64f6db26-ab66-41c3-85ed-b0fdbf96d6f9)
![image](https://github.com/user-attachments/assets/7bbb6d6e-f452-43e6-9e1e-79635f6ad8a4)
![image](https://github.com/user-attachments/assets/abab78a1-f14a-4f9c-8ed5-c03e346dfa50)
