### PR TITLE
ci(workflows): adopt short commit hash for service version

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -49,6 +49,10 @@ jobs:
           username: drop@instill-ai.com
           password: ${{ secrets.botDockerHubPassword }}
 
+      - name: Set short commit SHA
+        run: |
+          echo "COMMIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and push (latest)
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
@@ -60,7 +64,7 @@ jobs:
           provenance: false
           build-args: |
             SERVICE_NAME=${{ env.SERVICE_NAME }}
-            SERVICE_VERSION=${{ github.sha }}
+            SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
           tags: instill/model-backend:latest
           cache-from: type=registry,ref=instill/model-backend:buildcache
           cache-to: type=registry,ref=instill/model-backend:buildcache,mode=max

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -77,14 +77,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set short commit SHA
+        run: |
+          echo "COMMIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: model-backend
           load: true
           build-args: |
-            SERVICE_NAME=model-backend
-            SERVICE_VERSION=${{ github.sha }}
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
+            SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
           tags: instill/model-backend:latest
           cache-from: |
             type=registry,ref=instill/model-backend:buildcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN mkdir /nonexistent > /dev/null && chown -R nobody:nogroup /nonexistent
 
 USER nobody:nogroup
 
-ARG SERVICE_NAME
+ARG SERVICE_NAME SERVICE_VERSION
 
 WORKDIR /${SERVICE_NAME}
 
@@ -72,3 +72,6 @@ COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-init ./
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME} ./
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-worker ./
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-init-model ./
+
+ENV SERVICE_NAME=${SERVICE_NAME}
+ENV SERVICE_VERSION=${SERVICE_VERSION}


### PR DESCRIPTION
Because

- `github.sha` is the complete commit SHA hash which is too long. Shot commit hash is preferred, especially for the backend service log presentation.

This commit

- adopted short git commit hash for representing the `latest` build version
