### PR TITLE
feat(minio): add service name and version to MinIO requests

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -53,6 +53,7 @@ jobs:
           provenance: false
           build-args: |
             SERVICE_NAME=model-backend
+            SERVICE_VERSION=${{ github.sha }}
           tags: instill/model-backend:latest
           cache-from: type=registry,ref=instill/model-backend:buildcache
           cache-to: type=registry,ref=instill/model-backend:buildcache,mode=max
@@ -79,6 +80,7 @@ jobs:
           provenance: false
           build-args: |
             SERVICE_NAME=model-backend
+            SERVICE_VERSION=${{steps.set_version.outputs.no_v_tag}}
           tags: instill/model-backend:${{steps.set_version.outputs.no_v_tag}}
           cache-from: type=registry,ref=instill/model-backend:buildcache
           cache-to: type=registry,ref=instill/model-backend:buildcache,mode=max

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -80,6 +80,7 @@ jobs:
           load: true
           build-args: |
             SERVICE_NAME=model-backend
+            SERVICE_VERSION=${{ github.sha }}
           tags: instill/model-backend:latest
 
       - name: Checkout repo (instill-core)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c
 	github.com/instill-ai/usage-client v0.3.0-alpha
-	github.com/instill-ai/x v0.6.0-alpha.0.20250212192855-6af31ff7cc27
+	github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/knadh/koanf v1.5.0
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.3.0-alpha h1:yY5eNn5zINqy8wpOogiNmrVYzJKnd1KMnMxlYBpr7Tk=
 github.com/instill-ai/usage-client v0.3.0-alpha/go.mod h1:8lvtZulkhQ7t8alttb2KkLKYoCp5u4oatzDbfFlEld0=
-github.com/instill-ai/x v0.6.0-alpha.0.20250212192855-6af31ff7cc27 h1:5MwjakOj/G1iP7NwUBS7WCKvnAeI72mhgqq/abfuV+0=
-github.com/instill-ai/x v0.6.0-alpha.0.20250212192855-6af31ff7cc27/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
+github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455 h1:hMkl7Csrasx0c8tMG/2cRF6CtA2W32DM9NGtmo051L4=
+github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=


### PR DESCRIPTION
Because

- We want to identify the service that is performing a MinIO action.

This commit

- Adds client information (app name and version) to the MinIO requests according to instill-ai/x/pull/37.
