### PR TITLE
fix(run): add namespace id in response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.21.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241022025309-9afd9231a821
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241105082344-134e33b0893e
 	github.com/instill-ai/usage-client v0.3.0-alpha
 	github.com/instill-ai/x v0.5.0-alpha.0.20241028101056-3b853d0b8656
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0 h1:AjbBfJuq+QoaXNcrova8smSjw
 github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3IftVLVezreAUtBOTZssDrjZEFHI=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241022025309-9afd9231a821 h1:yDtTSAjeM7gkiHkL2XX4yil+VHOIm2kbyk0ZlHskRW8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241022025309-9afd9231a821/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241105082344-134e33b0893e h1:7y4coZNWIHxpJGwO5iPhKsKLfQpywUUIqtI9KacHxxA=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241105082344-134e33b0893e/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.3.0-alpha h1:yY5eNn5zINqy8wpOogiNmrVYzJKnd1KMnMxlYBpr7Tk=
 github.com/instill-ai/usage-client v0.3.0-alpha/go.mod h1:8lvtZulkhQ7t8alttb2KkLKYoCp5u4oatzDbfFlEld0=
 github.com/instill-ai/x v0.5.0-alpha.0.20241028101056-3b853d0b8656 h1:/7XGEVLGiEaXf8mzzvWqg15DJO2yDMww/TC5ZlE1yUY=

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -117,15 +117,16 @@ func parseMetadataToStructArr(metadataMap map[string][]byte, run *datamodel.Mode
 
 func convertModelRunToPB(run *datamodel.ModelRun) *modelpb.ModelRun {
 	pbModelRun := &modelpb.ModelRun{
-		Uid:        run.UID.String(),
-		ModelUid:   run.ModelUID.String(),
-		ModelId:    &run.Model.ID,
-		Version:    run.ModelVersion,
-		Status:     runpb.RunStatus(run.Status),
-		Source:     runpb.RunSource(run.Source),
-		Error:      run.Error.Ptr(),
-		CreateTime: timestamppb.New(run.CreateTime),
-		UpdateTime: timestamppb.New(run.UpdateTime),
+		Uid:         run.UID.String(),
+		ModelUid:    run.ModelUID.String(),
+		ModelId:     &run.Model.ID,
+		NamespaceId: run.Model.NamespaceID,
+		Version:     run.ModelVersion,
+		Status:      runpb.RunStatus(run.Status),
+		Source:      runpb.RunSource(run.Source),
+		Error:       run.Error.Ptr(),
+		CreateTime:  timestamppb.New(run.CreateTime),
+		UpdateTime:  timestamppb.New(run.UpdateTime),
 	}
 
 	if run.TotalDuration.Valid {


### PR DESCRIPTION
Because

- dashboard needs pipeline/model namespace id to redirect

This commit

- add namespace id in response

![image](https://github.com/user-attachments/assets/7608a759-8874-45bb-989b-fe308bb64a37)
