### PR TITLE
fix(service): fix profile-image path

### DIFF
--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -154,7 +154,7 @@ func (s *service) DBToPBModel(ctx context.Context, modelDef *datamodel.ModelDefi
 
 	ctxUserUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
 
-	profileImage := fmt.Sprintf("%s/model/v1alpha/%s/models/%s/image", s.instillCoreHost, ownerName, dbModel.ID)
+	profileImage := fmt.Sprintf("%s/v1alpha/%s/models/%s/image", s.instillCoreHost, ownerName, dbModel.ID)
 
 	pbModel := &modelpb.Model{
 		Name:       fmt.Sprintf("%s/models/%s", ownerName, dbModel.ID),


### PR DESCRIPTION
Because

- we’ve removed the deprecated API endpoint with the `/model` prefix, but it’s still being used in profile-image path generation.

This commit

- fixes the profile-image path.