### PR TITLE
chore(proto): adopt latest `protogen-go` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250520071517-4ab9c1bff636
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61
 	github.com/instill-ai/usage-client v0.3.0-alpha
 	github.com/instill-ai/x v0.7.0-alpha
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0 h1:AjbBfJuq+QoaXNcrova8smSjw
 github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3IftVLVezreAUtBOTZssDrjZEFHI=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250520071517-4ab9c1bff636 h1:OwMlPW+ViWvgtQ7gSqkgUGnCICMpGFZrEaO8i+AXvVU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250520071517-4ab9c1bff636/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61 h1:wA9YlKStdlutjW/QxlTZApNFJXRivFvlqsUiwKz4MlQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.3.0-alpha h1:yY5eNn5zINqy8wpOogiNmrVYzJKnd1KMnMxlYBpr7Tk=
 github.com/instill-ai/usage-client v0.3.0-alpha/go.mod h1:8lvtZulkhQ7t8alttb2KkLKYoCp5u4oatzDbfFlEld0=
 github.com/instill-ai/x v0.7.0-alpha h1:THv1AOP7uVK7WaQxSM8tC5lFeyKtk6256nFznYkMy88=

--- a/integration-test/proto/core/mgmt/v1beta/mgmt.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt.proto
@@ -123,8 +123,6 @@ message OrganizationProfile {
 // the public user information plus some fields that should only be accessed by
 // the user themselves.
 message AuthenticatedUser {
-  option (google.api.resource) = {type: "api.instill-ai.com/AuthenticatedUser"};
-
   // The name of the user, defined by its ID.
   // - Format: `users/{user.id}`.
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -182,7 +180,6 @@ message Owner {
 // contain any private information about the user.
 message User {
   option (google.api.resource) = {
-    type: "api.instill-ai.com/User"
     pattern: "users/{user.id}"
     pattern: "users/{user.uid}"
   };
@@ -360,10 +357,7 @@ message GetUserRequest {
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // User ID
-  string user_id = 3 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill-ai.com/User"
-  ];
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetUserResponse contains the requested user.
@@ -457,12 +451,54 @@ message CheckNamespaceAdminResponse {
   Namespace type = 1;
   // Namespace UID.
   string uid = 2;
+  // The owner, which can be either a User or an Organization.
+  oneof owner {
+    // User.
+    core.mgmt.v1beta.User user = 3;
+    // Organization.
+    core.mgmt.v1beta.Organization organization = 4;
+  }
+}
+
+// CheckNamespaceByUIDAdminRequest represents a request to verify if a namespace is
+// available.
+message CheckNamespaceByUIDAdminRequest {
+  // The namespace UID to be checked.
+  string uid = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CheckNamespaceByUIDAdminResponse contains the availability of a namespace or the type
+// of resource that's using it.
+message CheckNamespaceByUIDAdminResponse {
+  // Namespace contains information about the availability of a namespace.
+  enum Namespace {
+    // Unspecified.
+    NAMESPACE_UNSPECIFIED = 0;
+    // Available.
+    NAMESPACE_AVAILABLE = 1;
+    // Namespace belongs to a user.
+    NAMESPACE_USER = 2;
+    // Namespace belongs to an organization.
+    NAMESPACE_ORGANIZATION = 3;
+    // Reserved.
+    NAMESPACE_RESERVED = 4;
+  }
+
+  // Namespace type.
+  Namespace type = 1;
+  // Namespace ID.
+  string id = 2;
+  // The owner, which can be either a User or an Organization.
+  oneof owner {
+    // User.
+    core.mgmt.v1beta.User user = 3;
+    // Organization.
+    core.mgmt.v1beta.Organization organization = 4;
+  }
 }
 
 // API tokens allow users to make requests to the Instill AI API.
 message ApiToken {
-  option (google.api.resource) = {type: "api.instill-ai.com/ApiToken"};
-
   // When users trigger a pipeline which uses an API token, the token is
   // updated with the current time. This field is used to track the last time
   // the token was used.
@@ -552,10 +588,7 @@ message GetTokenRequest {
   // Reserverd for `name`
   reserved 1;
   // Token ID
-  string token_id = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill-ai.com/ApiToken"}
-  ];
+  string token_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetTokenResponse contains the requested token.
@@ -569,10 +602,7 @@ message DeleteTokenRequest {
   // Reserverd for `name`
   reserved 1;
   // Token ID
-  string token_id = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill-ai.com/ApiToken"}
-  ];
+  string token_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteTokenResponse is an empty response.
@@ -716,10 +746,7 @@ message AuthChangePasswordResponse {}
 // Organizations group several users. As entities, they can own resources such
 // as pipelines or releases.
 message Organization {
-  option (google.api.resource) = {
-    type: "api.instill-ai.com/Organization"
-    pattern: "organizations/{organization.id}"
-  };
+  option (google.api.resource) = {pattern: "organizations/{organization.id}"};
 
   // The name of the organization, defined by its ID.
   // - Format: `organization/{organization.id}`.
@@ -792,10 +819,7 @@ message GetOrganizationRequest {
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // Organization ID
-  string organization_id = 3 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill-ai.com/Organization"
-  ];
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetOrganizationResponse contains the requested organization.
@@ -828,10 +852,7 @@ message DeleteOrganizationRequest {
   // Reserverd for `name`
   reserved 1;
   // Organization ID
-  string organization_id = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill-ai.com/Organization"
-  ];
+  string organization_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteOrganizationResponse is an empty response.
@@ -1075,8 +1096,10 @@ message UserSubscription {
     PLAN_UNSPECIFIED = 0;
     // Free plan.
     PLAN_FREE = 1;
+    // 2 is reserved for the deprecated PLAN_PRO value.
+    reserved 2;
     // Starter plan.
-    PLAN_STARTER = 2;
+    PLAN_STARTER = 3;
   }
 
   // Plan identifier.
@@ -1091,22 +1114,20 @@ message OrganizationSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Unpaid.
-    PLAN_UNPAID = 1;
+    // Free plan.
+    PLAN_FREE = 1;
     // Team plan.
     PLAN_TEAM = 2;
     // Enterprise plan.
     PLAN_ENTERPRISE = 3;
-    // Team pro plan.
-    PLAN_TEAM_PRO = 4;
   }
 
   // Plan identifier.
   Plan plan = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Details of the associated Stripe subscription.
   StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Maximum number of seats allowed.
-  int32 max_seats = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reserved for max_seats
+  reserved 3;
   // Number of used seats within the organization subscription.
   int32 used_seats = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }


### PR DESCRIPTION
Because

- we've updated the enum for user plan.

This commit

- adopts latest `protogen-go` package.
