### PR TITLE
chore(minio): align expiry rules with pipeline-backend

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -24,15 +24,13 @@ import (
 	"github.com/instill-ai/model-backend/pkg/datamodel"
 	"github.com/instill-ai/model-backend/pkg/ray"
 	"github.com/instill-ai/model-backend/pkg/repository"
+	"github.com/instill-ai/x/temporal"
+	"github.com/instill-ai/x/zapadapter"
 
 	database "github.com/instill-ai/model-backend/pkg/db"
 	customlogger "github.com/instill-ai/model-backend/pkg/logger"
 	customotel "github.com/instill-ai/model-backend/pkg/logger/otel"
 	modelWorker "github.com/instill-ai/model-backend/pkg/worker"
-
-	"github.com/instill-ai/x/temporal"
-	"github.com/instill-ai/x/zapadapter"
-
 	miniox "github.com/instill-ai/x/minio"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c
 	github.com/instill-ai/usage-client v0.3.0-alpha
-	github.com/instill-ai/x v0.5.0-alpha.0.20241203111314-11f1aa4a3d91
+	github.com/instill-ai/x v0.5.0-alpha.0.20241213094923-890bb310fcb2
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/knadh/koanf v1.5.0
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.3.0-alpha h1:yY5eNn5zINqy8wpOogiNmrVYzJKnd1KMnMxlYBpr7Tk=
 github.com/instill-ai/usage-client v0.3.0-alpha/go.mod h1:8lvtZulkhQ7t8alttb2KkLKYoCp5u4oatzDbfFlEld0=
-github.com/instill-ai/x v0.5.0-alpha.0.20241203111314-11f1aa4a3d91 h1:baD7UhjwpmbBkaykoxi+6qd9A97qb/fkvvkocmwSrFA=
-github.com/instill-ai/x v0.5.0-alpha.0.20241203111314-11f1aa4a3d91/go.mod h1:jkVtaq9T2zAFA5N46tlV4K5EEVE7FcOVNbqY4wFWYz8=
+github.com/instill-ai/x v0.5.0-alpha.0.20241213094923-890bb310fcb2 h1:JHQpGbLn8ViRH3WNdOEt+smFkyhDJCs6U6hDbJ9suHA=
+github.com/instill-ai/x v0.5.0-alpha.0.20241213094923-890bb310fcb2/go.mod h1:qztbVw9eW69byjdQINhYc7dm9tmhR0zuP46GjV3hwlQ=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/pkg/service/metadataretention.go
+++ b/pkg/service/metadataretention.go
@@ -8,27 +8,37 @@ import (
 	miniox "github.com/instill-ai/x/minio"
 )
 
+// MetadataRetentionHandler allows clients to access the object expiration rule
+// associated to a namespace. This is used to set the expiration of objects,
+// e.g. when uploading the data of a model run. The preferred way to set the
+// expiration of an object is by attaching a tag to the object. The MinIO
+// client should set the tag-ased expiration rules for the bucket when it is
+// initialized.
 type MetadataRetentionHandler interface {
-	GetExpiryTagBySubscriptionPlan(ctx context.Context, requesterUID uuid.UUID) (string, error)
+	ListExpiryRules() []miniox.ExpiryRule
+	GetExpiryRuleByNamespace(_ context.Context, namespaceUID uuid.UUID) (miniox.ExpiryRule, error)
 }
 
 type metadataRetentionHandler struct{}
 
+// NewRetentionHandler is the default implementation of
+// MetadataRetentionHandler. It returns the same expiration rule for all
+// namespaces.
 func NewRetentionHandler() MetadataRetentionHandler {
 	return &metadataRetentionHandler{}
 }
 
-func (h metadataRetentionHandler) GetExpiryTagBySubscriptionPlan(ctx context.Context, requesterUID uuid.UUID) (string, error) {
-	return defaultExpiryTag, nil
-}
-
-const (
-	defaultExpiryTag = "default-expiry"
+var (
+	defaultExpiryRule = miniox.ExpiryRule{
+		Tag:            "default-expiry",
+		ExpirationDays: 3,
+	}
 )
 
-var MetadataExpiryRules = []miniox.ExpiryRule{
-	{
-		Tag:            defaultExpiryTag,
-		ExpirationDays: 3,
-	},
+func (h *metadataRetentionHandler) ListExpiryRules() []miniox.ExpiryRule {
+	return []miniox.ExpiryRule{defaultExpiryRule}
+}
+
+func (h *metadataRetentionHandler) GetExpiryRuleByNamespace(_ context.Context, _ uuid.UUID) (miniox.ExpiryRule, error) {
+	return defaultExpiryRule, nil
 }


### PR DESCRIPTION
Because

- https://github.com/instill-ai/pipeline-backend/pull/937 modifies the
  metadata retention interface, allowing clients to fetch both the
  expiration tag and the duration.

This commit

- Align metadata retention implementation with `pipeline-backend`'s.
