### PR TITLE
chore(minio): update x/minio package

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/service"
 	"github.com/instill-ai/model-backend/pkg/usage"
 	"github.com/instill-ai/model-backend/pkg/utils"
+	"github.com/instill-ai/x/minio"
 	"github.com/instill-ai/x/temporal"
 	"github.com/instill-ai/x/zapadapter"
 
@@ -52,7 +53,6 @@ import (
 	customotel "github.com/instill-ai/model-backend/pkg/logger/otel"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	modelpb "github.com/instill-ai/protogen-go/model/model/v1alpha"
-	miniox "github.com/instill-ai/x/minio"
 )
 
 var propagator = b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader))
@@ -237,11 +237,11 @@ func main() {
 
 	// Initialize MinIO client
 	retentionHandler := service.NewRetentionHandler()
-	minioClient, err := miniox.NewMinioClientAndInitBucket(ctx, miniox.ClientParams{
+	minioClient, err := minio.NewMinIOClientAndInitBucket(ctx, minio.ClientParams{
 		Config:      config.Config.Minio,
 		Logger:      logger,
 		ExpiryRules: retentionHandler.ListExpiryRules(),
-		AppInfo: miniox.AppInfo{
+		AppInfo: minio.AppInfo{
 			Name:    serviceName,
 			Version: version,
 		},

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/ray"
 	"github.com/instill-ai/model-backend/pkg/repository"
 	"github.com/instill-ai/model-backend/pkg/service"
+	"github.com/instill-ai/x/minio"
 	"github.com/instill-ai/x/temporal"
 	"github.com/instill-ai/x/zapadapter"
 
@@ -32,7 +33,6 @@ import (
 	customlogger "github.com/instill-ai/model-backend/pkg/logger"
 	customotel "github.com/instill-ai/model-backend/pkg/logger/otel"
 	modelWorker "github.com/instill-ai/model-backend/pkg/worker"
-	miniox "github.com/instill-ai/x/minio"
 )
 
 // These variables might be overridden at buildtime.
@@ -165,11 +165,11 @@ func main() {
 
 	// Initialize MinIO client
 	retentionHandler := service.NewRetentionHandler()
-	minioClient, err := miniox.NewMinioClientAndInitBucket(ctx, miniox.ClientParams{
+	minioClient, err := minio.NewMinIOClientAndInitBucket(ctx, minio.ClientParams{
 		Config:      config.Config.Minio,
 		Logger:      logger,
 		ExpiryRules: retentionHandler.ListExpiryRules(),
-		AppInfo: miniox.AppInfo{
+		AppInfo: minio.AppInfo{
 			Name:    serviceName,
 			Version: version,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/instill-ai/x/minio"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/redis/go-redis/v9"
-
-	miniox "github.com/instill-ai/x/minio"
 )
 
 // ServerConfig defines HTTP server configurations
@@ -175,7 +174,7 @@ type AppConfig struct {
 	Registry        RegistryConfig        `koanf:"registry"`
 	InitModel       InitModelConfig       `koanf:"initmodel"`
 	Log             LogConfig             `koanf:"log"`
-	Minio           miniox.Config         `koanf:"minio"`
+	Minio           minio.Config          `koanf:"minio"`
 	InfluxDB        InfluxDBConfig        `koanf:"influxdb"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c
 	github.com/instill-ai/usage-client v0.3.0-alpha
-	github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703
+	github.com/instill-ai/x v0.6.0-alpha.0.20250220064016-87c34501e6cd
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/knadh/koanf v1.5.0
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,10 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241211175103-4f1558f81c9c/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.3.0-alpha h1:yY5eNn5zINqy8wpOogiNmrVYzJKnd1KMnMxlYBpr7Tk=
 github.com/instill-ai/usage-client v0.3.0-alpha/go.mod h1:8lvtZulkhQ7t8alttb2KkLKYoCp5u4oatzDbfFlEld0=
-github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703 h1:K+V5ADMPM9K0qeXyPh2ZC6a1zl3rbnn4iG0tBQjIZzA=
-github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
+github.com/instill-ai/x v0.6.0-alpha.0.20250219152326-8226b146129b h1:S4hsBsL5GU1qi322Ax1XjwaeKH17biwV/b0gvQqDdxI=
+github.com/instill-ai/x v0.6.0-alpha.0.20250219152326-8226b146129b/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
+github.com/instill-ai/x v0.6.0-alpha.0.20250220064016-87c34501e6cd h1:NThz1N8tPcZ/MfbeZH570SRAIVAz50PffA619CjbEWc=
+github.com/instill-ai/x v0.6.0-alpha.0.20250220064016-87c34501e6cd/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/pkg/service/metadataretention.go
+++ b/pkg/service/metadataretention.go
@@ -4,8 +4,7 @@ import (
 	"context"
 
 	"github.com/gofrs/uuid"
-
-	miniox "github.com/instill-ai/x/minio"
+	"github.com/instill-ai/x/minio"
 )
 
 // MetadataRetentionHandler allows clients to access the object expiration rule
@@ -15,8 +14,8 @@ import (
 // client should set the tag-ased expiration rules for the bucket when it is
 // initialized.
 type MetadataRetentionHandler interface {
-	ListExpiryRules() []miniox.ExpiryRule
-	GetExpiryRuleByNamespace(_ context.Context, namespaceUID uuid.UUID) (miniox.ExpiryRule, error)
+	ListExpiryRules() []minio.ExpiryRule
+	GetExpiryRuleByNamespace(_ context.Context, namespaceUID uuid.UUID) (minio.ExpiryRule, error)
 }
 
 type metadataRetentionHandler struct{}
@@ -29,16 +28,16 @@ func NewRetentionHandler() MetadataRetentionHandler {
 }
 
 var (
-	defaultExpiryRule = miniox.ExpiryRule{
+	defaultExpiryRule = minio.ExpiryRule{
 		Tag:            "default-expiry",
 		ExpirationDays: 3,
 	}
 )
 
-func (h *metadataRetentionHandler) ListExpiryRules() []miniox.ExpiryRule {
-	return []miniox.ExpiryRule{defaultExpiryRule}
+func (h *metadataRetentionHandler) ListExpiryRules() []minio.ExpiryRule {
+	return []minio.ExpiryRule{defaultExpiryRule}
 }
 
-func (h *metadataRetentionHandler) GetExpiryRuleByNamespace(_ context.Context, _ uuid.UUID) (miniox.ExpiryRule, error) {
+func (h *metadataRetentionHandler) GetExpiryRuleByNamespace(_ context.Context, _ uuid.UUID) (minio.ExpiryRule, error) {
 	return defaultExpiryRule, nil
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/utils"
 	"github.com/instill-ai/model-backend/pkg/worker"
 	"github.com/instill-ai/x/errmsg"
+	"github.com/instill-ai/x/minio"
 
 	custom_logger "github.com/instill-ai/model-backend/pkg/logger"
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
@@ -43,7 +44,6 @@ import (
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	modelpb "github.com/instill-ai/protogen-go/model/model/v1alpha"
 	constantx "github.com/instill-ai/x/constant"
-	miniox "github.com/instill-ai/x/minio"
 	resourcex "github.com/instill-ai/x/resource"
 )
 
@@ -116,7 +116,7 @@ type service struct {
 	temporalClient               client.Client
 	ray                          ray.Ray
 	aclClient                    acl.ACLClientInterface
-	minioClient                  miniox.MinioI
+	minioClient                  minio.Client
 	retentionHandler             MetadataRetentionHandler
 	instillCoreHost              string
 }
@@ -132,7 +132,7 @@ func NewService(
 	tc client.Client,
 	ra ray.Ray,
 	a acl.ACLClientInterface,
-	minioClient miniox.MinioI,
+	minioClient minio.Client,
 	retentionHandler MetadataRetentionHandler,
 	h string,
 ) Service {
@@ -196,11 +196,11 @@ func (s *service) CreateModelRun(ctx context.Context, triggerUID uuid.UUID, mode
 		return nil, fmt.Errorf("fetching expiration rule: %w", err)
 	}
 
-	inputReferenceID := miniox.GenerateInputRefID("model-runs")
+	inputReferenceID := minio.GenerateInputRefID("model-runs")
 	// todo: put it in separate workflow activity and store url and file size
 	_, _, err = s.minioClient.UploadFileBytes(
 		ctx,
-		&miniox.UploadFileBytesParam{
+		&minio.UploadFileBytesParam{
 			UserUID:       userUID,
 			FilePath:      inputReferenceID,
 			FileBytes:     inputJSON,

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -10,8 +10,7 @@ import (
 	"github.com/instill-ai/model-backend/pkg/ray"
 	"github.com/instill-ai/model-backend/pkg/repository"
 	"github.com/instill-ai/model-backend/pkg/usage"
-
-	miniox "github.com/instill-ai/x/minio"
+	"github.com/instill-ai/x/minio"
 )
 
 // TaskQueue is the Temporal task queue name for model-backend
@@ -27,7 +26,7 @@ type Worker interface {
 type worker struct {
 	redisClient         *redis.Client
 	ray                 ray.Ray
-	minioClient         miniox.MinioI
+	minioClient         minio.Client
 	repository          repository.Repository
 	influxDBWriteClient api.WriteAPI
 	modelUsageHandler   usage.ModelUsageHandler
@@ -39,7 +38,7 @@ func NewWorker(
 	ra ray.Ray,
 	repo repository.Repository,
 	i api.WriteAPI,
-	minioClient miniox.MinioI,
+	minioClient minio.Client,
 	modelUsageHandler usage.ModelUsageHandler,
 ) Worker {
 	if modelUsageHandler == nil {

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -40,7 +40,7 @@ func TestWorker_TriggerModelActivity(t *testing.T) {
 
 	repo := mock.NewRepositoryMock(mc)
 
-	mockMinio := mockx.NewMinioIMock(mc)
+	mockMinio := mockx.NewClientMock(mc)
 	mockMinio.UploadFileBytesMock.Return("", nil, nil)
 
 	t.Run("Task_TASK_TEXT_GENERATION", func(t *testing.T) {

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -21,13 +21,13 @@ import (
 	"github.com/instill-ai/model-backend/pkg/usage"
 	"github.com/instill-ai/model-backend/pkg/utils"
 	"github.com/instill-ai/x/errmsg"
+	"github.com/instill-ai/x/minio"
 
 	custom_logger "github.com/instill-ai/model-backend/pkg/logger"
 	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
 	commonpb "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	modelpb "github.com/instill-ai/protogen-go/model/model/v1alpha"
-	miniox "github.com/instill-ai/x/minio"
 )
 
 type InferInput any
@@ -278,11 +278,11 @@ func (w *worker) TriggerModelActivity(ctx context.Context, param *TriggerModelAc
 		return w.toApplicationError(err, param.ModelID, ModelActivityError)
 	}
 
-	outputReferenceID := miniox.GenerateOutputRefID("model-runs")
+	outputReferenceID := minio.GenerateOutputRefID("model-runs")
 	// todo: put it in separate workflow activity and store url and file size
 	_, _, err = w.minioClient.UploadFileBytes(
 		ctx,
-		&miniox.UploadFileBytesParam{
+		&minio.UploadFileBytesParam{
 			UserUID:       param.UserUID,
 			FilePath:      outputReferenceID,
 			FileBytes:     outputJSON,


### PR DESCRIPTION
Because

- `x/minio` has been updated with some API breaking changes.

This commit

- Migrates to the latest `x/minio`.
