### PR TITLE
ci(workflows): add rc image build and push

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,6 +2,13 @@ name: Build and Push Images
 
 on:
   workflow_call:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+    tags:
+      - "*-rc"
   release:
     types: [published]
 
@@ -52,14 +59,14 @@ jobs:
           push: true
           provenance: false
           build-args: |
-            SERVICE_NAME=model-backend
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ github.sha }}
           tags: instill/model-backend:latest
           cache-from: type=registry,ref=instill/model-backend:buildcache
           cache-to: type=registry,ref=instill/model-backend:buildcache,mode=max
 
       - name: Set Versions
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
         uses: actions/github-script@v6
         id: set_version
         with:
@@ -69,8 +76,8 @@ jobs:
             core.setOutput('tag', tag)
             core.setOutput('no_v_tag', no_v_tag)
 
-      - name: Build and push (release)
-        if: github.event_name == 'release'
+      - name: Build and push (rc/release)
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
@@ -79,7 +86,7 @@ jobs:
           push: true
           provenance: false
           build-args: |
-            SERVICE_NAME=model-backend
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{steps.set_version.outputs.no_v_tag}}
           tags: instill/model-backend:${{steps.set_version.outputs.no_v_tag}}
           cache-from: type=registry,ref=instill/model-backend:buildcache


### PR DESCRIPTION
Because

- we are going to introduce rc (release candidate) stage to enhance the robustness of our release cycle.

This commit

- implement the logic:
   git tag <next-release-version>-rc && git push origin <next-release-version>-rc triggers the rc image build and push flow.
