### PR TITLE
feat(ray): utilize redis as deployment config cache

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -160,9 +160,6 @@ func main() {
 	publicGrpcS := grpc.NewServer(grpcServerOpts...)
 	reflection.Register(publicGrpcS)
 
-	rayService := ray.NewRay()
-	defer rayService.Close()
-
 	mgmtPublicServiceClient, mgmtPublicServiceClientConn := external.InitMgmtPublicServiceClient(ctx)
 	defer mgmtPublicServiceClientConn.Close()
 
@@ -174,6 +171,9 @@ func main() {
 
 	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
 	defer redisClient.Close()
+
+	rayService := ray.NewRay(redisClient)
+	defer rayService.Close()
 
 	temporalTracingInterceptor, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
 		Tracer:            otel.Tracer("temporal-tracer"),

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -109,11 +109,11 @@ func main() {
 	db := database.GetSharedConnection()
 	defer database.Close(db)
 
-	rayService := ray.NewRay()
-	defer rayService.Close()
-
 	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
 	defer redisClient.Close()
+
+	rayService := ray.NewRay(redisClient)
+	defer rayService.Close()
 
 	temporalTracingInterceptor, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
 		Tracer:            otel.Tracer("temporal-tracer"),

--- a/pkg/ray/const.go
+++ b/pkg/ray/const.go
@@ -282,6 +282,10 @@ var SupportedAcceleratorTypeMemory = map[string]int{
 }
 
 const (
+	// Ray redis key
+	RayDeploymentKey = "model_deployment_config"
+
+	// Ray deployment env variables
 	EnvIsTestModel        = "RAY_IS_TEST_MODEL"
 	EnvMemory             = "RAY_MEMORY"
 	EnvTotalVRAM          = "RAY_TOTAL_VRAM"
@@ -291,8 +295,5 @@ const (
 	EnvNumOfCPUs          = "RAY_NUM_OF_CPUS"
 	EnvNumOfMinReplicas   = "RAY_NUM_OF_MIN_REPLICAS"
 	EnvNumOfMaxReplicas   = "RAY_NUM_OF_MAX_REPLICAS"
-)
-
-const (
-	DummyModelPrefix = "dummy-"
+	DummyModelPrefix      = "dummy-"
 )


### PR DESCRIPTION
Because

- avoid constant disk IO ops

This commit

- utilize redis as deployment config cache
- write config to persistent disk only on program exit
