### PR TITLE
fix(ci): remove docker images only when they exist

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -14,7 +14,7 @@ jobs:
           mkdir /tmp/test
           df --human-readable
           sudo apt clean
-          docker rmi $(docker image ls --all --quiet)
+          docker image ls --all --quiet | xargs -r docker rmi
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 


### PR DESCRIPTION
Because

- Build [fails](https://github.com/instill-ai/model-backend/actions/runs/13271033782/job/37075787828) due to missing images to remove.

```sh
  mkdir /tmp/test
  df --human-readable
  sudo apt clean
  docker rmi $(docker image ls --all --quiet)
  rm --recursive --force "$AGENT_TOOLSDIRECTORY"
  df --human-readable
  shell: /usr/bin/bash -e {0}
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   45G   28G  63% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   59M  761M   8% /boot
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

"docker rmi" requires at least 1 argument.
See 'docker rmi --help'.
```

This commit

- Runs `docker rmi` only when there are images to remove.
