### PR TITLE
chore(minio): do not configure MinIO with root credentials

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,23 +40,8 @@ linters-settings:
         replacement: 'any'
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
-  gomnd:
-    # don't include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-    ignored-numbers:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
-    ignored-functions:
-      - strings.SplitN
 
   govet:
-    check-shadowing: false
     settings:
       printf:
         funcs:
@@ -137,10 +122,6 @@ issues:
     - test/testdata_etc  # test files
     - internal/jsonref  # from https://github.com/lestrrat-go/jsref
   exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-
     - path: pkg/golinters/errcheck.go
       text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
     - path: pkg/commands/run.go

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,8 +78,8 @@ registry:
 minio:
   host: minio
   port: 9000
-  rootuser: minioadmin
-  rootpwd: minioadmin
+  user: minioadmin
+  password: minioadmin
   bucketname: instill-ai-model
   secure: false
 influxdb:

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c
 	github.com/instill-ai/usage-client v0.3.0-alpha
-	github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455
+	github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/knadh/koanf v1.5.0
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.3.0-alpha h1:yY5eNn5zINqy8wpOogiNmrVYzJKnd1KMnMxlYBpr7Tk=
 github.com/instill-ai/usage-client v0.3.0-alpha/go.mod h1:8lvtZulkhQ7t8alttb2KkLKYoCp5u4oatzDbfFlEld0=
-github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455 h1:hMkl7Csrasx0c8tMG/2cRF6CtA2W32DM9NGtmo051L4=
-github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
+github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703 h1:K+V5ADMPM9K0qeXyPh2ZC6a1zl3rbnn4iG0tBQjIZzA=
+github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/pkg/handler/create.go
+++ b/pkg/handler/create.go
@@ -56,7 +56,7 @@ func createContainerizedModel(s service.Service, ctx context.Context, ns resourc
 	// Manually set the custom header to have a StatusCreated http response for REST endpoint
 	if err := grpc.SetHeader(ctx, metadata.Pairs("x-http-code", strconv.Itoa(http.StatusCreated))); err != nil {
 		span.SetStatus(1, err.Error())
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -143,7 +143,7 @@ func (r *repository) listModels(ctx context.Context, where string, whereArgs []a
 	countBuilder.Count(&totalSize)
 
 	queryBuilder := db.Distinct().Model(&datamodel.Model{}).Joins(joinStr).Where(where, whereArgs...)
-	if order.Fields == nil || len(order.Fields) == 0 {
+	if len(order.Fields) == 0 {
 		order.Fields = append(order.Fields, ordering.Field{
 			Path: "create_time",
 			Desc: true,
@@ -623,7 +623,7 @@ func (r *repository) GetModelDefinitionByUID(uid uuid.UUID) (*datamodel.ModelDef
 
 func (r *repository) ListModelDefinitions(view modelpb.View, pageSize int64, pageToken string) (definitions []*datamodel.ModelDefinition, nextPageToken string, totalSize int64, err error) {
 	if result := r.db.Model(&datamodel.ModelDefinition{}).Count(&totalSize); result.Error != nil {
-		return nil, "", 0, status.Errorf(codes.Internal, result.Error.Error())
+		return nil, "", 0, status.Error(codes.Internal, result.Error.Error())
 	}
 
 	queryBuilder := r.db.Model(&datamodel.ModelDefinition{}).Order("create_time DESC, id DESC")
@@ -650,7 +650,7 @@ func (r *repository) ListModelDefinitions(view modelpb.View, pageSize int64, pag
 	var createTime time.Time
 	rows, err := queryBuilder.Rows()
 	if err != nil {
-		return nil, "", 0, status.Errorf(codes.Internal, err.Error())
+		return nil, "", 0, status.Error(codes.Internal, err.Error())
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -668,7 +668,7 @@ func (r *repository) ListModelDefinitions(view modelpb.View, pageSize int64, pag
 		if result := r.db.Model(&datamodel.ModelDefinition{}).
 			Order("create_time ASC, id ASC").
 			Limit(1).Find(lastItem); result.Error != nil {
-			return nil, "", 0, status.Errorf(codes.Internal, result.Error.Error())
+			return nil, "", 0, status.Error(codes.Internal, result.Error.Error())
 		}
 		if lastItem.ID == lastID {
 			nextPageToken = ""
@@ -725,7 +725,7 @@ func (r *repository) getModelRunByModelUID(ctx context.Context, where string, wh
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, status.Errorf(codes.NotFound, "The model trigger not found")
 		}
-		return nil, status.Errorf(codes.Internal, result.Error.Error())
+		return nil, status.Error(codes.Internal, result.Error.Error())
 	}
 
 	return &trigger, nil
@@ -766,7 +766,7 @@ func (r *repository) ListModelRuns(ctx context.Context, pageSize, page int64, fi
 	}
 
 	queryBuilder := db.Where(where, whereArgs...)
-	if order.Fields == nil || len(order.Fields) == 0 {
+	if len(order.Fields) == 0 {
 		order.Fields = append(order.Fields, ordering.Field{
 			Path: "create_time",
 			Desc: true,
@@ -862,7 +862,7 @@ func (r *repository) ListModelRunsByRequester(ctx context.Context, params *ListM
 
 	queryBuilder := db.Preload(clause.Associations).Where(where, whereArgs...)
 	order := params.Order
-	if order.Fields == nil || len(order.Fields) == 0 {
+	if len(order.Fields) == 0 {
 		order.Fields = append(order.Fields, ordering.Field{
 			Path: "create_time",
 			Desc: true,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -378,10 +378,10 @@ func (s *service) CreateNamespaceModel(ctx context.Context, ns resource.Namespac
 	var modelConfig datamodel.ContainerizedModelConfiguration
 	b, err := model.GetConfiguration().MarshalJSON()
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	if err := json.Unmarshal(b, &modelConfig); err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	bModelConfig, _ := json.Marshal(modelConfig)


### PR DESCRIPTION
Because

- MinIO config params lead to the conclusion that the root credentials are needed, when any valid user/pass with the right permissions (bucket & object) will be valid.

This commit

- Updates the configuration for the MinIO client.
