### PR TITLE
ci(workflows): update release-please setting removing pre-release

### DIFF
--- a/release-please/config.json
+++ b/release-please/config.json
@@ -3,9 +3,9 @@
     ".": {
       "release-type": "go",
       "draft": false,
-      "prerelease": true,
+      "prerelease": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Because

- we are taking of the pre-release suffix -beta or -alpha

This commit

- configure release-please bot accordingly