### PR TITLE
chore(configs): remove model store config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -77,8 +77,7 @@ type RayConfig struct {
 		GCS       int `koanf:"gcs"`
 		METRICS   int `koanf:"metrics"`
 	} `koanf:"port"`
-	ModelStore string `koanf:"modelstore"`
-	Vram       string `koanf:"vram"`
+	Vram string `koanf:"vram"`
 }
 
 // MgmtBackendConfig related to mgmt-backend

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,7 +40,6 @@ ray:
     gcs: 6379
     client: 10001
     metrics: 8080
-  modelstore: /model-store
   vram:
 mgmtbackend:
   host: mgmt-backend

--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -91,7 +91,7 @@ func (r *ray) Init(rc *redis.Client) {
 	r.rayHTTPClient = &http.Client{Timeout: time.Minute}
 	r.configChan = make(chan ApplicationWithAction, 10000)
 	r.doneChan = make(chan error, 10000)
-	r.configFilePath = path.Join(config.Config.Ray.ModelStore, "deploy.yaml")
+	r.configFilePath = path.Join("/tmp", "deploy.yaml")
 
 	if currentConfigFile, err := r.redisClient.Get(
 		ctx,


### PR DESCRIPTION
Because

- config for `model-store` volume mounting is overkilled and not used at all

This commit

- remove model store configuration