### PR TITLE
chore(ray): update min_replica value

### DIFF
--- a/pkg/ray/ray.go
+++ b/pkg/ray/ray.go
@@ -266,7 +266,7 @@ func (r *ray) UpdateContainerizedModel(ctx context.Context, modelName string, us
 		if IsDummyModel(modelName) {
 			envVars[EnvNumOfCPUs] = "0.001"
 		}
-		envVars[EnvNumOfMinReplicas] = "0"
+		envVars[EnvNumOfMinReplicas] = "1"
 		envVars[EnvNumOfMaxReplicas] = "10"
 	}
 


### PR DESCRIPTION
Because

- before we completely refactor the serving logic to adopt RayService and expose all Ray Serve configurations, we will keep the `min_replica` value 1 to allow no cold start time.

This commit

- update the env variable accordingly
