### PR TITLE
refactor(config): remove db version from config file

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 
 	"github.com/instill-ai/model-backend/config"
+	"github.com/instill-ai/model-backend/pkg/db"
 	"github.com/instill-ai/model-backend/pkg/db/migration"
 )
 
@@ -101,7 +102,7 @@ func main() {
 		panic(err)
 	}
 
-	ExpectedVersion := databaseConfig.Version
+	ExpectedVersion := uint(db.TargetSchemaVersion)
 
 	fmt.Printf("Expected migration version is %d\n", ExpectedVersion)
 	fmt.Printf("The current schema version is %d, and dirty flag is %t\n", version, dirty)

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,6 @@ type DatabaseConfig struct {
 		ReplicationTimeFrame int    `koanf:"replicationtimeframe"` // in seconds
 	} `koanf:"replica"`
 	Name     string `koanf:"name"`
-	Version  uint   `koanf:"version"`
 	TimeZone string `koanf:"timezone"`
 	Pool     struct {
 		IdleConnections int           `koanf:"idleconnections"`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,6 @@ database:
   host: pg-sql
   port: 5432
   name: model
-  version: 12
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -16,6 +16,9 @@ import (
 var db *gorm.DB
 var once sync.Once
 
+// TargetSchemaVersion is the target database schema version
+const TargetSchemaVersion = 12
+
 // GetConnection returns a connection to the database
 func GetConnection() *gorm.DB {
 	databaseConfig := config.Config.Database


### PR DESCRIPTION
Because

- The DB version should always be bound to the codebase; we shouldn’t use a config file for it.

This commit

- Removes the DB version from the config file.