### PR TITLE
test(integration): remove deprecated API prefix

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -18,10 +18,10 @@ export const defaultPassword = "password"
 export const apiPrivateHost = "http://model-backend:3083"
 
 export const gRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`
-export const apiPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/model` : `http://api-gateway:8080/model`
+export const apiPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}` : `http://api-gateway:8080`
 
 export const mgmtGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`
-export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/core` : `http://api-gateway:8080/core`
+export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}` : `http://api-gateway:8080`
 
 export const mgmtGRPCPrivateHost = "mgmt-backend:3084"
 export const mgmtApiPrivateHost = "http://mgmt-backend:3084"


### PR DESCRIPTION
Because

- the tests are still using deprecated API endpoints.

This commit

- removes deprecated API prefix.
