### PR TITLE
fix(migration): migrate unsupported task to custom

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,7 @@ database:
   host: pg-sql
   port: 5432
   name: model
-  version: 11
+  version: 12
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/pkg/db/migration/000011_run_logging_namespace.down.sql
+++ b/pkg/db/migration/000011_run_logging_namespace.down.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-comment on column model_trigger.requester_uid is null;
+COMMENT ON COLUMN model_trigger.requester_uid IS NULL;
 
-alter table model_trigger drop column runner_uid;
+ALTER TABLE model_trigger DROP COLUMN runner_uid;
 
 COMMIT;

--- a/pkg/db/migration/000011_run_logging_namespace.up.sql
+++ b/pkg/db/migration/000011_run_logging_namespace.up.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
-alter table model_trigger
-add runner_uid uuid;
+ALTER TABLE model_trigger
+ADD runner_uid uuid;
 
-comment on column model_trigger.requester_uid is 'run by namespace, which is the credit owner';
+COMMENT ON COLUMN model_trigger.requester_uid IS 'run by namespace, which is the credit owner';
 
-update model_trigger
-set runner_uid = requester_uid
-where runner_uid is null;
+UPDATE model_trigger
+SET runner_uid = requester_uid
+WHERE runner_uid IS NULL;
 
 COMMIT;

--- a/pkg/db/migration/000012_migrate_unsupported_task.down copy.sql
+++ b/pkg/db/migration/000012_migrate_unsupported_task.down copy.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+UPDATE model SET task = 'TASK_CUSTOM' WHERE task = 'TASK_IMAGE_TO_IMAGE';
+
+COMMIT;

--- a/pkg/db/migration/000012_migrate_unsupported_task.up.sql
+++ b/pkg/db/migration/000012_migrate_unsupported_task.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+UPDATE model SET task = 'TASK_IMAGE_TO_IMAGE' WHERE task = 'TASK_CUSTOM';
+
+COMMIT;


### PR DESCRIPTION
Because

- we have not support `TASK_IMAGE_TO_IMAGE` in the new AI Task standard

This commit

- migrate unsupported task to `TASK_CUSTOM
