### PR TITLE
fix(run): add metadata retention handler

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -232,13 +232,13 @@ func main() {
 	defer timeseries.Close()
 
 	// Initialize Minio client
-	minioClient, err := miniox.NewMinioClientAndInitBucket(ctx, &config.Config.Minio, logger, config.MetadataExpiryRules...)
+	minioClient, err := miniox.NewMinioClientAndInitBucket(ctx, &config.Config.Minio, logger, service.MetadataExpiryRules...)
 	if err != nil {
 		logger.Fatal("failed to create minio client", zap.Error(err))
 	}
 
 	serv := service.NewService(repo, timeseries.WriteAPI(), mgmtPublicServiceClient, mgmtPrivateServiceClient,
-		artifactPrivateServiceClient, redisClient, temporalClient, rayService, &aclClient, minioClient,
+		artifactPrivateServiceClient, redisClient, temporalClient, rayService, &aclClient, minioClient, nil,
 		config.Config.Server.InstillCoreHost)
 
 	modelpb.RegisterModelPublicServiceServer(

--- a/config/config.go
+++ b/config/config.go
@@ -232,14 +232,3 @@ func ParseConfigFlag() string {
 
 	return *configPath
 }
-
-const (
-	DefaultExpiryTag = "default-expiry"
-)
-
-var MetadataExpiryRules = []miniox.ExpiryRule{
-	{
-		Tag:            DefaultExpiryTag,
-		ExpirationDays: 3,
-	},
-}

--- a/pkg/service/metadataretention.go
+++ b/pkg/service/metadataretention.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"context"
+
+	"github.com/gofrs/uuid"
+
+	miniox "github.com/instill-ai/x/minio"
+)
+
+type MetadataRetentionHandler interface {
+	GetExpiryTagBySubscriptionPlan(ctx context.Context, requesterUID uuid.UUID) (string, error)
+}
+
+type metadataRetentionHandler struct{}
+
+func NewRetentionHandler() MetadataRetentionHandler {
+	return &metadataRetentionHandler{}
+}
+
+func (h metadataRetentionHandler) GetExpiryTagBySubscriptionPlan(ctx context.Context, requesterUID uuid.UUID) (string, error) {
+	return defaultExpiryTag, nil
+}
+
+const (
+	defaultExpiryTag = "default-expiry"
+)
+
+var MetadataExpiryRules = []miniox.ExpiryRule{
+	{
+		Tag:            defaultExpiryTag,
+		ExpirationDays: 3,
+	},
+}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -446,7 +446,7 @@ func TestGetModelDefinition(t *testing.T) {
 	t.Run("TestGetModelDefinition", func(t *testing.T) {
 		mockRepository := mock.NewRepositoryMock(mc)
 		mockRepository.GetModelDefinitionMock.Times(1).Expect("github").Return(&datamodel.ModelDefinition{}, nil)
-		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 		_, err := s.GetModelDefinition(context.Background(), "github")
 		assert.NoError(t, err)
@@ -455,7 +455,7 @@ func TestGetModelDefinition(t *testing.T) {
 	t.Run("GetModelDefinitionByUID", func(t *testing.T) {
 		mockRepository := mock.NewRepositoryMock(mc)
 		mockRepository.GetModelDefinitionByUIDMock.Times(1).Expect(ModelDefinition).Return(&datamodel.ModelDefinition{}, nil)
-		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 		_, err := s.GetModelDefinitionByUID(context.Background(), ModelDefinition)
 		assert.NoError(t, err)
@@ -469,7 +469,7 @@ func TestListModelDefinitions(t *testing.T) {
 		mockRepository := mock.NewRepositoryMock(mc)
 		mockRepository.ListModelDefinitionsMock.Times(1).Expect(modelPB.View_VIEW_FULL, 100, "").
 			Return([]*datamodel.ModelDefinition{}, "", 100, nil)
-		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+		s := service.NewService(mockRepository, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 		_, _, _, err := s.ListModelDefinitions(context.Background(), modelPB.View_VIEW_FULL, int32(100), "")
 		assert.NoError(t, err)


### PR DESCRIPTION
Because

- expiry tag should be set by different environments

This commit

- add metadata retention handler
